### PR TITLE
fix: detect CLI/plugin version drift in do-init

### DIFF
--- a/skills/do-init/SKILL.md
+++ b/skills/do-init/SKILL.md
@@ -14,13 +14,20 @@ Dispatch the **agent-maverick** agent with task `init` and any user-provided arg
 
 ## Process
 
-### 1. Ensure the Maverick CLI is installed
+### 1. Ensure the Maverick CLI is installed and matches the plugin
 
-Run `command -v maverick` to check whether the CLI is already on PATH. If it is, skip to step 2.
+Run `command -v maverick` to check whether the CLI is already on PATH.
 
-If `maverick` is not on PATH, dispatch the **/maverick:do-install** skill and wait for it to complete. After the install returns, re-run `command -v maverick` to confirm the binary is now resolvable. If it still is not (e.g. `~/.local/bin` is not on the user's PATH), report the install message verbatim to the user and stop — they need to fix PATH and re-invoke `/maverick:do-init` manually.
+**If `maverick` is not on PATH**, dispatch the **/maverick:do-install** skill and wait for it to complete. After the install returns, re-run `command -v maverick` to confirm the binary is now resolvable. If it still is not (e.g. `~/.local/bin` is not on the user's PATH), report the install message verbatim to the user and stop — they need to fix PATH and re-invoke `/maverick:do-init` manually.
 
-`do-init` cannot complete without the CLI. The remaining steps invoke `maverick` directly.
+**If `maverick` is on PATH**, verify the installed CLI matches the loaded plugin. A stale binary from an earlier plugin version can be missing subcommands the rest of this skill depends on (e.g. `maverick integration`, `maverick preflight`).
+
+- Read the installed CLI version: `maverick --version`
+- Read the plugin version: `grep -Po '(?<=^version = ")[^"]+' "${CLAUDE_PLUGIN_ROOT}/pyproject.toml"`
+- If they differ, dispatch **/maverick:do-install** to refresh the CLI. That skill always runs `uv tool install --force` from the plugin root, so it overwrites whatever is currently installed. After it returns, re-run `maverick --version` and confirm it now matches the plugin version. If it still does not, surface the mismatch to the user and stop.
+- If the versions already match, skip to step 2.
+
+`do-init` cannot complete without a CLI version that matches the plugin. The remaining steps invoke `maverick` directly and depend on subcommands that may have been added in newer versions.
 
 ### 2. Initialise the project config
 

--- a/src/maverick/cli.py
+++ b/src/maverick/cli.py
@@ -1,12 +1,32 @@
 """Unified CLI entry point for claude-maverick."""
 
 import argparse
+from importlib.metadata import PackageNotFoundError, version
+
+
+def _get_version() -> str:
+    try:
+        v = version("maverick")
+    except PackageNotFoundError:
+        return "unknown"
+    # importlib.metadata returns PEP 440 normalised form (e.g. "1.0.3.dev0"),
+    # but pyproject.toml uses the literal "-dev" suffix. Emit the source form
+    # so callers can do exact-string comparison against the plugin's
+    # pyproject.toml.
+    if v.endswith(".dev0"):
+        return v[: -len(".dev0")] + "-dev"
+    return v
 
 
 def main():
     parser = argparse.ArgumentParser(
         prog="maverick",
         description="Claude Code provisioning and configuration tool",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {_get_version()}",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 

--- a/src/maverick/skills/do-init/body.md.j2
+++ b/src/maverick/skills/do-init/body.md.j2
@@ -9,13 +9,20 @@ Dispatch the **{{ AGENTS.AGENT_MAVERICK }}** agent with task `init` and any user
 
 ## Process
 
-### 1. Ensure the Maverick CLI is installed
+### 1. Ensure the Maverick CLI is installed and matches the plugin
 
-Run `command -v maverick` to check whether the CLI is already on PATH. If it is, skip to step 2.
+Run `command -v maverick` to check whether the CLI is already on PATH.
 
-If `maverick` is not on PATH, dispatch the **/maverick:{{ SKILLS.DO_INSTALL }}** skill and wait for it to complete. After the install returns, re-run `command -v maverick` to confirm the binary is now resolvable. If it still is not (e.g. `~/.local/bin` is not on the user's PATH), report the install message verbatim to the user and stop — they need to fix PATH and re-invoke `/maverick:do-init` manually.
+**If `maverick` is not on PATH**, dispatch the **/maverick:{{ SKILLS.DO_INSTALL }}** skill and wait for it to complete. After the install returns, re-run `command -v maverick` to confirm the binary is now resolvable. If it still is not (e.g. `~/.local/bin` is not on the user's PATH), report the install message verbatim to the user and stop — they need to fix PATH and re-invoke `/maverick:do-init` manually.
 
-`do-init` cannot complete without the CLI. The remaining steps invoke `maverick` directly.
+**If `maverick` is on PATH**, verify the installed CLI matches the loaded plugin. A stale binary from an earlier plugin version can be missing subcommands the rest of this skill depends on (e.g. `maverick integration`, `maverick preflight`).
+
+- Read the installed CLI version: `maverick --version`
+- Read the plugin version: `grep -Po '(?<=^version = ")[^"]+' "${CLAUDE_PLUGIN_ROOT}/pyproject.toml"`
+- If they differ, dispatch **/maverick:{{ SKILLS.DO_INSTALL }}** to refresh the CLI. That skill always runs `uv tool install --force` from the plugin root, so it overwrites whatever is currently installed. After it returns, re-run `maverick --version` and confirm it now matches the plugin version. If it still does not, surface the mismatch to the user and stop.
+- If the versions already match, skip to step 2.
+
+`do-init` cannot complete without a CLI version that matches the plugin. The remaining steps invoke `maverick` directly and depend on subcommands that may have been added in newer versions.
 
 ### 2. Initialise the project config
 


### PR DESCRIPTION
## Summary

- Add `maverick --version` to the CLI, emitting the source pyproject.toml form (`1.0.3-dev`) so it can be string-compared against the plugin's `pyproject.toml`.
- `do-init` step 1 now compares the installed CLI version against `${CLAUDE_PLUGIN_ROOT}/pyproject.toml` and dispatches `do-install` (which already runs `uv tool install --force`) on mismatch.

## Why

A clean `do-init` run on a machine with a leftover pre-1.0 `maverick` CLI on PATH was reported as failing on subcommands that the skill assumed exist (`integration get/set`, `preflight`). The CLI was actually 0.5.x — but appeared to be 1.0.2 because the plugin cache was at 1.0.2. There was no observable signal of the drift.

Three contributing causes, all addressed:

1. CLI had no `--version` flag, so drift was undetectable.
2. `do-init` only checked CLI presence, not freshness — a stale binary passed the gate.
3. `do-install` already force-installs, so removing the gate is safe; re-dispatching always overwrites the stale CLI.

## Test plan

- [x] `uv run maverick --version` prints `maverick 1.0.3-dev`
- [x] `ruff check` and `pyright` clean on `src/maverick/cli.py`
- [x] `make build` regenerates `skills/do-init/SKILL.md` matching the body template
- [ ] Reviewer: confirm the version-compare instruction reads well to an LLM-driven `do-init` run

## Versioning

Main is at `1.0.3-dev`; running `./scripts/release.sh patch` from main after this merges will graduate it to `1.0.3` and ship the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)