### PR TITLE
fix: fast-forward stable via REST API in release-finalize

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -78,12 +78,24 @@ jobs:
 
       - name: Fast-forward stable branch to the new release
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
           TAG: ${{ steps.version.outputs.tag }}
         run: |
           # `stable` is the branch that end users clone to install a
           # released version. It is always fast-forwarded to the most
           # recent tag commit — never moves during -dev cycles.
-          git push origin "refs/tags/${TAG}:refs/heads/stable"
+          #
+          # Updated via the REST API rather than `git push` because
+          # the runner's git transport hits a `[remote rejected]` even
+          # when named branch protection / rulesets are disabled,
+          # while the REST endpoint accepts the same fast-forward
+          # update with the same auth. Diagnosed during the 1.0.0
+          # and 1.0.1 releases (see commit history for context).
+          COMMIT_SHA=$(git rev-parse "${TAG}^{commit}")
+          gh api -X PATCH \
+            "repos/${REPO}/git/refs/heads/stable" \
+            -f sha="$COMMIT_SHA"
 
       - name: Open PR to bump main to next -dev cycle
         env:


### PR DESCRIPTION
## Why

The `Fast-forward stable branch to the new release` step in `release-finalize.yml` has failed on **every** release so far (1.0.0 and 1.0.1) with `[remote rejected] (failed)` from `git push origin "refs/tags/${TAG}:refs/heads/stable"`.

Diagnostic findings during the 1.0.1 release:
- Named branch protection on `stable`: not configured (`gh api ... /branches/stable/protection` returns 404)
- Repository rulesets affecting `stable`: present but `enforcement: disabled`
- The exact same fast-forward update succeeds via `gh api -X PATCH .../git/refs/heads/stable` with identical auth.

So whatever blocks the runner's `git push` doesn't apply to the REST endpoint. Switching the step to use REST removes the failure mode regardless of root cause.

## What

Replaces:

```yaml
git push origin "refs/tags/${TAG}:refs/heads/stable"
```

with:

```yaml
COMMIT_SHA=$(git rev-parse "${TAG}^{commit}")
gh api -X PATCH "repos/${REPO}/git/refs/heads/stable" -f sha="$COMMIT_SHA"
```

Plus moves `github.repository` and the tag into the step's `env:` block (per GitHub's workflow-injection guidance — the security_reminder hook flags this on every workflow edit).

## Properties preserved

- **Fast-forward semantics.** REST `PATCH` on a ref returns `422 Unprocessable Entity` if the update isn't a fast-forward (unless `force: true` is passed, which we don't). Same safety as `git push` without `--force`.
- **Auth.** Uses the workflow's existing `GITHUB_TOKEN` via the `gh` CLI's standard auth path. No new secret.
- **No new dependency.** `gh` is pre-installed on GitHub-hosted runners.

## Verification

- Locally proven: identical REST call succeeded on `v1.0.0` and `v1.0.1` stable updates after the workflow's push step failed in both cases. Stable is currently at `c595665...` (the v1.0.1 commit) thanks to that REST call.
- This PR doesn't alter behaviour for any subsequent step — the rest of `release-finalize.yml` is untouched.

## Test plan

- [ ] CI green on the PR
- [ ] Next release (1.0.2 or beyond) — confirm `release-finalize` completes end-to-end without manual intervention