### PR TITLE
fix: parse JSON when checking gh-app status in preflight

### DIFF
--- a/src/maverick/preflight.py
+++ b/src/maverick/preflight.py
@@ -24,6 +24,7 @@ a new tool or runtime check is a one-line addition to TOOLS / RUNTIME_CHECKS.
 
 from __future__ import annotations
 
+import json
 import shutil
 import subprocess
 from collections.abc import Callable
@@ -128,7 +129,11 @@ def _check_gh_app_configured() -> tuple[bool, str]:
     """Return (ok, message). The GitHub App must report ``configured: true``.
 
     Uses ``maverick gh-app status`` so the check is consistent with what
-    do-epic Phase 0 already runs.
+    do-epic Phase 0 already runs. The subcommand emits JSON on stdout
+    (e.g. ``{"configured": true, "app_id": 123, ...}``); we parse it
+    rather than substring-match because the JSON form ``"configured":
+    true`` is not a substring of any plain-text needle that includes
+    the key without surrounding quotes.
     """
     try:
         result = subprocess.run(
@@ -140,9 +145,13 @@ def _check_gh_app_configured() -> tuple[bool, str]:
         )
     except (FileNotFoundError, subprocess.TimeoutExpired) as e:
         return False, f"could not run `maverick gh-app status`: {e}"
-    output = (result.stdout or "") + (result.stderr or "")
-    if result.returncode == 0 and "configured: true" in output.lower():
-        return True, ""
+    if result.returncode == 0 and (result.stdout or "").strip():
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            payload = {}
+        if isinstance(payload, dict) and payload.get("configured") is True:
+            return True, ""
     return False, (
         "the Maverick GitHub App is not configured. Create a GitHub App at "
         "https://github.com/settings/apps/new (read access to contents and "

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -7,6 +7,8 @@ from argparse import Namespace
 from pathlib import Path
 from unittest.mock import patch
 
+from subprocess import CompletedProcess
+
 from maverick import preflight, preflight_cli
 
 # ---------------------------------------------------------------------------
@@ -287,6 +289,51 @@ class TestPrereqsTableConsistency:
                     f"PREREQS[{skill!r}] references runtime check "
                     f"{name!r} which is not registered in RUNTIME_CHECKS"
                 )
+
+    def test_check_gh_app_configured_parses_real_json(self, monkeypatch):
+        """Regression: the runtime check must parse the JSON output of
+        `maverick gh-app status`, not substring-match. The JSON shape
+        emits `"configured": true` with quotes around the key — earlier
+        code looked for the literal needle `configured: true`, which
+        never matched and made do-issue-solo / do-epic / do-init
+        impossible to preflight-pass.
+        """
+        real_output = json.dumps(
+            {"app_id": 1, "configured": True, "installation_id": 2}, indent=2
+        )
+
+        def fake_run(*args, **kwargs):
+            return CompletedProcess(
+                args=args[0], returncode=0, stdout=real_output, stderr=""
+            )
+
+        monkeypatch.setattr(preflight.subprocess, "run", fake_run)
+        ok, msg = preflight._check_gh_app_configured()
+        assert ok, f"expected pass; got fail with message: {msg}"
+
+    def test_check_gh_app_configured_fails_on_configured_false(self, monkeypatch):
+        real_output = json.dumps(
+            {"configured": False, "reason": "no config at /x"}, indent=2
+        )
+
+        def fake_run(*args, **kwargs):
+            return CompletedProcess(
+                args=args[0], returncode=0, stdout=real_output, stderr=""
+            )
+
+        monkeypatch.setattr(preflight.subprocess, "run", fake_run)
+        ok, _ = preflight._check_gh_app_configured()
+        assert ok is False
+
+    def test_check_gh_app_configured_fails_on_malformed_stdout(self, monkeypatch):
+        def fake_run(*args, **kwargs):
+            return CompletedProcess(
+                args=args[0], returncode=0, stdout="not json at all", stderr=""
+            )
+
+        monkeypatch.setattr(preflight.subprocess, "run", fake_run)
+        ok, _ = preflight._check_gh_app_configured()
+        assert ok is False
 
     def test_every_integration_flag_has_remediation(self):
         """FLAG_REMEDIATION must cover every flag that can appear in a missing list."""


### PR DESCRIPTION
## Summary
`_check_gh_app_configured` substring-matched the literal text `configured: true` against the captured output of `maverick gh-app status`. But that subcommand emits JSON where the key is quoted: `"configured": true`. The needle is never a substring of the haystack, so the runtime check could **never** report success — regardless of whether the GitHub App is properly set up. This blocks `do-init`, `do-issue-solo`, and `do-epic` on every 2.0.0 install.

The bug is pre-existing (it predates the bot→gh-app rename) but went unnoticed because the test suite only exercised `_check_gh_app_configured` indirectly through stubbed `RUNTIME_CHECKS`, never against the real subprocess output shape.

## Fix
Parse the captured stdout as JSON and verify `payload.get("configured") is True`.

## Regression tests
Three new tests in `TestPrereqsTableConsistency`:
- Real-shape JSON (`{"app_id": 1, "configured": true, "installation_id": 2}`) → check passes
- `{"configured": false, "reason": "..."}` → check fails
- Malformed stdout → check fails cleanly (no traceback)

The first test would have failed against the previous substring-match implementation.

## Verification
On a machine with a working `gh_app` config in `~/.maverick/config.json`:
- Pre-fix: `uv run maverick preflight do-init` reported `gh_app_configured` failing
- Post-fix: `uv run maverick preflight do-init` reports `do-init OK`

## Test plan
- [ ] `uv run pytest tests/unit/` — 340 passing locally
- [ ] On a configured machine, `uv run maverick preflight do-init` exits 0
- [ ] On an unconfigured machine, `uv run maverick preflight do-init` exits 1 with the existing remediation message

## Follow-up
After this merges, cut a **2.0.1** patch release so the fix reaches users on `2.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)