### PR TITLE
fix: wrap SessionStart entries per Claude Code hook schema

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -2,8 +2,12 @@
   "hooks": {
     "SessionStart": [
       {
-        "type": "command",
-        "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/install_check.py"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/install_check.py"
+          }
+        ]
       }
     ]
   }

--- a/src/maverick/hooks/hooks.json
+++ b/src/maverick/hooks/hooks.json
@@ -2,8 +2,12 @@
   "hooks": {
     "SessionStart": [
       {
-        "type": "command",
-        "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/install_check.py"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/install_check.py"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary

Each entry in a hook event array (e.g. `SessionStart`) must be a matcher block containing a nested `hooks` array. The plugin has shipped a flat shape since v1.0.0 — strict-validating Claude Code versions (2.1.x) reject it with:

```
hooks.SessionStart[0].hooks  expected array, received undefined
```

This breaks `/reload-plugins` entirely on machines that have updated Claude Code, regardless of which 1.0.x maverick is installed.

## Change

```diff
 "SessionStart": [
   {
+    "hooks": [
+      {
         "type": "command",
         "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/install_check.py"
+      }
+    ]
   }
 ]
```

Applied to both the source (`src/maverick/hooks/hooks.json`) and the build output (`hooks/hooks.json`) via `make build`.

## Test plan

- [x] `make build` produces the wrapped shape in `hooks/hooks.json`
- [ ] Reviewer: load the plugin in Claude Code 2.1.x and confirm `/reload-plugins` reports 1 hook loaded with no errors

## Versioning

Ships in 1.0.3 alongside #21 once `./scripts/release.sh patch` is run from main after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)