### PR TITLE
fix: release.sh -dev suffix off-by-one for patch bump

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,6 +16,16 @@ set -euo pipefail
 #
 # Usage: ./scripts/release.sh [major|minor|patch]
 # Default: patch
+#
+# Version semantics:
+#   - "X.Y.Z-dev" means "in development for the X.Y.Z release". The base is
+#     the target version. `release.sh patch` from "X.Y.Z-dev" produces "X.Y.Z"
+#     (graduates the dev cycle); minor/major from a -dev version skip the
+#     in-flight patch (e.g. patch from 1.0.2-dev -> 1.0.2 but minor -> 1.1.0).
+#   - "X.Y.Z" with no suffix means the previous release was X.Y.Z. Patch then
+#     increments (e.g. patch from 1.0.2 -> 1.0.3).
+#   - The release-finalize workflow always bumps to "X.Y.(Z+1)-dev" after a
+#     release tag, so most invocations will be from a -dev base.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -69,11 +79,24 @@ CURRENT_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 BASE_VERSION="${CURRENT_VERSION%%-*}"
 IFS='.' read -r V_MAJOR V_MINOR V_PATCH <<< "$BASE_VERSION"
 
-case "$BUMP_TYPE" in
-  major) V_MAJOR=$((V_MAJOR + 1)); V_MINOR=0; V_PATCH=0 ;;
-  minor) V_MINOR=$((V_MINOR + 1)); V_PATCH=0 ;;
-  patch) V_PATCH=$((V_PATCH + 1)) ;;
-esac
+# A "-dev" suffix means "in development for $BASE_VERSION" — the base is the
+# target version. Plain "X.Y.Z" with no suffix means the previous release was
+# X.Y.Z and we want to bump from there. Treat the two cases differently for
+# patch (only); minor and major always increment regardless because skipping
+# the in-flight patch is the right behaviour for a major/minor cut.
+if [[ "$CURRENT_VERSION" == *-dev ]]; then
+  case "$BUMP_TYPE" in
+    major) V_MAJOR=$((V_MAJOR + 1)); V_MINOR=0; V_PATCH=0 ;;
+    minor) V_MINOR=$((V_MINOR + 1)); V_PATCH=0 ;;
+    patch) ;; # no-op: -dev base is already the target patch
+  esac
+else
+  case "$BUMP_TYPE" in
+    major) V_MAJOR=$((V_MAJOR + 1)); V_MINOR=0; V_PATCH=0 ;;
+    minor) V_MINOR=$((V_MINOR + 1)); V_PATCH=0 ;;
+    patch) V_PATCH=$((V_PATCH + 1)) ;;
+  esac
+fi
 
 NEW_VERSION="${V_MAJOR}.${V_MINOR}.${V_PATCH}"
 NEW_TAG="v${NEW_VERSION}"


### PR DESCRIPTION
## Why

Running `./scripts/release.sh patch` from a `-dev` version produced the next-next patch instead of the in-development target. Concretely: from `1.0.2-dev`, the script produced `1.0.3` because it stripped `-dev` (leaving `1.0.2`) then unconditionally incremented patch.

This bit us during the 1.0.1 release — the script would have cut `1.0.2` instead of `1.0.1`, so I hand-rolled `release/1.0.1` instead of using the script.

The convention this project uses (per `release-finalize.yml`) is that a `-dev` suffix means "in development for the X.Y.Z release" — the base is the target. So `patch` from `1.0.2-dev` should produce `1.0.2`, graduating the dev cycle to release.

## Fix

Detect the `-dev` suffix and skip the patch increment for that case only. Minor and major still increment in both cases because cutting a minor/major from a `-dev` cycle correctly skips the in-flight patch (e.g. minor from `1.0.2-dev` → `1.1.0` is the right behaviour — you're abandoning the in-flight patch in favour of a new minor).

Header docstring expanded to spell out the version semantics so future readers don't need to reverse-engineer the convention.

## Truth table after the fix

| From | Bump | Result | Notes |
| --- | --- | --- | --- |
| `1.0.2-dev` | `patch` | `1.0.2` | graduate dev to release (was `1.0.3` — the bug) |
| `1.0.2-dev` | `minor` | `1.1.0` | skip in-flight patch |
| `1.0.2-dev` | `major` | `2.0.0` | |
| `1.0.2` | `patch` | `1.0.3` | previous release was `1.0.2` |
| `1.0.2` | `minor` | `1.1.0` | |
| `1.0.2` | `major` | `2.0.0` | |

Only the first row's behaviour changes; everything else is preserved.

## Verification

Sourced the bump logic in isolation against nine cases (both `-dev` and stable bases, plus edge versions like `0.0.1-dev` and `10.20.30-dev`). All nine match expected outputs. `bash -n` passes; would run `shellcheck` but it's not installed locally.

## Test plan

- [ ] CI green
- [ ] Reviewer confirms the truth table matches the project's intended semantics
- [ ] Next release uses the script directly without manual workarounds