### PR TITLE
chore: begin 1.0.3-dev cycle

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,12 +5,12 @@
     "name": "David Cheal",
     "email": "david.cheal@thermite.au"
   },
-  "version": "1.0.2",
+  "version": "1.0.3-dev",
   "plugins": [
     {
       "name": "maverick",
       "description": "Skills, Agents, and Hooks for autonomous AI development. Claude Code, Cursor IDE, Codex.",
-      "version": "1.0.2",
+      "version": "1.0.3-dev",
       "source": "./",
       "author": {
         "name": "David Cheal",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "maverick",
   "description": "Autonomous AI development skills, agents, and hooks for Claude Code",
-  "version": "1.0.2",
+  "version": "1.0.3-dev",
   "author": {
     "name": "David Cheal",
     "email": "david.cheal@thermite.au"

--- a/.cursor-plugin/cursor.plugin.json
+++ b/.cursor-plugin/cursor.plugin.json
@@ -2,7 +2,7 @@
   "name": "maverick",
   "displayName": "Maverick",
   "description": "Autonomous AI development skills, agents, and hooks for Claude Code",
-  "version": "1.0.2",
+  "version": "1.0.3-dev",
   "author": {
     "name": "David Cheal",
     "email": "david.cheal@thermite.au"

--- a/agents/agent-code-reviewer.md
+++ b/agents/agent-code-reviewer.md
@@ -176,4 +176,4 @@ comment so the human knows what to look at first]
 - **If in doubt, FAIL.** A conservative eject is recoverable via human
   review; a lenient PASS merges broken code.
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/agents/agent-github-issue-planner.md
+++ b/agents/agent-github-issue-planner.md
@@ -82,4 +82,4 @@ checklist | sub-issues
 - **Scope boundaries** — follow the mav-scope-boundaries skill. Flag any tasks that touch infrastructure, auth, or destructive operations.
 - **Durable output** — always post the tasks comment and update the state file before returning, so work is not lost if the caller's session crashes.
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/agents/agent-issue-analyst.md
+++ b/agents/agent-issue-analyst.md
@@ -74,4 +74,4 @@ Return a structured message containing:
 - **Right-sized design** — scale design depth to the task per the mav-create-solution-design skill's sizing table.
 - **Durable output** — always post the design comment and update the state file before returning, so work is not lost if the caller's session crashes.
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/agents/agent-maverick.md
+++ b/agents/agent-maverick.md
@@ -53,4 +53,4 @@ Return a structured message containing:
 - **Follow skill instructions exactly** — do not improvise or add extra steps
 - **Report clearly** — surface successes, failures, and warnings so the caller can act on them
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/agents/agent-session-reviewer.md
+++ b/agents/agent-session-reviewer.md
@@ -88,4 +88,4 @@ Return your findings as structured markdown:
 - **Consider context** — prototyping code has different standards than production code
 - **Focus on actionable findings** — each finding should suggest what to do differently
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/agents/agent-tech-docs-writer.md
+++ b/agents/agent-tech-docs-writer.md
@@ -29,4 +29,4 @@ You are a Senior Technical Documentation Writer. Your role is to produce clear, 
 - **Right-sized** — scale documentation depth to the topic's complexity
 - **Project-agnostic** — do not assume any specific technology stack; discover it from the codebase
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maverick"
-version = "1.0.2"
+version = "1.0.3-dev"
 description = "Claude Code plugin that enables autonomous AI development while maintaining best practices"
 requires-python = ">=3.10"
 dependencies = [

--- a/skills/do-adopt/SKILL.md
+++ b/skills/do-adopt/SKILL.md
@@ -109,4 +109,4 @@ Follow the mav-git-workflow skill for commit conventions. Do not push — the us
 - **No branch creation** — commit directly to the current branch. The user is expected to be on an appropriate branch.
 - **One commit per topic** — separate commits make it easy to review or revert individual adoptions
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/do-cybersecurity-review/SKILL.md
+++ b/skills/do-cybersecurity-review/SKILL.md
@@ -245,4 +245,4 @@ Update mode produces transient findings, not a snapshot of the whole codebase. W
 - **Defer to mav-bp-application-security** for what "good" looks like in each category. This skill is the audit; that one is the standard.
 - **Follow mav-scope-boundaries** — do not run anything that would modify production systems, change auth/permissions, or take destructive action.
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/do-docs/SKILL.md
+++ b/skills/do-docs/SKILL.md
@@ -180,4 +180,4 @@ Run the do-tech-docs validation checklist against every document changed or crea
 - In **update** mode, scope narrowly to the diff — do not refactor surrounding documentation
 - Verify every factual claim against the source code before writing it
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/do-epic/SKILL.md
+++ b/skills/do-epic/SKILL.md
@@ -241,4 +241,4 @@ state.
 - **Never auto-close an epic with ejected stories.** Those belong to the
   human.
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/do-init/SKILL.md
+++ b/skills/do-init/SKILL.md
@@ -60,4 +60,4 @@ Print a final summary to the user:
 
 The integration checklist gives the user (and any future Maverick session) a clear view of what's been completed and what's still pending.
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/do-install/SKILL.md
+++ b/skills/do-install/SKILL.md
@@ -33,4 +33,4 @@ Dispatch the **maverick** agent with task `install` and any user-provided argume
 
 4. **Report.** Return a structured result: install path, whether the settings file was modified or already had the permission entry, and any PATH warnings.
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/do-issue-guided/SKILL.md
+++ b/skills/do-issue-guided/SKILL.md
@@ -169,4 +169,4 @@ This phase **always runs** before push. Any changed code AND any code that could
 - **Use conventional commits** that reference the issue number (e.g., `feat: add rubric export (#42)`).
 - **Always create a PR** at the end — deliver a complete result.
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/do-issue-solo/SKILL.md
+++ b/skills/do-issue-solo/SKILL.md
@@ -297,4 +297,4 @@ next step is eject-to-human, not iterate.
 - **Never remove a `blocked-by:#N` label from inside the workflow.** Only a
   human may clear a block.
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/do-maverick-alignment/SKILL.md
+++ b/skills/do-maverick-alignment/SKILL.md
@@ -399,4 +399,4 @@ uv run maverick integration set alignment true
 This commits the milestone into `.maverick/config.json` — the file is in git
 so the state is durable across machines and contributors.
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/do-pullrequest-review/SKILL.md
+++ b/skills/do-pullrequest-review/SKILL.md
@@ -154,4 +154,4 @@ When receiving review during a do-issue workflow:
 4. If the review came from the agent-code-reviewer agent and had spec compliance failures, request a re-review after fixing
 5. Update the plan comment on the issue if fixes changed the implementation approach
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/do-recommend/SKILL.md
+++ b/skills/do-recommend/SKILL.md
@@ -127,4 +127,4 @@ To adopt the recommended option, run `/maverick:do-adopt <topic>`.
 - **Frontmatter required** — name, title, generated, status fields mandatory
 - **Write directly** — no user approval needed, file is version-controlled
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/do-tech-docs/SKILL.md
+++ b/skills/do-tech-docs/SKILL.md
@@ -191,4 +191,4 @@ Before finalising documentation:
 - [ ] All public exports from documented modules are covered (check for multiple exports per file)
 - [ ] Numbering, terminology, and facts are consistent across all documents in the set
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/do-upskill/SKILL.md
+++ b/skills/do-upskill/SKILL.md
@@ -370,4 +370,4 @@ When no scan hints are provided by the calling skill, use these defaults:
 - **grep**: `dotenv|process\.env|os\.environ|docker-compose|devcontainer|CONTRIBUTING`
 - **files**: `.env.example`, `.env.sample`, `.env.template`, `.devcontainer/**`, `docker-compose*.yml`, `Vagrantfile`, `flake.nix`, `shell.nix`, `CONTRIBUTING.md`
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-block-propagation/SKILL.md
+++ b/skills/mav-block-propagation/SKILL.md
@@ -130,4 +130,4 @@ human-removed label will let the story run on the next wave-selection pass.
 - **Idempotent throughout.** Every step in the walk checks current state
   before writing. Re-running the walk end-to-end is safe.
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-accessibility/SKILL.md
+++ b/skills/mav-bp-accessibility/SKILL.md
@@ -308,4 +308,4 @@ When reviewing code for user-facing interfaces, flag these patterns:
 | Custom widget without keyboard handling | Inoperable for keyboard users | Implement full keyboard interaction pattern |
 | Error shown only by colour change | Screen readers cannot detect colour | Add text message and `aria-describedby` |
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-alerting/SKILL.md
+++ b/skills/mav-bp-alerting/SKILL.md
@@ -142,4 +142,4 @@ Alerting and logging are complementary but separate concerns:
 | Alert but no log                                 | Missing investigation trail | Always log before alerting                 |
 | Frontend calling alerting service directly       | Security risk               | Route through backend API                  |
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-api-design/SKILL.md
+++ b/skills/mav-bp-api-design/SKILL.md
@@ -269,4 +269,4 @@ When reviewing code, flag these patterns:
 | No idempotency on payment/financial endpoints      | Duplicate processing risk          | Require idempotency keys                               |
 | API docs maintained separately from code           | Documentation drift                | Generate docs from source (OpenAPI, introspection)     |
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-application-security/SKILL.md
+++ b/skills/mav-bp-application-security/SKILL.md
@@ -269,4 +269,4 @@ Always prefer the secure option unless there is a documented, reviewed reason to
 | Deserialisation of untrusted data                        | Remote code execution        | Avoid deserialising untrusted input; use safe formats (JSON) |
 | Missing `HttpOnly`/`Secure` flags on session cookies     | Session hijacking            | Set `HttpOnly`, `Secure`, and `SameSite` on all auth cookies |
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-cicd-azure/SKILL.md
+++ b/skills/mav-bp-cicd-azure/SKILL.md
@@ -134,4 +134,4 @@ digraph ci {
 - Fix CI failures before declaring work complete
 - Report CI failures clearly if you cannot fix them
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-cicd-bitbucket/SKILL.md
+++ b/skills/mav-bp-cicd-bitbucket/SKILL.md
@@ -98,4 +98,4 @@ digraph ci {
 - Fix CI failures before declaring work complete
 - Report CI failures clearly if you cannot fix them
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-cicd-github/SKILL.md
+++ b/skills/mav-bp-cicd-github/SKILL.md
@@ -89,4 +89,4 @@ digraph ci {
 - Fix CI failures before declaring work complete
 - Report CI failures clearly if you cannot fix them
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-cicd-gitlab/SKILL.md
+++ b/skills/mav-bp-cicd-gitlab/SKILL.md
@@ -126,4 +126,4 @@ digraph ci {
 - Fix CI failures before declaring work complete
 - Report CI failures clearly if you cannot fix them
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-cicd/SKILL.md
+++ b/skills/mav-bp-cicd/SKILL.md
@@ -209,4 +209,4 @@ digraph lookup {
 | Pipeline takes >15 minutes | Developer productivity drain | Profile and optimise, add caching |
 | Unpinned action/image versions | Non-reproducible builds | Pin to specific versions/SHAs |
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-code-review/SKILL.md
+++ b/skills/mav-bp-code-review/SKILL.md
@@ -118,4 +118,4 @@ Human review time is expensive. Do not spend it on issues that automated tools h
 | Self-approval on protected branch                  | Missing review gate                | Configure branch protection to disallow self-approval |
 | Skipping CI to merge faster                        | Bypassing quality gates            | CI must pass; fix failures, do not skip them         |
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-database-management/SKILL.md
+++ b/skills/mav-bp-database-management/SKILL.md
@@ -202,4 +202,4 @@ When reviewing code, flag these patterns:
 | `DROP TABLE` or `DROP COLUMN` without staged rollout| Breaks running application        | Stage the change: remove code references first         |
 | No transaction wrapping for multi-step migration   | Partial application on failure     | Wrap in transaction where the database supports it     |
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-dependency-management/SKILL.md
+++ b/skills/mav-bp-dependency-management/SKILL.md
@@ -244,4 +244,4 @@ digraph lookup {
 | Large transitive dependency addition | Unexpected supply chain expansion | Investigate and consider lighter alternatives |
 | `--force` or `--legacy-peer-deps` in install commands | Masking resolution conflicts | Fix the underlying version conflict |
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-documentation/SKILL.md
+++ b/skills/mav-bp-documentation/SKILL.md
@@ -142,4 +142,4 @@ When reviewing code or auditing a project, flag these patterns:
 | Inline comments restating obvious code           | Noise, not documentation     | Remove; write higher-level docs instead                  |
 | Documentation in external wiki only              | Not versioned with code      | Move to repo `docs/` directory                           |
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-environment-management/SKILL.md
+++ b/skills/mav-bp-environment-management/SKILL.md
@@ -215,4 +215,4 @@ When both skills apply (e.g., a Docker Compose file used in both local dev and C
 | Database engine differs between dev and production | Environment parity violation | Use the same engine locally via Docker |
 | No health checks in Docker Compose services | Startup race conditions | Add health checks and depends_on with condition |
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-error-handling/SKILL.md
+++ b/skills/mav-bp-error-handling/SKILL.md
@@ -299,4 +299,4 @@ Error handling, logging, and alerting are complementary:
 | No error boundary around UI sections                | Single component crashes page  | Wrap sections in error boundaries with fallback UI |
 | Generic error message for all failures              | Poor user experience           | Distinguish client vs server errors                |
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-infrastructure-as-code/SKILL.md
+++ b/skills/mav-bp-infrastructure-as-code/SKILL.md
@@ -164,4 +164,4 @@ When IaC is not possible -- because the platform does not support it, the tool l
 | Destructive changes auto-applied               | Accidental data loss           | Require human approval for destroy/replace actions   |
 | Mixed IaC tools for the same resource layer    | Conflicting state management   | Standardise on one tool per layer                    |
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-integration-testing/SKILL.md
+++ b/skills/mav-bp-integration-testing/SKILL.md
@@ -166,4 +166,4 @@ digraph lookup {
 | Hard-coded connection strings | Breaks in different environments | Use environment variables or config |
 | Test requires manual environment setup | Not reproducible | Automate with containers or scripts |
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-linting/SKILL.md
+++ b/skills/mav-bp-linting/SKILL.md
@@ -171,4 +171,4 @@ digraph lookup {
 | No pre-commit formatting | Style inconsistency across commits | Add lint-staged or equivalent |
 | Linter running on generated/vendor code | False positives, slow runs | Update ignore patterns |
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-logging/SKILL.md
+++ b/skills/mav-bp-logging/SKILL.md
@@ -288,4 +288,4 @@ When reviewing code, flag these patterns:
 | Different loggers in different files               | Inconsistency                 | Use single logger module                     |
 | `try/catch` that silently swallows                 | Lost errors                   | Log or re-throw                              |
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-observability/SKILL.md
+++ b/skills/mav-bp-observability/SKILL.md
@@ -208,4 +208,4 @@ Every deployed service should have a dashboard showing the **four golden signals
 | Dashboard with no link to traces or logs         | Slow investigation              | Add drill-down links from dashboard panels                 |
 | Custom metric collection instead of standard library | Maintenance burden, incompatibility | Migrate to OpenTelemetry or equivalent             |
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-remote-code-review/SKILL.md
+++ b/skills/mav-bp-remote-code-review/SKILL.md
@@ -48,4 +48,4 @@ If the workflow file is missing or malformed:
 
 Per the project's binary review contract, the agent code reviewer's verdict is the only signal the auto-merge path trusts. If the gate is local-only, a PR can land via `gh pr merge --auto` without the gate ever running — for example, when a wave of stories is dispatched in parallel and one worktree's local review fails to fire. Putting the review in CI means the merge cannot complete until the workflow has reported back, regardless of what happened on the developer's machine.
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-solutions-design/SKILL.md
+++ b/skills/mav-bp-solutions-design/SKILL.md
@@ -215,4 +215,4 @@ Not every change needs a 10-page design document. The investment in design shoul
 | Design doc exists but is stale | Documentation rot | Update the design doc to reflect what was actually built |
 | Requirements ambiguity resolved by guessing | Risk of building the wrong thing | Clarify with stakeholder before proceeding |
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-source-control/SKILL.md
+++ b/skills/mav-bp-source-control/SKILL.md
@@ -157,4 +157,4 @@ When auditing a project or starting work, flag these patterns:
 | Sensitive file patterns missing from `.gitignore` | Future risk of secret commits | Add missing patterns to `.gitignore`                  |
 | Remote URL points to deleted/moved repo    | Effectively no remote           | Update remote URL to valid repository                     |
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-task-tracking/SKILL.md
+++ b/skills/mav-bp-task-tracking/SKILL.md
@@ -163,4 +163,4 @@ When reviewing workflow and project management practices, flag these patterns:
 | Local TODO list used instead of tracker | Invisible work | Move tasks to the external system |
 | Task marked done but PR not merged | Status does not reflect reality | Update status to match actual state |
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-unit-testing/SKILL.md
+++ b/skills/mav-bp-unit-testing/SKILL.md
@@ -156,4 +156,4 @@ digraph lookup {
 | Test duplicates implementation logic | Tautological test | Assert on outputs, not reimplemented logic |
 | Commented-out tests | Dead tests hiding failures | Delete or fix |
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-bp-versioning/SKILL.md
+++ b/skills/mav-bp-versioning/SKILL.md
@@ -230,4 +230,4 @@ The two are related but distinct:
 | Deprecated code no longer functions | Broken deprecation contract | Fix deprecated code path — it must work until removal |
 | Multiple breaking changes across minor releases | Death by a thousand cuts for consumers | Batch breaking changes into a single major release |
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-claude-code-recovery/SKILL.md
+++ b/skills/mav-claude-code-recovery/SKILL.md
@@ -305,4 +305,4 @@ digraph subagent_failure {
 - **Reduce scope on repeated failure** — if a subagent fails twice on the same task, split the task into smaller pieces and dispatch subagents for each piece.
 - **Never silently swallow failures** — if a subagent fails and you cannot recover, report the failure clearly to the user.
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-create-solution-design/SKILL.md
+++ b/skills/mav-create-solution-design/SKILL.md
@@ -118,4 +118,4 @@ Before the design is considered complete:
 - [ ] Risks are honest — if there are none, you haven't looked hard enough
 - [ ] The approach is achievable in a single session (if not, flag for further decomposition)
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-create-tasks/SKILL.md
+++ b/skills/mav-create-tasks/SKILL.md
@@ -138,4 +138,4 @@ Before the task list is considered complete:
 - [ ] Dependencies between tasks are minimal and explicitly stated
 - [ ] The sum of all tasks fully implements the solution design
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-durability-on-gh/SKILL.md
+++ b/skills/mav-durability-on-gh/SKILL.md
@@ -179,4 +179,4 @@ Keep these strictly local:
 If a piece of state is regenerable within one task, don't mirror it to GitHub.
 The markers are a narrow coordination surface, not a storage layer.
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-git-workflow/SKILL.md
+++ b/skills/mav-git-workflow/SKILL.md
@@ -339,4 +339,4 @@ If there are uncommitted changes:
 - **Stash them** if they are unrelated: `git stash push -m "WIP: description"`
 - **Ask the user** if you are unsure what to do with them
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-github-issue-workflow/SKILL.md
+++ b/skills/mav-github-issue-workflow/SKILL.md
@@ -303,4 +303,4 @@ rm .claude/issue-state.json
 
 Do not delete the state file until the PR is successfully created, as it is needed for crash recovery.
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-local-verification/SKILL.md
+++ b/skills/mav-local-verification/SKILL.md
@@ -103,4 +103,4 @@ Not every change needs the full suite:
 
 For the final push before PR creation, always run the full suite regardless of change type.
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-multi-instance-coordination/SKILL.md
+++ b/skills/mav-multi-instance-coordination/SKILL.md
@@ -168,4 +168,4 @@ instance still holds.
   entire epic when you only intend to work on one wave blocks other
   instances unnecessarily.
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-plan-execution/SKILL.md
+++ b/skills/mav-plan-execution/SKILL.md
@@ -192,4 +192,4 @@ After all steps are complete and the full verification suite passes:
 Do not proceed to code review until every acceptance criterion is met and all checks pass.
 
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-scope-boundaries/SKILL.md
+++ b/skills/mav-scope-boundaries/SKILL.md
@@ -176,4 +176,4 @@ This task requires interaction with a production system that Claude Code cannot 
 *Posted by Claude Code*
 ```
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-stacked-prs/SKILL.md
+++ b/skills/mav-stacked-prs/SKILL.md
@@ -172,4 +172,4 @@ flags a conflict. Either way, B cannot silently merge into an orphan.
 - **Cross-reference `mav-git-workflow`** for conventional commit
   format, branch naming, and conflict resolution.
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/skills/mav-systematic-debugging/SKILL.md
+++ b/skills/mav-systematic-debugging/SKILL.md
@@ -171,4 +171,4 @@ When debugging occurs during plan execution (do-issue workflows):
 3. **Log diagnostic findings** — if the bug reveals a design issue, update the solution design comment on the issue
 4. **Time-box debugging** — if Phase 1 takes more than 30 minutes without progress, escalate to the user rather than continuing to investigate alone
 
-<!-- maverick-plugin-version: 1.0.2 -->
+<!-- maverick-plugin-version: 1.0.3-dev -->

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -310,7 +310,7 @@ wheels = [
 
 [[package]]
 name = "maverick"
-version = "1.0.2"
+version = "1.0.3.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Automated follow-up to the 1.0.2 release. Bumps `main` to the next in-development version.

The `release-finalize` workflow created and pushed this branch successfully but couldn't open the PR — repo setting "Allow GitHub Actions to create and approve pull requests" is off, so the workflow's `gh pr create` step gets a GraphQL permission error. PR opened manually with my user auth.

To fix permanently: Settings → Actions → General → Workflow permissions → tick "Allow GitHub Actions to create and approve pull requests".

## Changes

- `pyproject.toml`, `.claude-plugin/*.json`, `.cursor-plugin/cursor.plugin.json`: `1.0.2` → `1.0.3-dev`
- `uv.lock`: regenerated
- `skills/`, `agents/`, `hooks/`, `infra/`: rebuilt with the new version marker