### PR TITLE
chore: migrate to trunk-based workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,12 +5,12 @@
     "name": "David Cheal",
     "email": "david.cheal@thermite.au"
   },
-  "version": "0.5.7",
+  "version": "0.5.8-dev",
   "plugins": [
     {
       "name": "maverick",
       "description": "Skills, Agents, and Hooks for autonomous AI development. Claude Code, Cursor IDE, Codex.",
-      "version": "0.5.7",
+      "version": "0.5.8-dev",
       "source": "./",
       "author": {
         "name": "David Cheal",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "maverick",
   "description": "Autonomous AI development skills, agents, and hooks for Claude Code",
-  "version": "0.5.7",
+  "version": "0.5.8-dev",
   "author": {
     "name": "David Cheal",
     "email": "david.cheal@thermite.au"

--- a/.cursor-plugin/cursor.plugin.json
+++ b/.cursor-plugin/cursor.plugin.json
@@ -2,7 +2,7 @@
   "name": "maverick",
   "displayName": "Maverick",
   "description": "Autonomous AI development skills, agents, and hooks for Claude Code",
-  "version": "0.5.7",
+  "version": "0.5.8-dev",
   "author": {
     "name": "David Cheal",
     "email": "david.cheal@thermite.au"

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -1,8 +1,8 @@
 name: Release Finalize
 
 # Runs after a release/* PR is squash-merged into main.
-# Tags the merge commit, creates a GitHub Release, syncs develop,
-# and bumps develop to the next -dev version.
+# Tags the merge commit, creates a GitHub Release, and opens a
+# follow-up PR that bumps main to the next -dev version.
 
 on:
   pull_request:
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   finalize:
@@ -75,14 +76,17 @@ jobs:
             --notes-file /tmp/release-notes.md \
             --target main
 
-      - name: Sync develop and bump dev version
+      - name: Open PR to bump main to next -dev cycle
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          DEV_VERSION: ${{ steps.version.outputs.dev_version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          DEV_VERSION="${{ steps.version.outputs.dev_version }}"
+          BRANCH="chore/begin-${DEV_VERSION}-cycle"
 
-          git checkout develop
-          git pull origin develop
-          git merge main --no-edit
+          git checkout main
+          git pull origin main
+          git checkout -b "$BRANCH"
 
           # Bump version in pyproject.toml
           sed -i "s/^version = \"${VERSION}\"/version = \"${DEV_VERSION}\"/" pyproject.toml
@@ -104,4 +108,10 @@ jobs:
               agents/
 
           git commit -m "chore: begin ${DEV_VERSION} cycle"
-          git push origin develop
+          git push origin "$BRANCH"
+
+          gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore: begin ${DEV_VERSION} cycle" \
+              --body "Automated follow-up to the ${VERSION} release. Bumps main to the next in-development version."

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,7 +2,9 @@ name: Unit Tests
 
 on:
   push:
-    branches: [develop]
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   test:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,11 +34,12 @@ bash tests/integration/test_cli.sh
 bash tests/integration/test_real_repos.sh
 
 # Create a release (two-phase: local prep + CI finalize)
-# Phase 1 — run locally from the develop branch:
+# Phase 1 — run locally from the main branch:
 ./scripts/release.sh patch   # or: minor, major
-# This creates a release/<version> branch, bumps version, and opens a PR.
+# This creates a release/<version> branch from main, bumps version, and opens a PR.
 # Phase 2 — automatic after squash-merging the PR:
-# CI tags main, creates GitHub Release, syncs develop, bumps -dev version.
+# CI tags main, creates GitHub Release, then opens a follow-up PR
+# that bumps main to the next -dev version.
 ```
 
 ## Architecture
@@ -140,7 +141,7 @@ The registry (`src/maverick/registry.py`) discovers all `config.py` files, rende
 
 ## Key Conventions
 
-- **Git workflow**: `main` = stable releases only, `develop` = active integration. No direct commits or pushes to `main` — only squash merges via PR. Tags only on `main`. Feature branches: `<type>/<issue>-<desc>` (e.g., `feat/42-add-export`). Release branches: `release/<version>`. Conventional Commits with issue refs: `feat: add export button (#42)`.
+- **Git workflow**: Trunk-based. `main` is the only long-lived branch — it carries the current `-dev` version between releases and is tagged at each release. No direct commits or pushes to `main` — all changes land via squash-merged PRs. Feature branches are short-lived and branch from `main`: `<type>/<issue>-<desc>` (e.g., `feat/42-add-export`). Release branches (`release/<version>`) are short-lived and exist only long enough to cut a release. Conventional Commits with issue refs: `feat: add export button (#42)`.
 - **Scope boundaries** (`skills/mav-scope-boundaries/`): Four hard limits — no infrastructure changes without explicit issue authorization, no auth/permissions changes without human review, no destructive git ops without session consent, never touch production systems.
 - **Python**: 3.10+, `uv` package manager, `boto3` for AWS, `argparse` CLI framework.
 - **Skills format**: Source is `config.py` (frontmatter fields) + `body.md.j2` (Jinja2 template). Both skills and agents use `{{ SKILLS.CONSTANT }}` / `{{ AGENTS.CONSTANT }}` to reference other skills/agents. Build output is generated YAML frontmatter + rendered markdown.

--- a/agents/agent-code-reviewer.md
+++ b/agents/agent-code-reviewer.md
@@ -101,4 +101,4 @@ Return a structured review with both stages (or Stage 1 only if it failed). Be s
 - **Stay in scope** — review what changed, not the entire codebase
 - **Do not suggest over-engineering** — if the code works and is readable, do not request abstractions for hypothetical future requirements
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/agents/agent-github-issue-planner.md
+++ b/agents/agent-github-issue-planner.md
@@ -82,4 +82,4 @@ checklist | sub-issues
 - **Scope boundaries** — follow the mav-scope-boundaries skill. Flag any tasks that touch infrastructure, auth, or destructive operations.
 - **Durable output** — always post the tasks comment and update the state file before returning, so work is not lost if the caller's session crashes.
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/agents/agent-issue-analyst.md
+++ b/agents/agent-issue-analyst.md
@@ -74,4 +74,4 @@ Return a structured message containing:
 - **Right-sized design** — scale design depth to the task per the mav-create-solution-design skill's sizing table.
 - **Durable output** — always post the design comment and update the state file before returning, so work is not lost if the caller's session crashes.
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/agents/agent-maverick.md
+++ b/agents/agent-maverick.md
@@ -53,4 +53,4 @@ Return a structured message containing:
 - **Follow skill instructions exactly** — do not improvise or add extra steps
 - **Report clearly** — surface successes, failures, and warnings so the caller can act on them
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/agents/agent-session-reviewer.md
+++ b/agents/agent-session-reviewer.md
@@ -88,4 +88,4 @@ Return your findings as structured markdown:
 - **Consider context** — prototyping code has different standards than production code
 - **Focus on actionable findings** — each finding should suggest what to do differently
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/agents/agent-task-planner.md
+++ b/agents/agent-task-planner.md
@@ -64,4 +64,4 @@ Return a structured message containing:
 - **Scope boundaries** — follow the mav-scope-boundaries skill. Flag any tasks that touch infrastructure, auth, or destructive operations.
 - **Durable output** — always write the tasks file and update the state file before returning, so work is not lost if the caller's session crashes.
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/agents/agent-tech-docs-writer.md
+++ b/agents/agent-tech-docs-writer.md
@@ -29,4 +29,4 @@ You are a Senior Technical Documentation Writer. Your role is to produce clear, 
 - **Right-sized** — scale documentation depth to the topic's complexity
 - **Project-agnostic** — do not assume any specific technology stack; discover it from the codebase
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -66,7 +66,7 @@ When `upskill` detects a CI platform, it generates a project-level skill describ
 
 ### Maverick's own CI
 
-Maverick itself uses GitHub Actions for CI (`.github/workflows/unit-tests.yml`), running its unit test suite on push to `develop`.
+Maverick itself uses GitHub Actions for CI (`.github/workflows/unit-tests.yml`), running its unit test suite on pushes and PRs to `main`.
 
 ## Pipeline Stages
 

--- a/docs/comprehensive-testing.md
+++ b/docs/comprehensive-testing.md
@@ -200,7 +200,7 @@ This cycle is how an LLM iterates toward correctness. Without tests, the LLM has
 
 ## Maverick's Own Tests
 
-Maverick follows its own testing standards with a pytest unit test suite covering the Python codebase under `src/maverick/`. The suite includes tests for models, names, config, registry, CLI, lambda handler, and session review modules (parser, analyzers, reporter, skills). Tests run automatically on push to `develop` via GitHub Actions (`.github/workflows/unit-tests.yml`).
+Maverick follows its own testing standards with a pytest unit test suite covering the Python codebase under `src/maverick/`. The suite includes tests for models, names, config, registry, CLI, lambda handler, and session review modules (parser, analyzers, reporter, skills). Tests run automatically on pushes and PRs to `main` via GitHub Actions (`.github/workflows/unit-tests.yml`).
 
 ## Further Reading
 

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -37,43 +37,43 @@ These skills work together to constrain the LLM into a disciplined workflow that
 
 ## Branching Strategy
 
-Maverick uses a simplified Gitflow model with two long-lived branches and short-lived feature branches.
+Maverick uses a trunk-based model: `main` is the only long-lived branch. All work happens on short-lived branches that PR back to `main`.
 
 ```mermaid
 gitGraph
-    commit id: "initial"
-    branch develop
-    commit id: "d1"
+    commit id: "m1"
     branch feat/12-add-export
     commit id: "feat: add CSV export module"
     commit id: "feat: add export button to UI"
-    checkout develop
-    merge feat/12-add-export id: "merge PR #13"
+    checkout main
+    merge feat/12-add-export id: "squash-merge PR #13"
     branch fix/15-null-check
     commit id: "fix: handle null input in parser"
-    checkout develop
-    merge fix/15-null-check id: "merge PR #16"
     checkout main
-    merge develop id: "release v1.2.0"
+    merge fix/15-null-check id: "squash-merge PR #16"
+    branch release/1.2.0
+    commit id: "chore: release 1.2.0"
+    checkout main
+    merge release/1.2.0 id: "squash-merge + tag v1.2.0"
 ```
 
 ### Long-lived branches
 
-| Branch    | Purpose                                                 | Direct commits allowed |
-| --------- | ------------------------------------------------------- | ---------------------- |
-| `main`    | Production-ready code. Tagged with release versions.    | Never                  |
-| `develop` | Integration branch. All feature work merges here first. | Never                  |
+| Branch | Purpose                                                                                               | Direct commits allowed |
+| ------ | ----------------------------------------------------------------------------------------------------- | ---------------------- |
+| `main` | Trunk. Carries the current `-dev` version between releases. Tagged `vX.Y.Z` at each release.          | Never                  |
 
 ### Short-lived branches
 
-Feature and fix branches are created per issue and deleted after merge.
+Feature, fix, and release branches are created for a specific purpose and deleted after merge.
 
-| Branch type | Naming pattern                 | Merges into          |
-| ----------- | ------------------------------ | -------------------- |
-| Feature     | `feat/<issue>-<description>`   | `develop`            |
-| Fix         | `fix/<issue>-<description>`    | `develop`            |
-| Chore       | `chore/<issue>-<description>`  | `develop`            |
-| Hotfix      | `hotfix/<issue>-<description>` | `main` and `develop` |
+| Branch type | Naming pattern                 | Merges into |
+| ----------- | ------------------------------ | ----------- |
+| Feature     | `feat/<issue>-<description>`   | `main`      |
+| Fix         | `fix/<issue>-<description>`    | `main`      |
+| Chore       | `chore/<issue>-<description>`  | `main`      |
+| Hotfix      | `hotfix/<issue>-<description>` | `main`      |
+| Release     | `release/<version>`            | `main`      |
 
 ## Branch Naming Convention
 
@@ -163,7 +163,7 @@ An LLM opening a PR without issue linking is producing unaccountable work. The `
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Created: LLM creates branch from develop
+    [*] --> Created: LLM creates branch from main
     Created --> InProgress: LLM commits changes
     InProgress --> PROpened: LLM opens pull request
     PROpened --> CIPassing: All checks pass
@@ -172,14 +172,14 @@ stateDiagram-v2
     CIPassing --> ReviewApproved: Human approves
     CIPassing --> ChangesRequested: Human requests changes
     ChangesRequested --> InProgress: LLM addresses feedback
-    ReviewApproved --> Merged: PR merged to develop
+    ReviewApproved --> Merged: PR squash-merged to main
     Merged --> Deleted: Branch cleaned up
     Deleted --> [*]
 ```
 
 ### Branch creation
 
-- Always branch from `develop` (or `main` for hotfixes)
+- Always branch from `main`
 - Always use the naming convention
 - Always verify the branch does not already exist
 
@@ -230,7 +230,7 @@ The `mav-scope-boundaries` skill encodes these prohibitions. An LLM operating wi
 
 | Phase   | Action                                            | Skill enforcing                         |
 | ------- | ------------------------------------------------- | --------------------------------------- |
-| Start   | Read issue, create branch from `develop`          | `mav-github-issue-workflow`, `mav-git-workflow` |
+| Start   | Read issue, create branch from `main`             | `mav-github-issue-workflow`, `mav-git-workflow` |
 | Develop | Commit with conventional messages, push regularly | `mav-git-workflow`                              |
 | Verify  | Run local checks before push                      | `mav-local-verification`                        |
 | PR      | Open PR linking to issue, wait for CI             | `mav-github-issue-workflow`, `mav-git-workflow` |
@@ -239,7 +239,7 @@ The `mav-scope-boundaries` skill encodes these prohibitions. An LLM operating wi
 
 ## Key Constraints for LLMs
 
-- Never commit directly to `main` or `develop`
+- Never commit directly to `main`
 - Never create a branch without an issue number
 - Never use `--no-verify` to skip hooks
 - Never force push to any branch

--- a/docs/maverick-build.md
+++ b/docs/maverick-build.md
@@ -96,21 +96,22 @@ make release VERSION=0.2.0
 
 ### What the script does
 
-The release script follows a develop-first flow: the release is prepared on `develop`, merged to `main`, tagged, and then `develop` is bumped to the next dev version so it always stays ahead of `main`.
+The release script follows a trunk-based flow. `main` carries the current `-dev` version between releases. The script cuts a short-lived `release/<version>` branch from `main`, bumps the version, and opens a PR back to `main`. After the PR squash-merges, `release-finalize.yml` takes over: tag, GitHub Release, and a follow-up PR that bumps `main` to the next `-dev` version.
 
-1. **Pre-flight checks** — validates the version is valid semver, the branch is `develop`, the working tree is clean, the tag does not already exist, and `main` is an ancestor of `develop`
-2. Bumps the version to `X.Y.Z` in all four manifest files
-3. Updates `CHANGELOG.md` — adds a dated version section below `[Unreleased]` and updates comparison links
-4. Runs `uv lock` to sync the lockfile
-5. Commits on `develop`: `chore: release X.Y.Z`
-6. Checks out `main` and merges `develop` with `--no-ff`
-7. Creates an annotated git tag `vX.Y.Z` on `main`
-8. Checks out `develop` and bumps the version to `X.(Y+1).0-dev` in all four manifest files
-9. Runs `uv lock` and commits: `chore: begin X.(Y+1).0-dev cycle`
+**Local phase** (`scripts/release.sh`):
 
-After running the script, push both branches and the tag, then create a GitHub release:
+1. **Pre-flight checks** — validates the current branch is `main`, the working tree is clean, the computed version has not already been tagged, and the release branch does not already exist
+2. Creates `release/<version>` from `main`
+3. Bumps the version to `X.Y.Z` in `pyproject.toml`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `.cursor-plugin/cursor.plugin.json`
+4. Updates `CHANGELOG.md` — adds a dated version section below `[Unreleased]` and updates comparison links
+5. Runs `uv lock` and `make build` to refresh the lockfile and regenerated output
+6. Commits on `release/<version>`: `chore: release X.Y.Z`
+7. Pushes the release branch and creates a PR targeting `main` with the release notes
 
-```bash
-git push origin main develop --tags
-gh release create vX.Y.Z --generate-notes
-```
+**CI phase** (`.github/workflows/release-finalize.yml`):
+
+After the release PR squash-merges into `main`:
+
+1. Tags the merge commit `vX.Y.Z`
+2. Creates a GitHub Release with notes extracted from `CHANGELOG.md`
+3. Opens a follow-up PR (`chore/begin-X.Y.(Z+1)-dev-cycle`) that bumps `main` back to the next `-dev` version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maverick"
-version = "0.5.7"
+version = "0.5.8-dev"
 description = "Claude Code plugin that enables autonomous AI development while maintaining best practices"
 requires-python = ">=3.10"
 dependencies = [

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Release script for maverick — LOCAL PREP PHASE
 #
 # This script handles the local portion of the release process:
-#   1. Create release/<version> branch from develop
+#   1. Create release/<version> branch from main
 #   2. Bump version, update changelog, rebuild — commit on release branch
 #   3. Push release branch and create a PR targeting main
 #
@@ -12,8 +12,7 @@ set -euo pipefail
 # workflow automatically handles:
 #   - Tagging the squash commit on main
 #   - Creating the GitHub Release
-#   - Merging main back into develop
-#   - Bumping develop to the next -dev version
+#   - Opening a follow-up PR that bumps main to the next -dev version
 #
 # Usage: ./scripts/release.sh [major|minor|patch]
 # Default: patch
@@ -35,8 +34,8 @@ if [[ ! -f "$PYPROJECT" ]]; then
     exit 1
 fi
 
-if [[ "$CURRENT_BRANCH" != "develop" ]]; then
-    echo "ERROR: Must be on the develop branch. Currently on '$CURRENT_BRANCH'." >&2
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+    echo "ERROR: Must be on the main branch. Currently on '$CURRENT_BRANCH'." >&2
     exit 1
 fi
 
@@ -93,7 +92,7 @@ fi
 echo "Releasing: $CURRENT_VERSION -> $NEW_VERSION ($BUMP_TYPE)"
 
 # =============================================================================
-# Step 1: Create release branch from develop
+# Step 1: Create release branch from main
 # =============================================================================
 
 echo "Creating release branch: $RELEASE_BRANCH"
@@ -150,8 +149,7 @@ ${RELEASE_NOTES:-No changelog entries for this release.}
 **After squash-merging this PR**, the \`release-finalize\` workflow will automatically:
 1. Tag the merge commit with \`${NEW_TAG}\`
 2. Create a GitHub Release
-3. Merge main back into develop
-4. Bump develop to the next \`-dev\` version
+3. Open a follow-up PR that bumps \`main\` to the next \`-dev\` version
 EOF
 )")
 
@@ -166,5 +164,5 @@ echo "  3. CI will handle tagging, release,"
 echo "     and develop sync automatically"
 echo "========================================="
 
-# Return to develop
-git checkout develop
+# Return to main
+git checkout main

--- a/skills/do-adopt/SKILL.md
+++ b/skills/do-adopt/SKILL.md
@@ -109,4 +109,4 @@ Follow the mav-git-workflow skill for commit conventions. Do not push — the us
 - **No branch creation** — commit directly to the current branch. The user is expected to be on an appropriate branch.
 - **One commit per topic** — separate commits make it easy to review or revert individual adoptions
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/do-docs/SKILL.md
+++ b/skills/do-docs/SKILL.md
@@ -152,4 +152,4 @@ Run the do-tech-docs validation checklist against every document changed or crea
 - In **update** mode, scope narrowly to the diff — do not refactor surrounding documentation
 - Verify every factual claim against the source code before writing it
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/do-init/SKILL.md
+++ b/skills/do-init/SKILL.md
@@ -19,4 +19,4 @@ Dispatch the **agent-maverick** agent with task `init` and any user-provided arg
 3. Run the skill /maverick:do-docs
 4. Run the skill /maverick:do-upskill
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/do-install/SKILL.md
+++ b/skills/do-install/SKILL.md
@@ -21,4 +21,4 @@ Dispatch the **maverick** agent with task `install` and any user-provided argume
 4. Verify the installation by running `maverick --help`
 5. Report the result to the user — success or failure with any error output
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/do-issue-guided/SKILL.md
+++ b/skills/do-issue-guided/SKILL.md
@@ -49,7 +49,7 @@ Run Phase 3 as a subagent to keep the main context window clean for implementati
 ## Phase 4: Create Branch
 
 1. Derive the branch name per the mav-github-issue-workflow skill (branching conventions).
-2. Create the branch from the project's integration branch (typically `develop`).
+2. Create the branch from the project's default branch (typically `main`).
 3. Update phase to `branch` in the state file.
 
 ## Phase 5: Execute Tasks
@@ -87,7 +87,7 @@ Follow the mav-plan-execution skill for the execution loop, verification discipl
 
 ## Phase 6: Code Review
 
-1. Dispatch the agent-code-reviewer agent with the issue requirements and the diff (`git diff develop...HEAD`).
+1. Dispatch the agent-code-reviewer agent with the issue requirements and the diff (`git diff main...HEAD`).
 2. The reviewer performs two-stage review: spec compliance first, then code quality.
 3. If spec compliance fails, stop — fix the gaps before requesting re-review.
 4. Process code quality feedback per the do-pullrequest-review skill:
@@ -104,14 +104,14 @@ Follow the mav-plan-execution skill for the execution loop, verification discipl
 
 ## Phase 7: Documentation Review
 
-1. Run `git diff develop...HEAD --name-only` to identify all changed files.
+1. Run `git diff main...HEAD --name-only` to identify all changed files.
 2. Determine whether the changes affect behaviour that is covered by existing documentation in `docs/`:
    - Changed or added public APIs, components, services, or configuration
    - Altered data flows, integration points, or architectural patterns
    - Modified feature behaviour described in existing docs
 3. If documentation updates are needed, dispatch the **agent-tech-docs-writer** agent with:
    - Mode: **update**
-   - The diff (`git diff develop...HEAD`)
+   - The diff (`git diff main...HEAD`)
    - The list of affected doc files (or a note that new documentation is needed)
    - Instruction to update existing docs to reflect the changes — not to rewrite unrelated sections
 4. Review the agent's output. Verify that updates are accurate and scoped to the changes made.
@@ -137,8 +137,8 @@ Follow the mav-plan-execution skill for the execution loop, verification discipl
 - **Pause at checkpoints** — every phase marked with 🔲 requires user confirmation before continuing.
 - **Work autonomously between checkpoints** — do not ask for permission on routine implementation work. Only ask when uncertain, blocked, or at a checkpoint.
 - **Run verification** after each task and after all tasks. Do not declare success if checks fail.
-- **Never commit directly** to `main` or `develop`.
+- **Never commit directly** to `main`.
 - **Use conventional commits** that reference the issue number (e.g., `feat: add rubric export (#42)`).
 - **Always create a PR** at the end — deliver a complete result.
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/do-issue-solo/SKILL.md
+++ b/skills/do-issue-solo/SKILL.md
@@ -45,7 +45,7 @@ Run Phase 3 as a subagent to keep the main context window clean for implementati
 ## Phase 4: Create Branch
 
 1. Derive the branch name per the mav-github-issue-workflow skill (branching conventions).
-2. Create the branch from the project's integration branch (typically `develop`).
+2. Create the branch from the project's default branch (typically `main`).
 3. Update phase to `branch` in the state file.
 
 ## Phase 5: Execute Tasks
@@ -79,7 +79,7 @@ Follow the mav-plan-execution skill for the execution loop, verification discipl
 
 ## Phase 6: Code Review
 
-1. Dispatch the agent-code-reviewer agent with the issue requirements and the diff (`git diff develop...HEAD`).
+1. Dispatch the agent-code-reviewer agent with the issue requirements and the diff (`git diff main...HEAD`).
 2. The reviewer performs two-stage review: spec compliance first, then code quality.
 3. If spec compliance fails, stop — fix the gaps before requesting re-review.
 4. Process code quality feedback per the do-pullrequest-review skill:
@@ -94,14 +94,14 @@ Follow the mav-plan-execution skill for the execution loop, verification discipl
 
 ## Phase 7: Documentation Review
 
-1. Run `git diff develop...HEAD --name-only` to identify all changed files.
+1. Run `git diff main...HEAD --name-only` to identify all changed files.
 2. Determine whether the changes affect behaviour that is covered by existing documentation in `docs/`:
    - Changed or added public APIs, components, services, or configuration
    - Altered data flows, integration points, or architectural patterns
    - Modified feature behaviour described in existing docs
 3. If documentation updates are needed, dispatch the **agent-tech-docs-writer** agent with:
    - Mode: **update**
-   - The diff (`git diff develop...HEAD`)
+   - The diff (`git diff main...HEAD`)
    - The list of affected doc files (or a note that new documentation is needed)
    - Instruction to update existing docs to reflect the changes — not to rewrite unrelated sections
 4. Review the agent's output. Verify that updates are accurate and scoped to the changes made.
@@ -124,8 +124,8 @@ Follow the mav-plan-execution skill for the execution loop, verification discipl
 
 - **Only pause for user input** when blocked or when the issue is ambiguous. Do not ask for approval on design or tasks unless you are uncertain.
 - **Run verification** after each task and after all tasks. Do not declare success if checks fail.
-- **Never commit directly** to `main` or `develop`.
+- **Never commit directly** to `main`.
 - **Use conventional commits** that reference the issue number (e.g., `feat: add rubric export (#42)`).
 - **Always create a PR** at the end — this is the autonomous workflow, so deliver a complete result.
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/do-maverick-alignment/SKILL.md
+++ b/skills/do-maverick-alignment/SKILL.md
@@ -349,4 +349,4 @@ After writing the report, print a brief summary:
 - Which categories are WARN or FAIL
 - The path to the full report
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/do-pullrequest-review/SKILL.md
+++ b/skills/do-pullrequest-review/SKILL.md
@@ -144,4 +144,4 @@ When receiving review during a do-issue workflow:
 4. If the review came from the agent-code-reviewer agent and had spec compliance failures, request a re-review after fixing
 5. Update the plan comment on the issue if fixes changed the implementation approach
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/do-recommend/SKILL.md
+++ b/skills/do-recommend/SKILL.md
@@ -127,4 +127,4 @@ To adopt the recommended option, run `/maverick:do-adopt <topic>`.
 - **Frontmatter required** — name, title, generated, status fields mandatory
 - **Write directly** — no user approval needed, file is version-controlled
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/do-task-solo/SKILL.md
+++ b/skills/do-task-solo/SKILL.md
@@ -129,7 +129,7 @@ Run Phase 3 as a subagent to keep the main context window clean for implementati
 ## Phase 4: Create Branch
 
 1. Derive the branch name from the task. Use the format `<type>/<task-id>-<short-desc>` (e.g., `feat/TASK-001-add-export`). Follow the mav-git-workflow skill for type prefixes.
-2. Create the branch from the project's integration branch (typically `develop`).
+2. Create the branch from the project's default branch (typically `main`).
 3. Commit the task artifacts (`task.md`, `solution-design.md`, `tasks.md`) so they are tracked in version control.
 4. Update `state.json`: set `branch` and `phase` to `branch`.
 
@@ -151,7 +151,7 @@ Follow the mav-plan-execution skill for the execution loop, verification discipl
 
 ## Phase 6: Code Review
 
-1. Dispatch the agent-code-reviewer agent with the task requirements (from `task.md`) and the diff (`git diff develop...HEAD`).
+1. Dispatch the agent-code-reviewer agent with the task requirements (from `task.md`) and the diff (`git diff main...HEAD`).
 2. The reviewer performs two-stage review: spec compliance first, then code quality.
 3. If spec compliance fails, stop — fix the gaps before requesting re-review.
 4. Process code quality feedback per the do-pullrequest-review skill:
@@ -166,14 +166,14 @@ Follow the mav-plan-execution skill for the execution loop, verification discipl
 
 ## Phase 7: Documentation Review
 
-1. Run `git diff develop...HEAD --name-only` to identify all changed files.
+1. Run `git diff main...HEAD --name-only` to identify all changed files.
 2. Determine whether the changes affect behaviour that is covered by existing documentation in `docs/`:
    - Changed or added public APIs, components, services, or configuration
    - Altered data flows, integration points, or architectural patterns
    - Modified feature behaviour described in existing docs
 3. If documentation updates are needed, dispatch the **agent-tech-docs-writer** agent with:
    - Mode: **update**
-   - The diff (`git diff develop...HEAD`)
+   - The diff (`git diff main...HEAD`)
    - The list of affected doc files (or a note that new documentation is needed)
    - Instruction to update existing docs to reflect the changes — not to rewrite unrelated sections
 4. Review the agent's output. Verify that updates are accurate and scoped to the changes made.
@@ -251,9 +251,9 @@ When resuming work on a task (new session, after crash):
 
 - **Only pause for user input** when blocked or when the task is ambiguous. Do not ask for approval on design or tasks unless you are uncertain.
 - **Run verification** after each task and after all tasks. Do not declare success if checks fail.
-- **Never commit directly** to `main` or `develop`.
+- **Never commit directly** to `main`.
 - **Use conventional commits** that reference the task ID (e.g., `feat: add rubric export (TASK-001)`).
 - **Always create a PR** at the end — this is the autonomous workflow, so deliver a complete result.
 - **Commit task artifacts** (`task.md`, `solution-design.md`, `tasks.md`, `completion.md`) to version control so they are available for review and survive across sessions. Only `state.json` is gitignored.
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/do-tech-docs/SKILL.md
+++ b/skills/do-tech-docs/SKILL.md
@@ -191,4 +191,4 @@ Before finalising documentation:
 - [ ] All public exports from documented modules are covered (check for multiple exports per file)
 - [ ] Numbering, terminology, and facts are consistent across all documents in the set
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/do-upskill/SKILL.md
+++ b/skills/do-upskill/SKILL.md
@@ -350,4 +350,4 @@ When no scan hints are provided by the calling skill, use these defaults:
 - **grep**: `dotenv|process\.env|os\.environ|docker-compose|devcontainer|CONTRIBUTING`
 - **files**: `.env.example`, `.env.sample`, `.env.template`, `.devcontainer/**`, `docker-compose*.yml`, `Vagrantfile`, `flake.nix`, `shell.nix`, `CONTRIBUTING.md`
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-accessibility/SKILL.md
+++ b/skills/mav-bp-accessibility/SKILL.md
@@ -308,4 +308,4 @@ When reviewing code for user-facing interfaces, flag these patterns:
 | Custom widget without keyboard handling | Inoperable for keyboard users | Implement full keyboard interaction pattern |
 | Error shown only by colour change | Screen readers cannot detect colour | Add text message and `aria-describedby` |
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-alerting/SKILL.md
+++ b/skills/mav-bp-alerting/SKILL.md
@@ -142,4 +142,4 @@ Alerting and logging are complementary but separate concerns:
 | Alert but no log                                 | Missing investigation trail | Always log before alerting                 |
 | Frontend calling alerting service directly       | Security risk               | Route through backend API                  |
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-api-design/SKILL.md
+++ b/skills/mav-bp-api-design/SKILL.md
@@ -269,4 +269,4 @@ When reviewing code, flag these patterns:
 | No idempotency on payment/financial endpoints      | Duplicate processing risk          | Require idempotency keys                               |
 | API docs maintained separately from code           | Documentation drift                | Generate docs from source (OpenAPI, introspection)     |
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-application-security/SKILL.md
+++ b/skills/mav-bp-application-security/SKILL.md
@@ -269,4 +269,4 @@ Always prefer the secure option unless there is a documented, reviewed reason to
 | Deserialisation of untrusted data                        | Remote code execution        | Avoid deserialising untrusted input; use safe formats (JSON) |
 | Missing `HttpOnly`/`Secure` flags on session cookies     | Session hijacking            | Set `HttpOnly`, `Secure`, and `SameSite` on all auth cookies |
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-cicd-azure/SKILL.md
+++ b/skills/mav-bp-cicd-azure/SKILL.md
@@ -134,4 +134,4 @@ digraph ci {
 - Fix CI failures before declaring work complete
 - Report CI failures clearly if you cannot fix them
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-cicd-bitbucket/SKILL.md
+++ b/skills/mav-bp-cicd-bitbucket/SKILL.md
@@ -98,4 +98,4 @@ digraph ci {
 - Fix CI failures before declaring work complete
 - Report CI failures clearly if you cannot fix them
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-cicd-github/SKILL.md
+++ b/skills/mav-bp-cicd-github/SKILL.md
@@ -89,4 +89,4 @@ digraph ci {
 - Fix CI failures before declaring work complete
 - Report CI failures clearly if you cannot fix them
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-cicd-gitlab/SKILL.md
+++ b/skills/mav-bp-cicd-gitlab/SKILL.md
@@ -126,4 +126,4 @@ digraph ci {
 - Fix CI failures before declaring work complete
 - Report CI failures clearly if you cannot fix them
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-cicd/SKILL.md
+++ b/skills/mav-bp-cicd/SKILL.md
@@ -96,7 +96,7 @@ digraph envs {
 | Environment | Trigger | Approval |
 | ----------- | ------- | -------- |
 | Dev/Preview | Push to feature branch or PR | Automatic |
-| Staging | Merge to main/develop | Automatic |
+| Staging | Merge to main (or equivalent trunk) | Automatic |
 | Production | Promotion from staging | Manual approval required |
 
 ### Promotion Rules
@@ -209,4 +209,4 @@ digraph lookup {
 | Pipeline takes >15 minutes | Developer productivity drain | Profile and optimise, add caching |
 | Unpinned action/image versions | Non-reproducible builds | Pin to specific versions/SHAs |
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-code-review/SKILL.md
+++ b/skills/mav-bp-code-review/SKILL.md
@@ -17,7 +17,7 @@ Ensure all code changes are reviewed before merging. Reviews catch defects, shar
 
 ## Mandatory Review Requirements
 
-- **At least one approval** before merging to any protected branch (`main`, `develop`, `release/*`)
+- **At least one approval** before merging to any protected branch (e.g., `main`)
 - **No self-approvals** — the author cannot approve their own pull request
 - **Stale approvals dismissed on new pushes** — if the author pushes new commits after approval, the approval is invalidated and a re-review is required
 - **All CI checks passing** — do not merge with failing lints, tests, or type checks
@@ -116,4 +116,4 @@ Human review time is expensive. Do not spend it on issues that automated tools h
 | Self-approval on protected branch                  | Missing review gate                | Configure branch protection to disallow self-approval |
 | Skipping CI to merge faster                        | Bypassing quality gates            | CI must pass; fix failures, do not skip them         |
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-database-management/SKILL.md
+++ b/skills/mav-bp-database-management/SKILL.md
@@ -202,4 +202,4 @@ When reviewing code, flag these patterns:
 | `DROP TABLE` or `DROP COLUMN` without staged rollout| Breaks running application        | Stage the change: remove code references first         |
 | No transaction wrapping for multi-step migration   | Partial application on failure     | Wrap in transaction where the database supports it     |
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-dependency-management/SKILL.md
+++ b/skills/mav-bp-dependency-management/SKILL.md
@@ -244,4 +244,4 @@ digraph lookup {
 | Large transitive dependency addition | Unexpected supply chain expansion | Investigate and consider lighter alternatives |
 | `--force` or `--legacy-peer-deps` in install commands | Masking resolution conflicts | Fix the underlying version conflict |
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-documentation/SKILL.md
+++ b/skills/mav-bp-documentation/SKILL.md
@@ -142,4 +142,4 @@ When reviewing code or auditing a project, flag these patterns:
 | Inline comments restating obvious code           | Noise, not documentation     | Remove; write higher-level docs instead                  |
 | Documentation in external wiki only              | Not versioned with code      | Move to repo `docs/` directory                           |
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-environment-management/SKILL.md
+++ b/skills/mav-bp-environment-management/SKILL.md
@@ -215,4 +215,4 @@ When both skills apply (e.g., a Docker Compose file used in both local dev and C
 | Database engine differs between dev and production | Environment parity violation | Use the same engine locally via Docker |
 | No health checks in Docker Compose services | Startup race conditions | Add health checks and depends_on with condition |
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-error-handling/SKILL.md
+++ b/skills/mav-bp-error-handling/SKILL.md
@@ -299,4 +299,4 @@ Error handling, logging, and alerting are complementary:
 | No error boundary around UI sections                | Single component crashes page  | Wrap sections in error boundaries with fallback UI |
 | Generic error message for all failures              | Poor user experience           | Distinguish client vs server errors                |
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-infrastructure-as-code/SKILL.md
+++ b/skills/mav-bp-infrastructure-as-code/SKILL.md
@@ -164,4 +164,4 @@ When IaC is not possible -- because the platform does not support it, the tool l
 | Destructive changes auto-applied               | Accidental data loss           | Require human approval for destroy/replace actions   |
 | Mixed IaC tools for the same resource layer    | Conflicting state management   | Standardise on one tool per layer                    |
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-integration-testing/SKILL.md
+++ b/skills/mav-bp-integration-testing/SKILL.md
@@ -166,4 +166,4 @@ digraph lookup {
 | Hard-coded connection strings | Breaks in different environments | Use environment variables or config |
 | Test requires manual environment setup | Not reproducible | Automate with containers or scripts |
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-linting/SKILL.md
+++ b/skills/mav-bp-linting/SKILL.md
@@ -171,4 +171,4 @@ digraph lookup {
 | No pre-commit formatting | Style inconsistency across commits | Add lint-staged or equivalent |
 | Linter running on generated/vendor code | False positives, slow runs | Update ignore patterns |
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-logging/SKILL.md
+++ b/skills/mav-bp-logging/SKILL.md
@@ -288,4 +288,4 @@ When reviewing code, flag these patterns:
 | Different loggers in different files               | Inconsistency                 | Use single logger module                     |
 | `try/catch` that silently swallows                 | Lost errors                   | Log or re-throw                              |
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-observability/SKILL.md
+++ b/skills/mav-bp-observability/SKILL.md
@@ -208,4 +208,4 @@ Every deployed service should have a dashboard showing the **four golden signals
 | Dashboard with no link to traces or logs         | Slow investigation              | Add drill-down links from dashboard panels                 |
 | Custom metric collection instead of standard library | Maintenance burden, incompatibility | Migrate to OpenTelemetry or equivalent             |
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-solutions-design/SKILL.md
+++ b/skills/mav-bp-solutions-design/SKILL.md
@@ -215,4 +215,4 @@ Not every change needs a 10-page design document. The investment in design shoul
 | Design doc exists but is stale | Documentation rot | Update the design doc to reflect what was actually built |
 | Requirements ambiguity resolved by guessing | Risk of building the wrong thing | Clarify with stakeholder before proceeding |
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-source-control/SKILL.md
+++ b/skills/mav-bp-source-control/SKILL.md
@@ -137,7 +137,7 @@ For detailed branching strategy, commit message format, merge conflict handling,
 
 This skill covers:
 - Branch naming conventions (`<type>/<issue>-<desc>`)
-- Protected branches (`main`, `develop`)
+- Protected branch (`main`)
 - Conventional Commits format
 - Merge and rebase strategies
 - Branch cleanup after merge
@@ -157,4 +157,4 @@ When auditing a project or starting work, flag these patterns:
 | Sensitive file patterns missing from `.gitignore` | Future risk of secret commits | Add missing patterns to `.gitignore`                  |
 | Remote URL points to deleted/moved repo    | Effectively no remote           | Update remote URL to valid repository                     |
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-task-tracking/SKILL.md
+++ b/skills/mav-bp-task-tracking/SKILL.md
@@ -163,4 +163,4 @@ When reviewing workflow and project management practices, flag these patterns:
 | Local TODO list used instead of tracker | Invisible work | Move tasks to the external system |
 | Task marked done but PR not merged | Status does not reflect reality | Update status to match actual state |
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-unit-testing/SKILL.md
+++ b/skills/mav-bp-unit-testing/SKILL.md
@@ -156,4 +156,4 @@ digraph lookup {
 | Test duplicates implementation logic | Tautological test | Assert on outputs, not reimplemented logic |
 | Commented-out tests | Dead tests hiding failures | Delete or fix |
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-bp-versioning/SKILL.md
+++ b/skills/mav-bp-versioning/SKILL.md
@@ -230,4 +230,4 @@ The two are related but distinct:
 | Deprecated code no longer functions | Broken deprecation contract | Fix deprecated code path — it must work until removal |
 | Multiple breaking changes across minor releases | Death by a thousand cuts for consumers | Batch breaking changes into a single major release |
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-claude-code-recovery/SKILL.md
+++ b/skills/mav-claude-code-recovery/SKILL.md
@@ -225,4 +225,4 @@ digraph subagent_failure {
 - **Reduce scope on repeated failure** — if a subagent fails twice on the same task, split the task into smaller pieces and dispatch subagents for each piece.
 - **Never silently swallow failures** — if a subagent fails and you cannot recover, report the failure clearly to the user.
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-create-solution-design/SKILL.md
+++ b/skills/mav-create-solution-design/SKILL.md
@@ -118,4 +118,4 @@ Before the design is considered complete:
 - [ ] Risks are honest — if there are none, you haven't looked hard enough
 - [ ] The approach is achievable in a single session (if not, flag for further decomposition)
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-create-tasks/SKILL.md
+++ b/skills/mav-create-tasks/SKILL.md
@@ -149,4 +149,4 @@ Before the task list is considered complete:
 - [ ] Dependencies between tasks are minimal and explicitly stated
 - [ ] The sum of all tasks fully implements the solution design
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-git-workflow/SKILL.md
+++ b/skills/mav-git-workflow/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: false
 
 # Git Workflow
 
-A simplified Gitflow strategy for all development work. This skill defines how branches, commits, and merges are managed.
+A trunk-based strategy for all development work. This skill defines how branches, commits, and merges are managed.
 
 ## Remote Repository Requirement
 
@@ -30,26 +30,27 @@ A project with no remote cannot use protected branches, pull requests, or CI/CD 
 ## Branch Strategy
 
 ```
-main (production — never touched directly)
-  └── develop (integration branch — never committed to directly)
-        ├── feat/42-add-export
-        ├── fix/57-login-crash
-        └── chore/63-update-deps
+main (trunk — the only long-lived branch; tagged at each release)
+  ├── feat/42-add-export
+  ├── fix/57-login-crash
+  ├── chore/63-update-deps
+  └── release/<version> (short-lived; exists only long enough to cut a release)
 ```
 
 ### Branch Roles
 
 | Branch | Purpose | Who commits | Protected |
 |---|---|---|---|
-| `main` | Production releases | Merge from `develop` only (human-gated) | Yes |
-| `develop` | Integration branch | Merge from feature/fix branches via PR only | Yes |
-| Feature/fix branches | Active development | Claude Code and developers | No |
+| `main` | Trunk — carries the current `-dev` version between releases; tagged at each release | Merge from feature/fix/release branches via PR only | Yes |
+| Feature/fix/chore branches | Active development | Claude Code and developers | No |
+| `release/<version>` | Short-lived release prep — bumps version, updates CHANGELOG | Created by `scripts/release.sh` | No |
 
 ### Rules
 
-- **Never commit directly to `main` or `develop`**. All changes reach these branches via pull request.
-- **All work happens on feature/fix branches** created from `develop`.
+- **Never commit directly to `main`**. All changes reach `main` via pull request.
+- **All work happens on short-lived branches** created from `main` and PR'd back to `main`.
 - **One branch per issue/task**. Do not combine unrelated work on a single branch.
+- **Release branches are ephemeral**. Created by the release script, deleted after the release PR merges.
 
 ## Branch Naming
 
@@ -100,18 +101,14 @@ digraph branch {
 
 ### Identify the Base Branch
 
-The base branch is typically `develop`. To confirm, check:
+The base branch is the repository's default branch — typically `main`. To confirm:
 
 ```bash
-# Check default branch
 gh repo view --json defaultBranchRef -q '.defaultBranchRef.name'
-
-# Check if develop exists
-git branch -r | grep -q 'origin/develop'
 ```
 
-- If `develop` exists — branch from `develop`
-- If only `main` exists — branch from `main`
+- If the default branch is `main` — branch from `main`
+- If the project still uses a legacy integration branch (e.g., `develop`) — branch from that and ask the user whether to adopt trunk-based
 - If uncertain — ask the user
 
 ### Create the Branch
@@ -249,11 +246,11 @@ git push origin --delete $BRANCH_NAME
 For cleaning up stale local branches that have been merged:
 
 ```bash
-# List merged branches (excluding main and develop)
-git branch --merged $BASE_BRANCH | grep -vE '^\*|main|develop'
+# List merged branches (excluding main)
+git branch --merged $BASE_BRANCH | grep -vE '^\*|main'
 
 # Delete them
-git branch --merged $BASE_BRANCH | grep -vE '^\*|main|develop' | xargs git branch -d
+git branch --merged $BASE_BRANCH | grep -vE '^\*|main' | xargs git branch -d
 ```
 
 ## Pulling Updates
@@ -283,4 +280,4 @@ If there are uncommitted changes:
 - **Stash them** if they are unrelated: `git stash push -m "WIP: description"`
 - **Ask the user** if you are unsure what to do with them
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-github-issue-workflow/SKILL.md
+++ b/skills/mav-github-issue-workflow/SKILL.md
@@ -303,4 +303,4 @@ rm .claude/issue-state.json
 
 Do not delete the state file until the PR is successfully created, as it is needed for crash recovery.
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-local-verification/SKILL.md
+++ b/skills/mav-local-verification/SKILL.md
@@ -103,4 +103,4 @@ Not every change needs the full suite:
 
 For the final push before PR creation, always run the full suite regardless of change type.
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-plan-execution/SKILL.md
+++ b/skills/mav-plan-execution/SKILL.md
@@ -194,4 +194,4 @@ After all steps are complete and the full verification suite passes:
 Do not proceed to code review until every acceptance criterion is met and all checks pass.
 
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-scope-boundaries/SKILL.md
+++ b/skills/mav-scope-boundaries/SKILL.md
@@ -176,4 +176,4 @@ This task requires interaction with a production system that Claude Code cannot 
 *Posted by Claude Code*
 ```
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/skills/mav-systematic-debugging/SKILL.md
+++ b/skills/mav-systematic-debugging/SKILL.md
@@ -171,4 +171,4 @@ When debugging occurs during plan execution (do-issue workflows):
 3. **Log diagnostic findings** — if the bug reveals a design issue, update the solution design comment on the issue
 4. **Time-box debugging** — if Phase 1 takes more than 30 minutes without progress, escalate to the user rather than continuing to investigate alone
 
-<!-- maverick-plugin-version: 0.5.7 -->
+<!-- maverick-plugin-version: 0.5.8-dev -->

--- a/src/maverick/skills/do-issue-guided/body.md.j2
+++ b/src/maverick/skills/do-issue-guided/body.md.j2
@@ -42,7 +42,7 @@ Run Phase 3 as a subagent to keep the main context window clean for implementati
 ## Phase 4: Create Branch
 
 1. Derive the branch name per the {{ SKILLS.MAV_GITHUB_ISSUE_WORKFLOW }} skill (branching conventions).
-2. Create the branch from the project's integration branch (typically `develop`).
+2. Create the branch from the project's default branch (typically `main`).
 3. Update phase to `branch` in the state file.
 
 ## Phase 5: Execute Tasks
@@ -80,7 +80,7 @@ Follow the {{ SKILLS.MAV_PLAN_EXECUTION }} skill for the execution loop, verific
 
 ## Phase 6: Code Review
 
-1. Dispatch the {{ AGENTS.AGENT_CODE_REVIEWER }} agent with the issue requirements and the diff (`git diff develop...HEAD`).
+1. Dispatch the {{ AGENTS.AGENT_CODE_REVIEWER }} agent with the issue requirements and the diff (`git diff main...HEAD`).
 2. The reviewer performs two-stage review: spec compliance first, then code quality.
 3. If spec compliance fails, stop — fix the gaps before requesting re-review.
 4. Process code quality feedback per the {{ SKILLS.DO_PULLREQUEST_REVIEW }} skill:
@@ -97,14 +97,14 @@ Follow the {{ SKILLS.MAV_PLAN_EXECUTION }} skill for the execution loop, verific
 
 ## Phase 7: Documentation Review
 
-1. Run `git diff develop...HEAD --name-only` to identify all changed files.
+1. Run `git diff main...HEAD --name-only` to identify all changed files.
 2. Determine whether the changes affect behaviour that is covered by existing documentation in `docs/`:
    - Changed or added public APIs, components, services, or configuration
    - Altered data flows, integration points, or architectural patterns
    - Modified feature behaviour described in existing docs
 3. If documentation updates are needed, dispatch the **{{ AGENTS.AGENT_TECH_DOCS_WRITER }}** agent with:
    - Mode: **update**
-   - The diff (`git diff develop...HEAD`)
+   - The diff (`git diff main...HEAD`)
    - The list of affected doc files (or a note that new documentation is needed)
    - Instruction to update existing docs to reflect the changes — not to rewrite unrelated sections
 4. Review the agent's output. Verify that updates are accurate and scoped to the changes made.
@@ -130,6 +130,6 @@ Follow the {{ SKILLS.MAV_PLAN_EXECUTION }} skill for the execution loop, verific
 - **Pause at checkpoints** — every phase marked with 🔲 requires user confirmation before continuing.
 - **Work autonomously between checkpoints** — do not ask for permission on routine implementation work. Only ask when uncertain, blocked, or at a checkpoint.
 - **Run verification** after each task and after all tasks. Do not declare success if checks fail.
-- **Never commit directly** to `main` or `develop`.
+- **Never commit directly** to `main`.
 - **Use conventional commits** that reference the issue number (e.g., `feat: add rubric export (#42)`).
 - **Always create a PR** at the end — deliver a complete result.

--- a/src/maverick/skills/do-issue-solo/body.md.j2
+++ b/src/maverick/skills/do-issue-solo/body.md.j2
@@ -38,7 +38,7 @@ Run Phase 3 as a subagent to keep the main context window clean for implementati
 ## Phase 4: Create Branch
 
 1. Derive the branch name per the {{ SKILLS.MAV_GITHUB_ISSUE_WORKFLOW }} skill (branching conventions).
-2. Create the branch from the project's integration branch (typically `develop`).
+2. Create the branch from the project's default branch (typically `main`).
 3. Update phase to `branch` in the state file.
 
 ## Phase 5: Execute Tasks
@@ -72,7 +72,7 @@ Follow the {{ SKILLS.MAV_PLAN_EXECUTION }} skill for the execution loop, verific
 
 ## Phase 6: Code Review
 
-1. Dispatch the {{ AGENTS.AGENT_CODE_REVIEWER }} agent with the issue requirements and the diff (`git diff develop...HEAD`).
+1. Dispatch the {{ AGENTS.AGENT_CODE_REVIEWER }} agent with the issue requirements and the diff (`git diff main...HEAD`).
 2. The reviewer performs two-stage review: spec compliance first, then code quality.
 3. If spec compliance fails, stop — fix the gaps before requesting re-review.
 4. Process code quality feedback per the {{ SKILLS.DO_PULLREQUEST_REVIEW }} skill:
@@ -87,14 +87,14 @@ Follow the {{ SKILLS.MAV_PLAN_EXECUTION }} skill for the execution loop, verific
 
 ## Phase 7: Documentation Review
 
-1. Run `git diff develop...HEAD --name-only` to identify all changed files.
+1. Run `git diff main...HEAD --name-only` to identify all changed files.
 2. Determine whether the changes affect behaviour that is covered by existing documentation in `docs/`:
    - Changed or added public APIs, components, services, or configuration
    - Altered data flows, integration points, or architectural patterns
    - Modified feature behaviour described in existing docs
 3. If documentation updates are needed, dispatch the **{{ AGENTS.AGENT_TECH_DOCS_WRITER }}** agent with:
    - Mode: **update**
-   - The diff (`git diff develop...HEAD`)
+   - The diff (`git diff main...HEAD`)
    - The list of affected doc files (or a note that new documentation is needed)
    - Instruction to update existing docs to reflect the changes — not to rewrite unrelated sections
 4. Review the agent's output. Verify that updates are accurate and scoped to the changes made.
@@ -117,6 +117,6 @@ Follow the {{ SKILLS.MAV_PLAN_EXECUTION }} skill for the execution loop, verific
 
 - **Only pause for user input** when blocked or when the issue is ambiguous. Do not ask for approval on design or tasks unless you are uncertain.
 - **Run verification** after each task and after all tasks. Do not declare success if checks fail.
-- **Never commit directly** to `main` or `develop`.
+- **Never commit directly** to `main`.
 - **Use conventional commits** that reference the issue number (e.g., `feat: add rubric export (#42)`).
 - **Always create a PR** at the end — this is the autonomous workflow, so deliver a complete result.

--- a/src/maverick/skills/do-task-solo/body.md.j2
+++ b/src/maverick/skills/do-task-solo/body.md.j2
@@ -122,7 +122,7 @@ Run Phase 3 as a subagent to keep the main context window clean for implementati
 ## Phase 4: Create Branch
 
 1. Derive the branch name from the task. Use the format `<type>/<task-id>-<short-desc>` (e.g., `feat/TASK-001-add-export`). Follow the {{ SKILLS.MAV_GIT_WORKFLOW }} skill for type prefixes.
-2. Create the branch from the project's integration branch (typically `develop`).
+2. Create the branch from the project's default branch (typically `main`).
 3. Commit the task artifacts (`task.md`, `solution-design.md`, `tasks.md`) so they are tracked in version control.
 4. Update `state.json`: set `branch` and `phase` to `branch`.
 
@@ -144,7 +144,7 @@ Follow the {{ SKILLS.MAV_PLAN_EXECUTION }} skill for the execution loop, verific
 
 ## Phase 6: Code Review
 
-1. Dispatch the {{ AGENTS.AGENT_CODE_REVIEWER }} agent with the task requirements (from `task.md`) and the diff (`git diff develop...HEAD`).
+1. Dispatch the {{ AGENTS.AGENT_CODE_REVIEWER }} agent with the task requirements (from `task.md`) and the diff (`git diff main...HEAD`).
 2. The reviewer performs two-stage review: spec compliance first, then code quality.
 3. If spec compliance fails, stop — fix the gaps before requesting re-review.
 4. Process code quality feedback per the {{ SKILLS.DO_PULLREQUEST_REVIEW }} skill:
@@ -159,14 +159,14 @@ Follow the {{ SKILLS.MAV_PLAN_EXECUTION }} skill for the execution loop, verific
 
 ## Phase 7: Documentation Review
 
-1. Run `git diff develop...HEAD --name-only` to identify all changed files.
+1. Run `git diff main...HEAD --name-only` to identify all changed files.
 2. Determine whether the changes affect behaviour that is covered by existing documentation in `docs/`:
    - Changed or added public APIs, components, services, or configuration
    - Altered data flows, integration points, or architectural patterns
    - Modified feature behaviour described in existing docs
 3. If documentation updates are needed, dispatch the **{{ AGENTS.AGENT_TECH_DOCS_WRITER }}** agent with:
    - Mode: **update**
-   - The diff (`git diff develop...HEAD`)
+   - The diff (`git diff main...HEAD`)
    - The list of affected doc files (or a note that new documentation is needed)
    - Instruction to update existing docs to reflect the changes — not to rewrite unrelated sections
 4. Review the agent's output. Verify that updates are accurate and scoped to the changes made.
@@ -244,7 +244,7 @@ When resuming work on a task (new session, after crash):
 
 - **Only pause for user input** when blocked or when the task is ambiguous. Do not ask for approval on design or tasks unless you are uncertain.
 - **Run verification** after each task and after all tasks. Do not declare success if checks fail.
-- **Never commit directly** to `main` or `develop`.
+- **Never commit directly** to `main`.
 - **Use conventional commits** that reference the task ID (e.g., `feat: add rubric export (TASK-001)`).
 - **Always create a PR** at the end — this is the autonomous workflow, so deliver a complete result.
 - **Commit task artifacts** (`task.md`, `solution-design.md`, `tasks.md`, `completion.md`) to version control so they are available for review and survive across sessions. Only `state.json` is gitignored.

--- a/src/maverick/skills/mav-bp-cicd/body.md.j2
+++ b/src/maverick/skills/mav-bp-cicd/body.md.j2
@@ -91,7 +91,7 @@ digraph envs {
 | Environment | Trigger | Approval |
 | ----------- | ------- | -------- |
 | Dev/Preview | Push to feature branch or PR | Automatic |
-| Staging | Merge to main/develop | Automatic |
+| Staging | Merge to main (or equivalent trunk) | Automatic |
 | Production | Promotion from staging | Manual approval required |
 
 ### Promotion Rules

--- a/src/maverick/skills/mav-bp-code-review/body.md.j2
+++ b/src/maverick/skills/mav-bp-code-review/body.md.j2
@@ -12,7 +12,7 @@ Ensure all code changes are reviewed before merging. Reviews catch defects, shar
 
 ## Mandatory Review Requirements
 
-- **At least one approval** before merging to any protected branch (`main`, `develop`, `release/*`)
+- **At least one approval** before merging to any protected branch (e.g., `main`)
 - **No self-approvals** — the author cannot approve their own pull request
 - **Stale approvals dismissed on new pushes** — if the author pushes new commits after approval, the approval is invalidated and a re-review is required
 - **All CI checks passing** — do not merge with failing lints, tests, or type checks

--- a/src/maverick/skills/mav-bp-source-control/body.md.j2
+++ b/src/maverick/skills/mav-bp-source-control/body.md.j2
@@ -132,7 +132,7 @@ For detailed branching strategy, commit message format, merge conflict handling,
 
 This skill covers:
 - Branch naming conventions (`<type>/<issue>-<desc>`)
-- Protected branches (`main`, `develop`)
+- Protected branch (`main`)
 - Conventional Commits format
 - Merge and rebase strategies
 - Branch cleanup after merge

--- a/src/maverick/skills/mav-git-workflow/body.md.j2
+++ b/src/maverick/skills/mav-git-workflow/body.md.j2
@@ -1,7 +1,7 @@
 
 # Git Workflow
 
-A simplified Gitflow strategy for all development work. This skill defines how branches, commits, and merges are managed.
+A trunk-based strategy for all development work. This skill defines how branches, commits, and merges are managed.
 
 ## Remote Repository Requirement
 
@@ -25,26 +25,27 @@ A project with no remote cannot use protected branches, pull requests, or CI/CD 
 ## Branch Strategy
 
 ```
-main (production — never touched directly)
-  └── develop (integration branch — never committed to directly)
-        ├── feat/42-add-export
-        ├── fix/57-login-crash
-        └── chore/63-update-deps
+main (trunk — the only long-lived branch; tagged at each release)
+  ├── feat/42-add-export
+  ├── fix/57-login-crash
+  ├── chore/63-update-deps
+  └── release/<version> (short-lived; exists only long enough to cut a release)
 ```
 
 ### Branch Roles
 
 | Branch | Purpose | Who commits | Protected |
 |---|---|---|---|
-| `main` | Production releases | Merge from `develop` only (human-gated) | Yes |
-| `develop` | Integration branch | Merge from feature/fix branches via PR only | Yes |
-| Feature/fix branches | Active development | Claude Code and developers | No |
+| `main` | Trunk — carries the current `-dev` version between releases; tagged at each release | Merge from feature/fix/release branches via PR only | Yes |
+| Feature/fix/chore branches | Active development | Claude Code and developers | No |
+| `release/<version>` | Short-lived release prep — bumps version, updates CHANGELOG | Created by `scripts/release.sh` | No |
 
 ### Rules
 
-- **Never commit directly to `main` or `develop`**. All changes reach these branches via pull request.
-- **All work happens on feature/fix branches** created from `develop`.
+- **Never commit directly to `main`**. All changes reach `main` via pull request.
+- **All work happens on short-lived branches** created from `main` and PR'd back to `main`.
 - **One branch per issue/task**. Do not combine unrelated work on a single branch.
+- **Release branches are ephemeral**. Created by the release script, deleted after the release PR merges.
 
 ## Branch Naming
 
@@ -95,18 +96,14 @@ digraph branch {
 
 ### Identify the Base Branch
 
-The base branch is typically `develop`. To confirm, check:
+The base branch is the repository's default branch — typically `main`. To confirm:
 
 ```bash
-# Check default branch
 gh repo view --json defaultBranchRef -q '.defaultBranchRef.name'
-
-# Check if develop exists
-git branch -r | grep -q 'origin/develop'
 ```
 
-- If `develop` exists — branch from `develop`
-- If only `main` exists — branch from `main`
+- If the default branch is `main` — branch from `main`
+- If the project still uses a legacy integration branch (e.g., `develop`) — branch from that and ask the user whether to adopt trunk-based
 - If uncertain — ask the user
 
 ### Create the Branch
@@ -244,11 +241,11 @@ git push origin --delete $BRANCH_NAME
 For cleaning up stale local branches that have been merged:
 
 ```bash
-# List merged branches (excluding main and develop)
-git branch --merged $BASE_BRANCH | grep -vE '^\*|main|develop'
+# List merged branches (excluding main)
+git branch --merged $BASE_BRANCH | grep -vE '^\*|main'
 
 # Delete them
-git branch --merged $BASE_BRANCH | grep -vE '^\*|main|develop' | xargs git branch -d
+git branch --merged $BASE_BRANCH | grep -vE '^\*|main' | xargs git branch -d
 ```
 
 ## Pulling Updates

--- a/uv.lock
+++ b/uv.lock
@@ -168,7 +168,7 @@ wheels = [
 
 [[package]]
 name = "maverick"
-version = "0.5.7"
+version = "0.5.8.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

Drops the persistent integration branch and moves the project to trunk-based development. `main` becomes the only long-lived branch and carries the current `-dev` version between releases.

## Why

The dual-branch + squash-merge pattern has a structural bug: squash merges don't preserve multi-parent history, so after each release the two long-lived branches share only an ancient common ancestor. Every release-finalize CI step then rediscovered tree-wide diffs and produced ~50 false conflicts. We manually resolved this three times in a row (PRs #6, #7, #8) for the 0.5.7 release, which is a strong signal the pattern is wrong, not the operator.

Trunk-based removes the sync step entirely and eliminates the class of problem.

## What changed

- **`CLAUDE.md`** — rewrote the git-workflow key convention
- **`src/maverick/skills/mav-git-workflow/body.md.j2`** — trunk-based branch strategy, base branch is `main`, release branches are short-lived
- **`src/maverick/skills/{do-issue-solo,do-issue-guided,do-task-solo}/body.md.j2`** — diff references now use `main`; branch creation uses `main`
- **`src/maverick/skills/{mav-bp-source-control,mav-bp-code-review,mav-bp-cicd}/body.md.j2`** — protected branch now singular (`main`)
- **`scripts/release.sh`** — runs from `main`, cuts short-lived `release/<version>` branches
- **`.github/workflows/release-finalize.yml`** — drops the failing integration-sync step; replaces it with an auto-PR that bumps `main` to the next `-dev` cycle (requires `pull-requests: write` permission)
- **`.github/workflows/unit-tests.yml`** — triggers on push/PR to `main`
- **`docs/{git-workflow,maverick-build,cicd,comprehensive-testing}.md`** — updated branch-strategy and release-flow sections
- Version bumped to `0.5.8-dev` on `main`; regenerated `skills/`, `agents/`

## Follow-up after merge

1. Delete the legacy remote integration branch via the GitHub UI or CLI
2. In GitHub branch-protection settings, remove the protection rule for the legacy branch (if configured)
3. Next release (`0.5.8`) will be the first one under the new flow — a useful smoke test of the updated `release.sh` + `release-finalize.yml`

## Test plan

- [ ] Review the diff — largest by line count is regenerated build output
- [ ] Confirm `pyproject.toml`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.cursor-plugin/cursor.plugin.json` all read `0.5.8-dev`
- [ ] Confirm `.github/workflows/unit-tests.yml` triggers on `main`
- [ ] (At next release) Verify `release-finalize.yml` opens the auto-PR successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)