### PR TITLE
feat: add stable branch for end-user installs

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -76,6 +76,15 @@ jobs:
             --notes-file /tmp/release-notes.md \
             --target main
 
+      - name: Fast-forward stable branch to the new release
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          # `stable` is the branch that end users clone to install a
+          # released version. It is always fast-forwarded to the most
+          # recent tag commit — never moves during -dev cycles.
+          git push origin "refs/tags/${TAG}:refs/heads/stable"
+
       - name: Open PR to bump main to next -dev cycle
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,12 @@ The registry (`src/maverick/registry.py`) discovers all `config.py` files, rende
 
 ## Key Conventions
 
-- **Git workflow**: Trunk-based. `main` is the only long-lived branch — it carries the current `-dev` version between releases and is tagged at each release. No direct commits or pushes to `main` — all changes land via squash-merged PRs. Feature branches are short-lived and branch from `main`: `<type>/<issue>-<desc>` (e.g., `feat/42-add-export`). Release branches (`release/<version>`) are short-lived and exist only long enough to cut a release. Conventional Commits with issue refs: `feat: add export button (#42)`.
+- **Git workflow**: Trunk-based with a stable tracking branch.
+  - `main` is where development happens: it carries the current `-dev` version between releases, and is tagged `vX.Y.Z` at each release. No direct commits or pushes to `main` — all changes land via squash-merged PRs.
+  - `stable` is the branch end users install from (it is GitHub's default branch, so a bare `git clone` resolves to it). It is automatically fast-forwarded to the latest release tag by `release-finalize.yml` and never moves during `-dev` cycles. No human ever pushes to `stable` — it is CI-managed.
+  - Feature branches are short-lived, branch from `main`, and PR back to `main`: `<type>/<issue>-<desc>` (e.g., `feat/42-add-export`). Release branches (`release/<version>`) are short-lived and exist only long enough to cut a release.
+  - Conventional Commits with issue refs: `feat: add export button (#42)`.
+  - When creating PRs programmatically (e.g., via `gh pr create`), always pass `--base main` explicitly, because the repository's default branch is `stable`.
 - **Scope boundaries** (`skills/mav-scope-boundaries/`): Four hard limits — no infrastructure changes without explicit issue authorization, no auth/permissions changes without human review, no destructive git ops without session consent, never touch production systems.
 - **Python**: 3.10+, `uv` package manager, `boto3` for AWS, `argparse` CLI framework.
 - **Skills format**: Source is `config.py` (frontmatter fields) + `body.md.j2` (Jinja2 template). Both skills and agents use `{{ SKILLS.CONSTANT }}` / `{{ AGENTS.CONSTANT }}` to reference other skills/agents. Build output is generated YAML frontmatter + rendered markdown.

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -59,9 +59,10 @@ gitGraph
 
 ### Long-lived branches
 
-| Branch | Purpose                                                                                               | Direct commits allowed |
-| ------ | ----------------------------------------------------------------------------------------------------- | ---------------------- |
-| `main` | Trunk. Carries the current `-dev` version between releases. Tagged `vX.Y.Z` at each release.          | Never                  |
+| Branch   | Purpose                                                                                                                                                     | Direct commits allowed |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `main`   | Trunk. Carries the current `-dev` version between releases. Tagged `vX.Y.Z` at each release.                                                                | Never                  |
+| `stable` | What end users install. Automatically fast-forwarded to the latest release tag by `release-finalize.yml`. Never moves during `-dev` cycles. CI-managed.     | Never (CI only)        |
 
 ### Short-lived branches
 

--- a/docs/maverick-build.md
+++ b/docs/maverick-build.md
@@ -114,4 +114,11 @@ After the release PR squash-merges into `main`:
 
 1. Tags the merge commit `vX.Y.Z`
 2. Creates a GitHub Release with notes extracted from `CHANGELOG.md`
-3. Opens a follow-up PR (`chore/begin-X.Y.(Z+1)-dev-cycle`) that bumps `main` back to the next `-dev` version
+3. Fast-forwards the `stable` branch to the new tag commit (this is what end users clone)
+4. Opens a follow-up PR (`chore/begin-X.Y.(Z+1)-dev-cycle`) that bumps `main` back to the next `-dev` version
+
+### The `stable` branch
+
+`stable` is the branch end users install from — a bare `git clone git@github.com:thermiteau/maverick.git` resolves to it because `stable` is GitHub's default branch. It always points at the most recent release tag. Between releases `main` moves forward with feature PRs, but `stable` stays frozen on the last tagged commit, so consumers who pull updates only see new code once an actual release happens.
+
+No human pushes to `stable`. The only writer is the `Fast-forward stable branch to the new release` step in `release-finalize.yml`, which runs after tagging.

--- a/skills/mav-git-workflow/SKILL.md
+++ b/skills/mav-git-workflow/SKILL.md
@@ -30,7 +30,8 @@ A project with no remote cannot use protected branches, pull requests, or CI/CD 
 ## Branch Strategy
 
 ```
-main (trunk — the only long-lived branch; tagged at each release)
+stable (what end users clone; CI-managed; fast-forwarded to the latest release tag)
+main (trunk — carries -dev between releases; tagged at each release)
   ├── feat/42-add-export
   ├── fix/57-login-crash
   ├── chore/63-update-deps
@@ -41,16 +42,18 @@ main (trunk — the only long-lived branch; tagged at each release)
 
 | Branch | Purpose | Who commits | Protected |
 |---|---|---|---|
+| `stable` | What end users install — always points at the most recent release tag | Fast-forwarded by `release-finalize.yml` only; never by humans | Yes (CI-only) |
 | `main` | Trunk — carries the current `-dev` version between releases; tagged at each release | Merge from feature/fix/release branches via PR only | Yes |
 | Feature/fix/chore branches | Active development | Claude Code and developers | No |
 | `release/<version>` | Short-lived release prep — bumps version, updates CHANGELOG | Created by `scripts/release.sh` | No |
 
 ### Rules
 
-- **Never commit directly to `main`**. All changes reach `main` via pull request.
+- **Never commit directly to `main` or `stable`**. All changes reach `main` via pull request; `stable` is moved exclusively by CI.
 - **All work happens on short-lived branches** created from `main` and PR'd back to `main`.
 - **One branch per issue/task**. Do not combine unrelated work on a single branch.
 - **Release branches are ephemeral**. Created by the release script, deleted after the release PR merges.
+- **Always pass `--base main`** explicitly when creating PRs via `gh pr create` — the repository's default branch is `stable`, so omitting `--base` would target the wrong branch.
 
 ## Branch Naming
 

--- a/skills/mav-github-issue-workflow/SKILL.md
+++ b/skills/mav-github-issue-workflow/SKILL.md
@@ -249,7 +249,7 @@ BRANCH=$(jq -r '.branch' .claude/issue-state.json)
 
 git push -u origin $BRANCH
 
-gh pr create --title "<concise title>" --body "$(cat <<PR_EOF
+gh pr create --base main --title "<concise title>" --body "$(cat <<PR_EOF
 ## Summary
 <1-3 bullet points>
 

--- a/src/maverick/skills/mav-git-workflow/body.md.j2
+++ b/src/maverick/skills/mav-git-workflow/body.md.j2
@@ -25,7 +25,8 @@ A project with no remote cannot use protected branches, pull requests, or CI/CD 
 ## Branch Strategy
 
 ```
-main (trunk — the only long-lived branch; tagged at each release)
+stable (what end users clone; CI-managed; fast-forwarded to the latest release tag)
+main (trunk — carries -dev between releases; tagged at each release)
   ├── feat/42-add-export
   ├── fix/57-login-crash
   ├── chore/63-update-deps
@@ -36,16 +37,18 @@ main (trunk — the only long-lived branch; tagged at each release)
 
 | Branch | Purpose | Who commits | Protected |
 |---|---|---|---|
+| `stable` | What end users install — always points at the most recent release tag | Fast-forwarded by `release-finalize.yml` only; never by humans | Yes (CI-only) |
 | `main` | Trunk — carries the current `-dev` version between releases; tagged at each release | Merge from feature/fix/release branches via PR only | Yes |
 | Feature/fix/chore branches | Active development | Claude Code and developers | No |
 | `release/<version>` | Short-lived release prep — bumps version, updates CHANGELOG | Created by `scripts/release.sh` | No |
 
 ### Rules
 
-- **Never commit directly to `main`**. All changes reach `main` via pull request.
+- **Never commit directly to `main` or `stable`**. All changes reach `main` via pull request; `stable` is moved exclusively by CI.
 - **All work happens on short-lived branches** created from `main` and PR'd back to `main`.
 - **One branch per issue/task**. Do not combine unrelated work on a single branch.
 - **Release branches are ephemeral**. Created by the release script, deleted after the release PR merges.
+- **Always pass `--base main`** explicitly when creating PRs via `gh pr create` — the repository's default branch is `stable`, so omitting `--base` would target the wrong branch.
 
 ## Branch Naming
 

--- a/src/maverick/skills/mav-github-issue-workflow/body.md.j2
+++ b/src/maverick/skills/mav-github-issue-workflow/body.md.j2
@@ -244,7 +244,7 @@ BRANCH=$(jq -r '.branch' .claude/issue-state.json)
 
 git push -u origin $BRANCH
 
-gh pr create --title "<concise title>" --body "$(cat <<PR_EOF
+gh pr create --base main --title "<concise title>" --body "$(cat <<PR_EOF
 ## Summary
 <1-3 bullet points>
 


### PR DESCRIPTION
## Summary

Adds a CI-managed `stable` branch that is fast-forwarded to the latest release tag after each release. Intended to become the repository's default branch so that bare-URL installs resolve to a released version.

## Why

Under trunk-based, `main` carries `-dev` between releases. A bare `git clone git@github.com:thermiteau/maverick.git` currently resolves to whatever in-progress `-dev` state `main` is in, which is not what end users expect. Making `stable` the default branch gives them a tagged release; `main` remains the development trunk.

## What changed

- **`.github/workflows/release-finalize.yml`** — adds a `Fast-forward stable branch to the new release` step after tagging and GitHub Release creation. The step pushes the new tag commit to `refs/heads/stable`, creating the branch on first run and fast-forwarding on each subsequent release.
- **`CLAUDE.md`** — documents the `stable`/`main` split; notes the default-branch flip; adds the `--base main` rule for programmatic PR creation.
- **`docs/git-workflow.md`** — adds `stable` to the long-lived-branch table.
- **`docs/maverick-build.md`** — adds the stable-branch step to the release CI flow and explains the branch end-to-end.
- **`src/maverick/skills/mav-git-workflow/body.md.j2`** — adds `stable` to the branch-strategy diagram and roles table; adds the `--base main` rule.
- **`src/maverick/skills/mav-github-issue-workflow/body.md.j2`** — `gh pr create` now passes `--base main` explicitly.

## Follow-up after merge (outside git — admin actions)

1. Push the `stable` branch from the existing tag: `git push origin v0.5.7:refs/heads/stable`
2. Flip GitHub's default branch: `main` → `stable` (Settings → Branches, or `gh repo edit --default-branch stable`)
3. Add branch protection to `stable`: no direct pushes; only the `github-actions[bot]` can push
4. Confirm PR templates and workflow triggers still point at `main` (not the new default)

## Test plan

- [ ] Review the diff — it is small
- [ ] After merge, verify step 1 creates `origin/stable` at the `v0.5.7` commit
- [ ] After merge and default-branch flip, confirm `git clone` into a scratch dir resolves to the `stable` branch
- [ ] Next release (`0.5.8`) will be the first smoke test of the fast-forward step

🤖 Generated with [Claude Code](https://claude.com/claude-code)