### PR TITLE
feat: bot-authored comments + local-default PR review

### DIFF
--- a/docs/skills/maverick-skills.md
+++ b/docs/skills/maverick-skills.md
@@ -25,7 +25,7 @@ Work on a multi-story GitHub epic end-to-end. Builds a DAG from the child storie
 
 ## do-init
 
-Initialise a project for use with Maverick — verifies the GitHub App, installs the CLI if needed, writes the project config with integration tracking, scaffolds docs, generates project skills, scaffolds the mandatory remote code-review workflow, runs an initial cybersecurity audit, then commits the changes and opens a PR.
+Initialise a project for use with Maverick — verifies the GitHub App, installs the CLI if needed, writes the project config with integration tracking, scaffolds docs, generates project skills, runs an initial cybersecurity audit, then commits the changes and opens a PR.
 
 
 ## do-install

--- a/skills/do-epic/SKILL.md
+++ b/skills/do-epic/SKILL.md
@@ -23,13 +23,16 @@ Run this **first**. If it exits non-zero, halt and report the stderr output to t
 uv run maverick preflight do-epic
 ```
 
-The check verifies: the project is initialised, the mandatory remote
-code-review workflow is in place, the Maverick GitHub App is configured
-(`maverick gh-app status` reports `configured: true`), git worktrees
-are usable, and required tools (`gh`, `git`, `uv`) are on PATH. If the code-review-workflow flag is false, offer to scaffold from
-`${CLAUDE_PLUGIN_ROOT}/skills/mav-bp-remote-code-review/code-review.yml`
-on a small setup PR; after that PR merges, run `uv run maverick
-integration set code_review_workflow true` and re-run preflight.
+The check verifies: the project is initialised, the Maverick GitHub
+App is configured (`maverick gh-app status` reports `configured: true`),
+git worktrees are usable, and required tools (`gh`, `git`, `uv`) are on
+PATH. PR code review runs locally inside each story's worktree as the
+`agent-code-reviewer` subagent (delegated from
+`do-issue-solo` Phase 9). For epics that fan out across
+many parallel workers, consider opting into the CI-side re-run
+described in `mav-bp-remote-code-review` so the merge is
+gated by an independent check even if a worker's local review fails to
+fire — that workflow is optional and not enforced by preflight.
 
 ## Before You Begin
 

--- a/skills/do-init/SKILL.md
+++ b/skills/do-init/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: do-init
-description: Initialise a project for use with Maverick — verifies the GitHub App, installs the CLI if needed, writes the project config with integration tracking, scaffolds docs, generates project skills, scaffolds the mandatory remote code-review workflow, runs an initial cybersecurity audit, then commits the changes and opens a PR.
+description: Initialise a project for use with Maverick — verifies the GitHub App, installs the CLI if needed, writes the project config with integration tracking, scaffolds docs, generates project skills, runs an initial cybersecurity audit, then commits the changes and opens a PR.
 user-invocable: true
 ---
 
 # Init Maverick Project
 
-Set up the current repository for Maverick — install the CLI if needed, validate the Maverick GitHub App, write the project-level config, scaffold docs and project skills, scaffold the mandatory remote code-review workflow, run the cybersecurity audit, then commit everything and open a pull request for the user to approve.
+Set up the current repository for Maverick — install the CLI if needed, validate the Maverick GitHub App, write the project-level config, scaffold docs and project skills, run the cybersecurity audit, then commit everything and open a pull request for the user to approve.
 
 ## Dispatch
 
@@ -95,30 +95,11 @@ Dispatch **/maverick:do-docs**. The greenfield mode of that skill flips `integra
 
 Dispatch **/maverick:do-upskill**. It iterates every topic in `topics.json` and writes per-topic skills under `docs/maverick/skills/`, then flips `integration.upskill` to `true`.
 
-### 7. Scaffold the remote code-review workflow
-
-The mandatory remote code-review GitHub Actions workflow (described in `mav-bp-remote-code-review`) must exist before `do-issue-solo` or `do-epic` can run. Detect whether the project already has one:
-
-```bash
-grep -lR '^# maverick:code-review$' .github/workflows/ 2>/dev/null
-```
-
-- **If any file is found**, the contract is already satisfied — log "code-review workflow already present" and run `uv run maverick integration set code_review_workflow true` so future preflights agree, then skip the rest of this step. Do not overwrite an existing custom workflow.
-- **If no file is found**, copy the reference template into place:
-
-  ```bash
-  mkdir -p .github/workflows
-  cp "${CLAUDE_PLUGIN_ROOT}/skills/mav-bp-remote-code-review/code-review.yml" .github/workflows/code-review.yml
-  uv run maverick integration set code_review_workflow true
-  ```
-
-The workflow needs the `ANTHROPIC_API_KEY` repository secret to run — call this out in the final report so the user knows to set it before merging the PR.
-
-### 8. Run the cybersecurity review
+### 7. Run the cybersecurity review
 
 Dispatch **/maverick:do-cybersecurity-review**. It scans the existing codebase for common security risks (secrets, dependency vulnerabilities, auth/input-validation patterns), writes findings to `docs/security-audit.md`, and flips `integration.cybersecurity_reviewed` to `true`. The review is surface-only — it reports, it does not modify code. Any FAIL findings should be tracked as follow-up issues by the user.
 
-### 9. Commit changes and open a pull request
+### 8. Commit changes and open a pull request
 
 The earlier steps wrote a number of new and modified files. Commit them on a fresh branch and open a PR for the user to approve.
 
@@ -127,7 +108,6 @@ The earlier steps wrote a number of new and modified files. Commit them on a fre
    - `docs/maverick/skills/...` (from `do-upskill`)
    - `docs/...` content created by `do-docs` greenfield
    - `docs/security-audit.md` (from `do-cybersecurity-review`)
-   - `.github/workflows/code-review.yml` (from step 7, when newly scaffolded)
 
    If `git status` shows changes outside these paths, **abort and report to the user** — they have unrelated uncommitted work that should be handled first.
 
@@ -141,7 +121,6 @@ The earlier steps wrote a number of new and modified files. Commit them on a fre
    ```bash
    git checkout -b chore/maverick-init
    git add .maverick/
-   [ -f .github/workflows/code-review.yml ] && git add .github/workflows/code-review.yml
    [ -d docs/maverick ] && git add docs/maverick/
    [ -f docs/security-audit.md ] && git add docs/security-audit.md
    # Stage anything else under docs/ that do-docs greenfield created.
@@ -168,11 +147,7 @@ The earlier steps wrote a number of new and modified files. Commit them on a fre
    - `.maverick/` — project config and integration tracking
    - `docs/maverick/skills/` — generated project-specific skills
    - `docs/security-audit.md` — initial cybersecurity audit findings (review FAIL items)
-   - `.github/workflows/code-review.yml` — mandatory remote code-review workflow (only when newly scaffolded)
    - Other `docs/` content scaffolded by `do-docs`
-
-   ### Required setup before merging
-   - Set the `ANTHROPIC_API_KEY` repository secret in this repo's GitHub Actions secrets so the code-review workflow can run.
 
    ### Verify after merge
    ```bash
@@ -184,17 +159,17 @@ The earlier steps wrote a number of new and modified files. Commit them on a fre
 
 6. Capture the PR URL from the `gh pr create` output and pass it through to the report in the next step.
 
-### 10. Report
+### 9. Report
 
 Print a final summary to the user:
 
 - Detected modules (from step 3's output)
 - Whether docs were scaffolded greenfield or already existed
 - How many project skills were generated
-- Whether the code-review workflow was newly scaffolded or already present
 - The number of security-audit findings at each severity, and the path to the audit report
 - The current integration state: `uv run maverick integration get`
-- The PR URL from step 9 — and a one-line reminder to set `ANTHROPIC_API_KEY` before merging
+- The PR URL from step 8
+- A one-line note that PR code review now runs locally as the `agent-code-reviewer` subagent during `do-issue-solo` / `do-epic`. If the project later wants the optional CI-side gate (multi-machine workflows, untrusted environments, audit needs), point the user at `mav-bp-remote-code-review` for the manual scaffold steps.
 
 The integration checklist gives the user (and any future Maverick session) a clear view of what's been completed and what's still pending.
 

--- a/skills/do-issue-guided/SKILL.md
+++ b/skills/do-issue-guided/SKILL.md
@@ -20,7 +20,7 @@ Run this **first**. If it exits non-zero, halt and report the stderr output to t
 uv run maverick preflight do-issue-guided
 ```
 
-The check verifies the project is initialised, the mandatory remote code-review workflow is in place, and required tools (`gh`, `git`, `uv`) are on PATH.
+The check verifies the project is initialised and required tools (`gh`, `git`, `uv`) are on PATH. PR code review runs locally as the `agent-code-reviewer` subagent (see Phase 6); the optional CI-side re-run described in `mav-bp-remote-code-review` is not required.
 
 ## Before You Begin
 

--- a/skills/do-issue-solo/SKILL.md
+++ b/skills/do-issue-solo/SKILL.md
@@ -25,10 +25,9 @@ do not work around missing prerequisites.
 uv run maverick preflight do-issue-solo
 ```
 
-The check verifies: the project is initialised, the mandatory remote
-code-review workflow is in place, the Maverick GitHub App is configured
-(`maverick gh-app status` reports `configured: true`), and required
-tools (`gh`, `git`, `uv`) are on PATH.
+The check verifies: the project is initialised, the Maverick GitHub
+App is configured (`maverick gh-app status` reports `configured: true`),
+and required tools (`gh`, `git`, `uv`) are on PATH.
 
 ## Before You Begin
 
@@ -38,17 +37,13 @@ for the issue number before proceeding.
 Determine the repo (via `gh repo view --json nameWithOwner`) — you will
 pass it to every `maverick coord` command below.
 
-If preflight reported a missing `code_review_workflow` flag, offer the
-user two paths before claiming the issue:
-
-1. **Scaffold the reference workflow.** Copy
-   `${CLAUDE_PLUGIN_ROOT}/skills/mav-bp-remote-code-review/code-review.yml`
-   into `.github/workflows/`, commit it on a small setup branch, open a
-   PR for it, and wait for the user to merge that PR before continuing
-   with ``. After the workflow merges, run
-   `uv run maverick integration set code_review_workflow true` and
-   re-run `uv run maverick preflight do-issue-solo`.
-2. **Abort.** If the user declines, stop here.
+PR code review runs locally during Phase 9 as the
+`agent-code-reviewer` subagent — its binary PASS/FAIL
+verdict is the gate. Some projects also opt into a CI-side re-run via
+`mav-bp-remote-code-review` (independent verification for
+multi-machine fleets or audit needs); when present it adds a status
+check the auto-merge in Phase 10 will wait on, but its absence is not
+a blocker.
 
 ## Phase 0: Coordination + cold-start
 
@@ -225,8 +220,9 @@ changes (callers, importers, dependents) must be reviewed by
 
 ## Phase 9: Code Review (binary, hard gate)
 
-This phase has changed. Review is now a **binary verdict** against the
-open PR, not a local-diff advisory loop. See `agent-code-reviewer`.
+The local **agent-code-reviewer** subagent's verdict is the
+review gate the auto-merge path trusts. This is a binary verdict against
+the open PR, not a local-diff advisory loop.
 
 1. Dispatch **agent-code-reviewer** with:
    - The PR URL
@@ -250,8 +246,12 @@ next step is eject-to-human, not iterate.
    ```bash
    uv run maverick gh-app gh -- pr merge <pr-url> --auto --squash
    ```
-   If CI was already green, GitHub merges immediately. Otherwise it
-   merges when CI passes.
+   The merge waits on whatever required status checks the project's
+   branch protection enforces — typically lint, tests, build, and (if
+   the optional `mav-bp-remote-code-review` workflow is
+   adopted) the CI-side re-run of agent-code-reviewer. If all required
+   checks were already green, GitHub merges immediately; otherwise it
+   merges when they pass.
 3. Post the completion comment on the issue per
    `mav-github-issue-workflow`.
 4. Update phase to `complete` in the state file.

--- a/skills/do-issue-solo/SKILL.md
+++ b/skills/do-issue-solo/SKILL.md
@@ -262,9 +262,10 @@ next step is eject-to-human, not iterate.
 
 ## Phase 11: Eject (on FAIL)
 
-1. Post the reviewer's verdict as a PR comment:
+1. Post the reviewer's verdict as a PR comment (App identity, per
+   `mav-github-issue-workflow`):
    ```bash
-   gh pr comment <pr-url> --body-file /tmp/review-verdict.md
+   uv run maverick gh-app gh -- pr comment <pr-url> --body-file /tmp/review-verdict.md
    ```
 2. Apply the `needs-human` label to both the PR and the issue:
    ```bash

--- a/skills/do-maverick-alignment/SKILL.md
+++ b/skills/do-maverick-alignment/SKILL.md
@@ -168,9 +168,9 @@ Record the evidence (file paths, dependency names, snippets) for each finding.
 
 **Additional detail:** Note which CI/CD platform is used and what steps the pipeline runs.
 
-### 6. Remote Code Review Workflow
+### 6. Remote Code Review Workflow (Optional CI Gate)
 
-Per mav-bp-remote-code-review, every project must ship a GitHub Actions workflow that runs the agent code reviewer on every pull request. Local subagent review is not enough — the remote workflow is the gate the auto-merge path trusts.
+Per mav-bp-remote-code-review, the remote workflow is an **optional** CI-side re-run of the local `agent-code-reviewer`. By default, the local subagent's verdict (run during `do-issue-solo` Phase 9) is the gate the auto-merge path trusts. Some projects opt into the remote workflow for an independent CI check — multi-machine fleets, untrusted dev environments, regulatory audit trails — but its absence is not a compliance failure.
 
 **Search for:**
 
@@ -184,11 +184,11 @@ Per mav-bp-remote-code-review, every project must ship a GitHub Actions workflow
 
 | Status | Criteria |
 | --- | --- |
-| PASS | A workflow file under `.github/workflows/` contains the `# maverick:code-review` marker AND has an `on: pull_request:` trigger |
-| WARN | A workflow with the marker exists but is missing the `pull_request` trigger, OR a `pull_request`-triggered workflow exists but no marker (likely a different review pipeline that needs the marker added) |
-| FAIL | No workflow under `.github/workflows/` contains the marker |
+| PASS | A workflow file under `.github/workflows/` contains the `# maverick:code-review` marker AND has an `on: pull_request:` trigger — the project has opted into the CI-side gate and the wiring looks right |
+| WARN | A workflow with the marker exists but is missing the `pull_request` trigger, OR a `pull_request`-triggered workflow exists but no marker (likely a different review pipeline that needs the marker added) — the team's intent is unclear |
+| INFO | No workflow under `.github/workflows/` contains the marker — the project is on the local-review default. Note this in the report and move on; do not flag it as a finding |
 
-**Recommendation on WARN/FAIL:** copy the reference template shipped with the plugin: `${CLAUDE_PLUGIN_ROOT}/skills/mav-bp-remote-code-review/code-review.yml` -> `.github/workflows/code-review.yml`. Set the `ANTHROPIC_API_KEY` repo secret. Open a PR — the workflow itself will run on its own PR as a smoke test.
+**Recommendation on WARN:** fix the marker / trigger so the workflow's role is unambiguous. **Recommendation on INFO:** none required. If the team later decides they want the optional CI gate, point them at `mav-bp-remote-code-review` for the manual scaffold steps and the `ANTHROPIC_API_KEY` setup.
 
 ### 7. Source Control
 

--- a/skills/mav-bp-remote-code-review/SKILL.md
+++ b/skills/mav-bp-remote-code-review/SKILL.md
@@ -4,16 +4,28 @@ description: Mandatory remote code review on every pull request. Defines the con
 disable-model-invocation: false
 ---
 
-# Remote Code Review
+# Remote Code Review (Optional CI Gate)
 
-Code review is mandatory and must run remotely in CI on every pull request — not only as a Claude Code subagent dispatched from a developer's session. Local subagent review is fast and useful, but it can be skipped or tampered with. The remote workflow is the gate that catches reviews that didn't happen locally.
+Maverick runs PR code review locally by default — `agent-code-reviewer` is dispatched as a subagent during `do-issue-solo` Phase 9 (and equivalent in `do-issue-guided` / `do-epic`) and produces the binary PASS/FAIL verdict that the auto-merge path trusts. The local agent's verdict is the gate.
 
-## The Contract
+This skill describes an **optional** GitHub Actions workflow that re-runs the same agent in CI. Adding it to a project gives you an independent CI-side check on every PR, at the cost of paid Anthropic API tokens for each run and a bit of setup. It is not required, and `do-init` does not scaffold it — projects that want it adopt it deliberately.
 
-A repository is compliant with this skill iff it ships a GitHub Actions workflow that:
+## When to Add the Remote Gate
+
+The remote workflow is worth the setup and the per-PR API spend when one or more of these apply:
+
+- **Multi-machine / fleet operation.** When `do-epic` dispatches a wave of stories across worktrees in parallel, a single worktree's local review can fail to fire (process crash, network blip, agent skipped). A CI gate guarantees the merge cannot complete without a review having run somewhere, regardless of what happened on any one worker.
+- **Untrusted dev environments.** If contributors run their own local sessions in environments you don't control (shared infra, varied tooling, contractors), a CI-side review is the only review you can rely on.
+- **Audit / regulatory needs.** Some teams need a verifiable status check on every PR — a record outside any one developer's session that an AI reviewer was invoked and what verdict it returned. The workflow's `Code Review` check on the PR is that record.
+
+For solo / single-machine use, the local agent runs in the same session that opens the PR. Skipping it requires deliberately ignoring its output. A CI re-run mostly duplicates work the local agent already did — and bills against `ANTHROPIC_API_KEY` for the privilege.
+
+## The Contract (When You Adopt It)
+
+A repository that opts in is compliant iff it ships a GitHub Actions workflow that:
 
 1. **Triggers on PR lifecycle events:** at minimum `pull_request: types: [opened, synchronize, reopened]`. Workflows that only run on `push` do not satisfy this contract — re-opened PRs, force-pushes, and base-branch retargets must each re-trigger the review.
-2. **Carries the marker comment** `# maverick:code-review` on its own line, anywhere in the file. The marker is the convention that lets `do-maverick-alignment` and the `do-issue-solo`/`do-epic` preconditions identify which workflow file plays the code-review role without parsing GitHub Actions semantics.
+2. **Carries the marker comment** `# maverick:code-review` on its own line, anywhere in the file. The marker is the convention that lets `do-maverick-alignment` identify which workflow file plays the code-review role without parsing GitHub Actions semantics.
 3. **Invokes the agent-code-reviewer contract** — i.e., produces a structured PASS/FAIL verdict and posts it on the PR. The supported invocation is Anthropic's `anthropics/claude-code-action`; teams using their own Maverick worker pipeline or a custom integration are free to substitute as long as the verdict semantics match.
 
 The shipped reference template `code-review.yml` (alongside this `SKILL.md`) is a drop-in starting point that satisfies the contract.
@@ -26,26 +38,28 @@ The fastest path is to copy the shipped template into the project:
 cp "${CLAUDE_PLUGIN_ROOT}/skills/mav-bp-remote-code-review/code-review.yml" .github/workflows/
 ```
 
-Edit it to match the project's secret naming and any environment quirks, commit on a feature branch, and open a PR. The workflow itself will run on its own PR — a useful smoke test that the marker is present and the action invocation works.
+Then, in the repo's GitHub settings:
+
+- **Set the `ANTHROPIC_API_KEY` repository (or organization) secret** so the action can authenticate to Anthropic. An org-level secret scoped to selected repositories is the lowest-friction option if Maverick will run across multiple projects.
+- **Optionally make the workflow a required status check** on the protected branch so PRs cannot merge until it returns green. Without this branch-protection rule the workflow runs but does not block merge — that may or may not be what you want.
+
+Edit `code-review.yml` to match the project's secret naming and any environment quirks, commit on a feature branch, and open a PR. The workflow itself will run on its own PR — a useful smoke test that the marker is present and the action invocation works.
 
 ## Detection Heuristic
 
-When auditing or pre-checking, look for any file under `.github/workflows/` that:
+When auditing, look for any file under `.github/workflows/` that:
 
 - contains the literal string `# maverick:code-review` on a line of its own (after stripping leading whitespace)
 - AND has a `pull_request:` trigger block (presence is sufficient — full validation of the trigger types is out of scope; the marker carries the team's intent)
 
 Either condition alone is not enough. The marker without a `pull_request:` trigger means a misplaced or in-progress workflow; a `pull_request:` trigger without the marker is some other PR workflow (lint, tests, etc.) and is not the code-review gate.
 
-## Failure Modes
+## Audit Behaviour
 
-If the workflow file is missing or malformed:
+`do-maverick-alignment` reports the workflow's presence as informational, not a compliance failure:
 
-- **`do-maverick-alignment`** scores this category FAIL and includes the path to the reference template in its recommendations.
-- **`do-issue-solo` and `do-epic`** abort before opening the PR. The orchestrator must offer two paths to the user: (a) abort and ask the user to add the workflow, or (b) scaffold it from the reference template and continue. There is no silent skip.
-
-## Why It's a Hard Gate
-
-Per the project's binary review contract, the agent code reviewer's verdict is the only signal the auto-merge path trusts. If the gate is local-only, a PR can land via `gh pr merge --auto` without the gate ever running — for example, when a wave of stories is dispatched in parallel and one worktree's local review fails to fire. Putting the review in CI means the merge cannot complete until the workflow has reported back, regardless of what happened on the developer's machine.
+- **Workflow present and well-formed** → PASS, with a note that a CI gate is in place.
+- **Workflow absent** → INFO, noting that the local agent review is the gate by default and pointing to this skill if the project wants the optional CI gate.
+- **Workflow present but malformed** (marker without `pull_request:` trigger, or vice versa) → WARN, since the team's intent is unclear.
 
 <!-- maverick-plugin-version: 2.0.0 -->

--- a/skills/mav-bp-remote-code-review/code-review.yml
+++ b/skills/mav-bp-remote-code-review/code-review.yml
@@ -25,6 +25,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write  # required by anthropics/claude-code-action@v1 (OIDC)
 
 concurrency:
   group: code-review-${{ github.event.pull_request.number }}

--- a/skills/mav-github-issue-workflow/SKILL.md
+++ b/skills/mav-github-issue-workflow/SKILL.md
@@ -103,10 +103,19 @@ gh issue view $ISSUE_NUMBER --json comments -q '.comments | length'
 
 Use one comment per artifact (design, plan, completion). Capture the comment ID so it can be updated later.
 
+### Identity
+
+Maverick-generated comments — design, plan, tasks, completion, PR-review verdicts, and updates to any of those — are posted **as the Maverick GitHub App** so they are visually distinct from the human user's edits. Use `uv run maverick gh-app gh -- <args>` for any write that produces a comment. Plain `gh` is fine for **read** operations (`gh issue view`, `gh api ... --jq '.body'`).
+
+**Failure modes — do not silently switch identity mid-workflow:**
+
+- *App not configured* — `uv run maverick gh-app gh ...` exits with code `4` and a `GitHub App not configured` message. For solo / ad-hoc single-machine use this is acceptable; fall back to plain `gh issue comment ...` (the comment will be authored by the human user). The fallback only applies to the entire session, not per-call: if the App is configured, every comment goes through it.
+- *App configured but missing `issues:write` or `pull_requests:write`* — the underlying `gh` call fails with HTTP 403. This is a **setup error**, not a runtime fallback. Stop the workflow and tell the user to grant the permission via the GitHub App settings, then re-run. Do not retry as the human user.
+
 ### Post and Capture ID
 
 ```bash
-COMMENT_URL=$(gh issue comment $ISSUE_NUMBER --body "$(cat <<'EOF'
+COMMENT_URL=$(uv run maverick gh-app gh -- issue comment $ISSUE_NUMBER --body "$(cat <<'EOF'
 ## Section Title
 
 Content here
@@ -133,7 +142,7 @@ jq ".comments.design = $COMMENT_ID" .claude/issue-state.json > .claude/issue-sta
 ### Post Design Comment
 
 ```bash
-COMMENT_URL=$(gh issue comment $ISSUE_NUMBER --body "$(cat <<'DESIGN_EOF'
+COMMENT_URL=$(uv run maverick gh-app gh -- issue comment $ISSUE_NUMBER --body "$(cat <<'DESIGN_EOF'
 ## Solution Design
 
 ### Approach
@@ -160,7 +169,7 @@ jq ".comments.design = $COMMENT_ID | .phase = \"design\"" .claude/issue-state.js
 ### Post Plan Comment
 
 ```bash
-COMMENT_URL=$(gh issue comment $ISSUE_NUMBER --body "$(cat <<'PLAN_EOF'
+COMMENT_URL=$(uv run maverick gh-app gh -- issue comment $ISSUE_NUMBER --body "$(cat <<'PLAN_EOF'
 ## Implementation Plan
 
 1. **Step name**
@@ -187,7 +196,7 @@ jq ".comments.plan = $COMMENT_ID | .phase = \"plan\"" .claude/issue-state.json >
 ```bash
 BRANCH=$(jq -r '.branch' .claude/issue-state.json)
 
-COMMENT_URL=$(gh issue comment $ISSUE_NUMBER --body "$(cat <<DONE_EOF
+COMMENT_URL=$(uv run maverick gh-app gh -- issue comment $ISSUE_NUMBER --body "$(cat <<DONE_EOF
 ## Implementation Complete
 
 **Branch:** \`$BRANCH\`
@@ -216,7 +225,7 @@ When a design or plan is revised, update the existing comment instead of posting
 REPO=$(jq -r '.repo' .claude/issue-state.json)
 COMMENT_ID=$(jq -r '.comments.design' .claude/issue-state.json)
 
-gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
+uv run maverick gh-app gh -- api "repos/$REPO/issues/comments/$COMMENT_ID" \
   -X PATCH \
   -f body="$(cat <<'EOF'
 ## Solution Design (Revised)
@@ -228,6 +237,8 @@ gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
 EOF
 )"
 ```
+
+The update goes through the same App identity as the original post, so the comment author stays consistent across edits.
 
 ## Branching
 

--- a/skills/mav-plan-execution/SKILL.md
+++ b/skills/mav-plan-execution/SKILL.md
@@ -108,8 +108,10 @@ REPO=$(jq -r '.repo' .claude/issue-state.json)
 COMMENT_ID=$(jq -r '.comments.tasks' .claude/issue-state.json)
 
 CURRENT_BODY=$(gh api "repos/$REPO/issues/comments/$COMMENT_ID" --jq '.body')
-# Update the checkbox for the completed task
-gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
+# Update the checkbox for the completed task — write goes through the App
+# identity so the comment's edit history matches its original author (see
+# mav-github-issue-workflow for the full identity rule).
+uv run maverick gh-app gh -- api "repos/$REPO/issues/comments/$COMMENT_ID" \
   -X PATCH \
   -f body="$UPDATED_BODY"
 ```

--- a/src/maverick/gh_app.py
+++ b/src/maverick/gh_app.py
@@ -1,13 +1,25 @@
 """GitHub App authentication — mints installation access tokens.
 
 The Maverick GitHub App (commonly installed as `maverick-bot`) is the identity
-Maverick uses for the actions that must not appear as the human user:
+Maverick uses for everything it generates on GitHub, so AI-authored content
+is visually distinct from edits the human user actually wrote:
 
-- `gh pr review --approve` on PRs the agent-code-reviewer approved
-- `gh pr merge --auto --squash` so auto-merge fires on the App's approval
+- Issue and PR comments: design, plan, tasks list, completion, PR-review verdict
+  (and any updates to those — the App identity is the author across the
+  comment's lifetime).
+- `gh pr review --approve` on PRs the agent-code-reviewer approved.
+- `gh pr merge --auto --squash` so auto-merge fires on the App's approval.
 - `maverick-state`, `maverick-lease`, `maverick-claim`, `maverick-dag`,
   `maverick-bprop` marker comments (so App-authored workflow state is
-  visually distinct from human edits)
+  visually distinct from human edits).
+
+The PR itself is still created by the human user — the bot's job is to
+approve, comment, and merge, which preserves the GitHub-imposed rule that
+a PR cannot be approved by its author.
+
+Required App permissions: `issues: write`, `pull_requests: write`,
+`metadata: read`. Read-only operations (`gh issue view`, `gh api ... -q`)
+go through plain `gh` and do not need the App identity.
 
 Configuration lives in `~/.maverick/config.json`:
 
@@ -24,8 +36,14 @@ The legacy `bot` block name is still accepted for backward compatibility
 should use `gh_app`.
 
 If the section is absent or the pem cannot be read, the helpers raise
-GhAppNotConfigured. Callers should handle that as "fall back to the
-human user" when the action doesn't actually need the App identity.
+GhAppNotConfigured. Two distinct failure modes for callers:
+
+- *App not configured at all* (`GhAppNotConfigured`) — single-machine
+  ad-hoc use is still supported; callers may fall back to plain `gh`
+  (the comment will be authored by the logged-in human user).
+- *App configured but a write fails with HTTP 403* — a missing permission
+  on the App. This is a setup error, not a runtime fallback: surface it
+  and stop, do not retry as the human user mid-workflow.
 """
 
 from __future__ import annotations

--- a/src/maverick/preflight.py
+++ b/src/maverick/preflight.py
@@ -56,16 +56,16 @@ PREREQS: dict[str, Prereqs] = {
         runtime=("gh_app_configured",),
     ),
     "do-issue-solo": Prereqs(
-        flags=("init", "code_review_workflow"),
+        flags=("init",),
         tools=("gh", "git", "uv"),
         runtime=("gh_app_configured",),
     ),
     "do-issue-guided": Prereqs(
-        flags=("init", "code_review_workflow"),
+        flags=("init",),
         tools=("gh", "git", "uv"),
     ),
     "do-epic": Prereqs(
-        flags=("init", "code_review_workflow"),
+        flags=("init",),
         tools=("gh", "git", "uv"),
         runtime=("gh_app_configured", "worktrees_enabled"),
     ),
@@ -110,10 +110,12 @@ FLAG_REMEDIATION: dict[str, str] = {
     "upskill": "Run /maverick:do-upskill",
     "tech_docs_scaffolded": "Run /maverick:do-docs",
     "code_review_workflow": (
-        "Run /maverick:do-init (it scaffolds the workflow), or copy "
+        "Optional CI gate — local agent-code-reviewer runs by default. "
+        "If you want the remote workflow as well, copy "
         "${CLAUDE_PLUGIN_ROOT}/skills/mav-bp-remote-code-review/code-review.yml "
-        "into .github/workflows/, commit it, then "
-        "`maverick integration set code_review_workflow true`"
+        "into .github/workflows/, set the ANTHROPIC_API_KEY secret, then "
+        "`maverick integration set code_review_workflow true`. See "
+        "mav-bp-remote-code-review for when the gate is worth adopting."
     ),
     "cybersecurity_reviewed": "Run /maverick:do-cybersecurity-review",
 }

--- a/src/maverick/skills/do-epic/body.md.j2
+++ b/src/maverick/skills/do-epic/body.md.j2
@@ -16,13 +16,16 @@ Run this **first**. If it exits non-zero, halt and report the stderr output to t
 uv run maverick preflight do-epic
 ```
 
-The check verifies: the project is initialised, the mandatory remote
-code-review workflow is in place, the Maverick GitHub App is configured
-(`maverick gh-app status` reports `configured: true`), git worktrees
-are usable, and required tools (`gh`, `git`, `uv`) are on PATH. If the code-review-workflow flag is false, offer to scaffold from
-`${CLAUDE_PLUGIN_ROOT}/skills/mav-bp-remote-code-review/code-review.yml`
-on a small setup PR; after that PR merges, run `uv run maverick
-integration set code_review_workflow true` and re-run preflight.
+The check verifies: the project is initialised, the Maverick GitHub
+App is configured (`maverick gh-app status` reports `configured: true`),
+git worktrees are usable, and required tools (`gh`, `git`, `uv`) are on
+PATH. PR code review runs locally inside each story's worktree as the
+`{{ AGENTS.AGENT_CODE_REVIEWER }}` subagent (delegated from
+`{{ SKILLS.DO_ISSUE_SOLO }}` Phase 9). For epics that fan out across
+many parallel workers, consider opting into the CI-side re-run
+described in `{{ SKILLS.MAV_BP_REMOTE_CODE_REVIEW }}` so the merge is
+gated by an independent check even if a worker's local review fails to
+fire — that workflow is optional and not enforced by preflight.
 
 ## Before You Begin
 

--- a/src/maverick/skills/do-init/body.md.j2
+++ b/src/maverick/skills/do-init/body.md.j2
@@ -1,7 +1,7 @@
 
 # Init Maverick Project
 
-Set up the current repository for Maverick — install the CLI if needed, validate the Maverick GitHub App, write the project-level config, scaffold docs and project skills, scaffold the mandatory remote code-review workflow, run the cybersecurity audit, then commit everything and open a pull request for the user to approve.
+Set up the current repository for Maverick — install the CLI if needed, validate the Maverick GitHub App, write the project-level config, scaffold docs and project skills, run the cybersecurity audit, then commit everything and open a pull request for the user to approve.
 
 ## Dispatch
 
@@ -90,30 +90,11 @@ Dispatch **/maverick:{{ SKILLS.DO_DOCS }}**. The greenfield mode of that skill f
 
 Dispatch **/maverick:{{ SKILLS.DO_UPSKILL }}**. It iterates every topic in `topics.json` and writes per-topic skills under `docs/maverick/skills/`, then flips `integration.upskill` to `true`.
 
-### 7. Scaffold the remote code-review workflow
-
-The mandatory remote code-review GitHub Actions workflow (described in `{{ SKILLS.MAV_BP_REMOTE_CODE_REVIEW }}`) must exist before `do-issue-solo` or `do-epic` can run. Detect whether the project already has one:
-
-```bash
-grep -lR '^# maverick:code-review$' .github/workflows/ 2>/dev/null
-```
-
-- **If any file is found**, the contract is already satisfied — log "code-review workflow already present" and run `uv run maverick integration set code_review_workflow true` so future preflights agree, then skip the rest of this step. Do not overwrite an existing custom workflow.
-- **If no file is found**, copy the reference template into place:
-
-  ```bash
-  mkdir -p .github/workflows
-  cp "${CLAUDE_PLUGIN_ROOT}/skills/mav-bp-remote-code-review/code-review.yml" .github/workflows/code-review.yml
-  uv run maverick integration set code_review_workflow true
-  ```
-
-The workflow needs the `ANTHROPIC_API_KEY` repository secret to run — call this out in the final report so the user knows to set it before merging the PR.
-
-### 8. Run the cybersecurity review
+### 7. Run the cybersecurity review
 
 Dispatch **/maverick:{{ SKILLS.DO_CYBERSECURITY_REVIEW }}**. It scans the existing codebase for common security risks (secrets, dependency vulnerabilities, auth/input-validation patterns), writes findings to `docs/security-audit.md`, and flips `integration.cybersecurity_reviewed` to `true`. The review is surface-only — it reports, it does not modify code. Any FAIL findings should be tracked as follow-up issues by the user.
 
-### 9. Commit changes and open a pull request
+### 8. Commit changes and open a pull request
 
 The earlier steps wrote a number of new and modified files. Commit them on a fresh branch and open a PR for the user to approve.
 
@@ -122,7 +103,6 @@ The earlier steps wrote a number of new and modified files. Commit them on a fre
    - `docs/maverick/skills/...` (from `do-upskill`)
    - `docs/...` content created by `do-docs` greenfield
    - `docs/security-audit.md` (from `do-cybersecurity-review`)
-   - `.github/workflows/code-review.yml` (from step 7, when newly scaffolded)
 
    If `git status` shows changes outside these paths, **abort and report to the user** — they have unrelated uncommitted work that should be handled first.
 
@@ -136,7 +116,6 @@ The earlier steps wrote a number of new and modified files. Commit them on a fre
    ```bash
    git checkout -b chore/maverick-init
    git add .maverick/
-   [ -f .github/workflows/code-review.yml ] && git add .github/workflows/code-review.yml
    [ -d docs/maverick ] && git add docs/maverick/
    [ -f docs/security-audit.md ] && git add docs/security-audit.md
    # Stage anything else under docs/ that do-docs greenfield created.
@@ -163,11 +142,7 @@ The earlier steps wrote a number of new and modified files. Commit them on a fre
    - `.maverick/` — project config and integration tracking
    - `docs/maverick/skills/` — generated project-specific skills
    - `docs/security-audit.md` — initial cybersecurity audit findings (review FAIL items)
-   - `.github/workflows/code-review.yml` — mandatory remote code-review workflow (only when newly scaffolded)
    - Other `docs/` content scaffolded by `do-docs`
-
-   ### Required setup before merging
-   - Set the `ANTHROPIC_API_KEY` repository secret in this repo's GitHub Actions secrets so the code-review workflow can run.
 
    ### Verify after merge
    ```bash
@@ -179,16 +154,16 @@ The earlier steps wrote a number of new and modified files. Commit them on a fre
 
 6. Capture the PR URL from the `gh pr create` output and pass it through to the report in the next step.
 
-### 10. Report
+### 9. Report
 
 Print a final summary to the user:
 
 - Detected modules (from step 3's output)
 - Whether docs were scaffolded greenfield or already existed
 - How many project skills were generated
-- Whether the code-review workflow was newly scaffolded or already present
 - The number of security-audit findings at each severity, and the path to the audit report
 - The current integration state: `uv run maverick integration get`
-- The PR URL from step 9 — and a one-line reminder to set `ANTHROPIC_API_KEY` before merging
+- The PR URL from step 8
+- A one-line note that PR code review now runs locally as the `agent-code-reviewer` subagent during `do-issue-solo` / `do-epic`. If the project later wants the optional CI-side gate (multi-machine workflows, untrusted environments, audit needs), point the user at `{{ SKILLS.MAV_BP_REMOTE_CODE_REVIEW }}` for the manual scaffold steps.
 
 The integration checklist gives the user (and any future Maverick session) a clear view of what's been completed and what's still pending.

--- a/src/maverick/skills/do-init/config.py
+++ b/src/maverick/skills/do-init/config.py
@@ -5,7 +5,6 @@ from maverick.names import (
     DO_INIT,
     DO_INSTALL,
     DO_UPSKILL,
-    MAV_BP_REMOTE_CODE_REVIEW,
 )
 
 CONFIG = SkillConfig(
@@ -13,9 +12,8 @@ CONFIG = SkillConfig(
     description=(
         "Initialise a project for use with Maverick — verifies the GitHub App,"
         " installs the CLI if needed, writes the project config with integration"
-        " tracking, scaffolds docs, generates project skills, scaffolds the"
-        " mandatory remote code-review workflow, runs an initial cybersecurity"
-        " audit, then commits the changes and opens a PR."
+        " tracking, scaffolds docs, generates project skills, runs an initial"
+        " cybersecurity audit, then commits the changes and opens a PR."
     ),
     user_invocable=True,
     disable_model_invocation=True,
@@ -24,6 +22,5 @@ CONFIG = SkillConfig(
         DO_DOCS,
         DO_UPSKILL,
         DO_CYBERSECURITY_REVIEW,
-        MAV_BP_REMOTE_CODE_REVIEW,
     ],
 )

--- a/src/maverick/skills/do-issue-guided/body.md.j2
+++ b/src/maverick/skills/do-issue-guided/body.md.j2
@@ -13,7 +13,7 @@ Run this **first**. If it exits non-zero, halt and report the stderr output to t
 uv run maverick preflight do-issue-guided
 ```
 
-The check verifies the project is initialised, the mandatory remote code-review workflow is in place, and required tools (`gh`, `git`, `uv`) are on PATH.
+The check verifies the project is initialised and required tools (`gh`, `git`, `uv`) are on PATH. PR code review runs locally as the `{{ AGENTS.AGENT_CODE_REVIEWER }}` subagent (see Phase 6); the optional CI-side re-run described in `{{ SKILLS.MAV_BP_REMOTE_CODE_REVIEW }}` is not required.
 
 ## Before You Begin
 

--- a/src/maverick/skills/do-issue-solo/body.md.j2
+++ b/src/maverick/skills/do-issue-solo/body.md.j2
@@ -18,10 +18,9 @@ do not work around missing prerequisites.
 uv run maverick preflight do-issue-solo
 ```
 
-The check verifies: the project is initialised, the mandatory remote
-code-review workflow is in place, the Maverick GitHub App is configured
-(`maverick gh-app status` reports `configured: true`), and required
-tools (`gh`, `git`, `uv`) are on PATH.
+The check verifies: the project is initialised, the Maverick GitHub
+App is configured (`maverick gh-app status` reports `configured: true`),
+and required tools (`gh`, `git`, `uv`) are on PATH.
 
 ## Before You Begin
 
@@ -31,17 +30,13 @@ for the issue number before proceeding.
 Determine the repo (via `gh repo view --json nameWithOwner`) — you will
 pass it to every `maverick coord` command below.
 
-If preflight reported a missing `code_review_workflow` flag, offer the
-user two paths before claiming the issue:
-
-1. **Scaffold the reference workflow.** Copy
-   `${CLAUDE_PLUGIN_ROOT}/skills/mav-bp-remote-code-review/code-review.yml`
-   into `.github/workflows/`, commit it on a small setup branch, open a
-   PR for it, and wait for the user to merge that PR before continuing
-   with `{{ ARGUMENTS }}`. After the workflow merges, run
-   `uv run maverick integration set code_review_workflow true` and
-   re-run `uv run maverick preflight do-issue-solo`.
-2. **Abort.** If the user declines, stop here.
+PR code review runs locally during Phase 9 as the
+`{{ AGENTS.AGENT_CODE_REVIEWER }}` subagent — its binary PASS/FAIL
+verdict is the gate. Some projects also opt into a CI-side re-run via
+`{{ SKILLS.MAV_BP_REMOTE_CODE_REVIEW }}` (independent verification for
+multi-machine fleets or audit needs); when present it adds a status
+check the auto-merge in Phase 10 will wait on, but its absence is not
+a blocker.
 
 ## Phase 0: Coordination + cold-start
 
@@ -218,8 +213,9 @@ changes (callers, importers, dependents) must be reviewed by
 
 ## Phase 9: Code Review (binary, hard gate)
 
-This phase has changed. Review is now a **binary verdict** against the
-open PR, not a local-diff advisory loop. See `{{ AGENTS.AGENT_CODE_REVIEWER }}`.
+The local **{{ AGENTS.AGENT_CODE_REVIEWER }}** subagent's verdict is the
+review gate the auto-merge path trusts. This is a binary verdict against
+the open PR, not a local-diff advisory loop.
 
 1. Dispatch **{{ AGENTS.AGENT_CODE_REVIEWER }}** with:
    - The PR URL
@@ -243,8 +239,12 @@ next step is eject-to-human, not iterate.
    ```bash
    uv run maverick gh-app gh -- pr merge <pr-url> --auto --squash
    ```
-   If CI was already green, GitHub merges immediately. Otherwise it
-   merges when CI passes.
+   The merge waits on whatever required status checks the project's
+   branch protection enforces — typically lint, tests, build, and (if
+   the optional `{{ SKILLS.MAV_BP_REMOTE_CODE_REVIEW }}` workflow is
+   adopted) the CI-side re-run of agent-code-reviewer. If all required
+   checks were already green, GitHub merges immediately; otherwise it
+   merges when they pass.
 3. Post the completion comment on the issue per
    `{{ SKILLS.MAV_GITHUB_ISSUE_WORKFLOW }}`.
 4. Update phase to `complete` in the state file.

--- a/src/maverick/skills/do-issue-solo/body.md.j2
+++ b/src/maverick/skills/do-issue-solo/body.md.j2
@@ -255,9 +255,10 @@ next step is eject-to-human, not iterate.
 
 ## Phase 11: Eject (on FAIL)
 
-1. Post the reviewer's verdict as a PR comment:
+1. Post the reviewer's verdict as a PR comment (App identity, per
+   `{{ SKILLS.MAV_GITHUB_ISSUE_WORKFLOW }}`):
    ```bash
-   gh pr comment <pr-url> --body-file /tmp/review-verdict.md
+   uv run maverick gh-app gh -- pr comment <pr-url> --body-file /tmp/review-verdict.md
    ```
 2. Apply the `needs-human` label to both the PR and the issue:
    ```bash

--- a/src/maverick/skills/do-maverick-alignment/body.md.j2
+++ b/src/maverick/skills/do-maverick-alignment/body.md.j2
@@ -162,9 +162,9 @@ Record the evidence (file paths, dependency names, snippets) for each finding.
 
 **Additional detail:** Note which CI/CD platform is used and what steps the pipeline runs.
 
-### 6. Remote Code Review Workflow
+### 6. Remote Code Review Workflow (Optional CI Gate)
 
-Per {{ SKILLS.MAV_BP_REMOTE_CODE_REVIEW }}, every project must ship a GitHub Actions workflow that runs the agent code reviewer on every pull request. Local subagent review is not enough — the remote workflow is the gate the auto-merge path trusts.
+Per {{ SKILLS.MAV_BP_REMOTE_CODE_REVIEW }}, the remote workflow is an **optional** CI-side re-run of the local `agent-code-reviewer`. By default, the local subagent's verdict (run during `do-issue-solo` Phase 9) is the gate the auto-merge path trusts. Some projects opt into the remote workflow for an independent CI check — multi-machine fleets, untrusted dev environments, regulatory audit trails — but its absence is not a compliance failure.
 
 **Search for:**
 
@@ -178,11 +178,11 @@ Per {{ SKILLS.MAV_BP_REMOTE_CODE_REVIEW }}, every project must ship a GitHub Act
 
 | Status | Criteria |
 | --- | --- |
-| PASS | A workflow file under `.github/workflows/` contains the `# maverick:code-review` marker AND has an `on: pull_request:` trigger |
-| WARN | A workflow with the marker exists but is missing the `pull_request` trigger, OR a `pull_request`-triggered workflow exists but no marker (likely a different review pipeline that needs the marker added) |
-| FAIL | No workflow under `.github/workflows/` contains the marker |
+| PASS | A workflow file under `.github/workflows/` contains the `# maverick:code-review` marker AND has an `on: pull_request:` trigger — the project has opted into the CI-side gate and the wiring looks right |
+| WARN | A workflow with the marker exists but is missing the `pull_request` trigger, OR a `pull_request`-triggered workflow exists but no marker (likely a different review pipeline that needs the marker added) — the team's intent is unclear |
+| INFO | No workflow under `.github/workflows/` contains the marker — the project is on the local-review default. Note this in the report and move on; do not flag it as a finding |
 
-**Recommendation on WARN/FAIL:** copy the reference template shipped with the plugin: `${CLAUDE_PLUGIN_ROOT}/skills/mav-bp-remote-code-review/code-review.yml` -> `.github/workflows/code-review.yml`. Set the `ANTHROPIC_API_KEY` repo secret. Open a PR — the workflow itself will run on its own PR as a smoke test.
+**Recommendation on WARN:** fix the marker / trigger so the workflow's role is unambiguous. **Recommendation on INFO:** none required. If the team later decides they want the optional CI gate, point them at `{{ SKILLS.MAV_BP_REMOTE_CODE_REVIEW }}` for the manual scaffold steps and the `ANTHROPIC_API_KEY` setup.
 
 ### 7. Source Control
 

--- a/src/maverick/skills/mav-bp-remote-code-review/body.md.j2
+++ b/src/maverick/skills/mav-bp-remote-code-review/body.md.j2
@@ -1,14 +1,26 @@
 
-# Remote Code Review
+# Remote Code Review (Optional CI Gate)
 
-Code review is mandatory and must run remotely in CI on every pull request — not only as a Claude Code subagent dispatched from a developer's session. Local subagent review is fast and useful, but it can be skipped or tampered with. The remote workflow is the gate that catches reviews that didn't happen locally.
+Maverick runs PR code review locally by default — `{{ AGENTS.AGENT_CODE_REVIEWER }}` is dispatched as a subagent during `do-issue-solo` Phase 9 (and equivalent in `do-issue-guided` / `do-epic`) and produces the binary PASS/FAIL verdict that the auto-merge path trusts. The local agent's verdict is the gate.
 
-## The Contract
+This skill describes an **optional** GitHub Actions workflow that re-runs the same agent in CI. Adding it to a project gives you an independent CI-side check on every PR, at the cost of paid Anthropic API tokens for each run and a bit of setup. It is not required, and `do-init` does not scaffold it — projects that want it adopt it deliberately.
 
-A repository is compliant with this skill iff it ships a GitHub Actions workflow that:
+## When to Add the Remote Gate
+
+The remote workflow is worth the setup and the per-PR API spend when one or more of these apply:
+
+- **Multi-machine / fleet operation.** When `do-epic` dispatches a wave of stories across worktrees in parallel, a single worktree's local review can fail to fire (process crash, network blip, agent skipped). A CI gate guarantees the merge cannot complete without a review having run somewhere, regardless of what happened on any one worker.
+- **Untrusted dev environments.** If contributors run their own local sessions in environments you don't control (shared infra, varied tooling, contractors), a CI-side review is the only review you can rely on.
+- **Audit / regulatory needs.** Some teams need a verifiable status check on every PR — a record outside any one developer's session that an AI reviewer was invoked and what verdict it returned. The workflow's `Code Review` check on the PR is that record.
+
+For solo / single-machine use, the local agent runs in the same session that opens the PR. Skipping it requires deliberately ignoring its output. A CI re-run mostly duplicates work the local agent already did — and bills against `ANTHROPIC_API_KEY` for the privilege.
+
+## The Contract (When You Adopt It)
+
+A repository that opts in is compliant iff it ships a GitHub Actions workflow that:
 
 1. **Triggers on PR lifecycle events:** at minimum `pull_request: types: [opened, synchronize, reopened]`. Workflows that only run on `push` do not satisfy this contract — re-opened PRs, force-pushes, and base-branch retargets must each re-trigger the review.
-2. **Carries the marker comment** `# maverick:code-review` on its own line, anywhere in the file. The marker is the convention that lets `do-maverick-alignment` and the `do-issue-solo`/`do-epic` preconditions identify which workflow file plays the code-review role without parsing GitHub Actions semantics.
+2. **Carries the marker comment** `# maverick:code-review` on its own line, anywhere in the file. The marker is the convention that lets `do-maverick-alignment` identify which workflow file plays the code-review role without parsing GitHub Actions semantics.
 3. **Invokes the {{ AGENTS.AGENT_CODE_REVIEWER }} contract** — i.e., produces a structured PASS/FAIL verdict and posts it on the PR. The supported invocation is Anthropic's `anthropics/claude-code-action`; teams using their own Maverick worker pipeline or a custom integration are free to substitute as long as the verdict semantics match.
 
 The shipped reference template `code-review.yml` (alongside this `SKILL.md`) is a drop-in starting point that satisfies the contract.
@@ -21,24 +33,26 @@ The fastest path is to copy the shipped template into the project:
 cp "${CLAUDE_PLUGIN_ROOT}/skills/mav-bp-remote-code-review/code-review.yml" .github/workflows/
 ```
 
-Edit it to match the project's secret naming and any environment quirks, commit on a feature branch, and open a PR. The workflow itself will run on its own PR — a useful smoke test that the marker is present and the action invocation works.
+Then, in the repo's GitHub settings:
+
+- **Set the `ANTHROPIC_API_KEY` repository (or organization) secret** so the action can authenticate to Anthropic. An org-level secret scoped to selected repositories is the lowest-friction option if Maverick will run across multiple projects.
+- **Optionally make the workflow a required status check** on the protected branch so PRs cannot merge until it returns green. Without this branch-protection rule the workflow runs but does not block merge — that may or may not be what you want.
+
+Edit `code-review.yml` to match the project's secret naming and any environment quirks, commit on a feature branch, and open a PR. The workflow itself will run on its own PR — a useful smoke test that the marker is present and the action invocation works.
 
 ## Detection Heuristic
 
-When auditing or pre-checking, look for any file under `.github/workflows/` that:
+When auditing, look for any file under `.github/workflows/` that:
 
 - contains the literal string `# maverick:code-review` on a line of its own (after stripping leading whitespace)
 - AND has a `pull_request:` trigger block (presence is sufficient — full validation of the trigger types is out of scope; the marker carries the team's intent)
 
 Either condition alone is not enough. The marker without a `pull_request:` trigger means a misplaced or in-progress workflow; a `pull_request:` trigger without the marker is some other PR workflow (lint, tests, etc.) and is not the code-review gate.
 
-## Failure Modes
+## Audit Behaviour
 
-If the workflow file is missing or malformed:
+`{{ SKILLS.DO_MAVERICK_ALIGNMENT }}` reports the workflow's presence as informational, not a compliance failure:
 
-- **`do-maverick-alignment`** scores this category FAIL and includes the path to the reference template in its recommendations.
-- **`do-issue-solo` and `do-epic`** abort before opening the PR. The orchestrator must offer two paths to the user: (a) abort and ask the user to add the workflow, or (b) scaffold it from the reference template and continue. There is no silent skip.
-
-## Why It's a Hard Gate
-
-Per the project's binary review contract, the agent code reviewer's verdict is the only signal the auto-merge path trusts. If the gate is local-only, a PR can land via `gh pr merge --auto` without the gate ever running — for example, when a wave of stories is dispatched in parallel and one worktree's local review fails to fire. Putting the review in CI means the merge cannot complete until the workflow has reported back, regardless of what happened on the developer's machine.
+- **Workflow present and well-formed** → PASS, with a note that a CI gate is in place.
+- **Workflow absent** → INFO, noting that the local agent review is the gate by default and pointing to this skill if the project wants the optional CI gate.
+- **Workflow present but malformed** (marker without `pull_request:` trigger, or vice versa) → WARN, since the team's intent is unclear.

--- a/src/maverick/skills/mav-bp-remote-code-review/code-review.yml
+++ b/src/maverick/skills/mav-bp-remote-code-review/code-review.yml
@@ -25,6 +25,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write  # required by anthropics/claude-code-action@v1 (OIDC)
 
 concurrency:
   group: code-review-${{ github.event.pull_request.number }}

--- a/src/maverick/skills/mav-github-issue-workflow/body.md.j2
+++ b/src/maverick/skills/mav-github-issue-workflow/body.md.j2
@@ -98,10 +98,19 @@ gh issue view $ISSUE_NUMBER --json comments -q '.comments | length'
 
 Use one comment per artifact (design, plan, completion). Capture the comment ID so it can be updated later.
 
+### Identity
+
+Maverick-generated comments — design, plan, tasks, completion, PR-review verdicts, and updates to any of those — are posted **as the Maverick GitHub App** so they are visually distinct from the human user's edits. Use `uv run maverick gh-app gh -- <args>` for any write that produces a comment. Plain `gh` is fine for **read** operations (`gh issue view`, `gh api ... --jq '.body'`).
+
+**Failure modes — do not silently switch identity mid-workflow:**
+
+- *App not configured* — `uv run maverick gh-app gh ...` exits with code `4` and a `GitHub App not configured` message. For solo / ad-hoc single-machine use this is acceptable; fall back to plain `gh issue comment ...` (the comment will be authored by the human user). The fallback only applies to the entire session, not per-call: if the App is configured, every comment goes through it.
+- *App configured but missing `issues:write` or `pull_requests:write`* — the underlying `gh` call fails with HTTP 403. This is a **setup error**, not a runtime fallback. Stop the workflow and tell the user to grant the permission via the GitHub App settings, then re-run. Do not retry as the human user.
+
 ### Post and Capture ID
 
 ```bash
-COMMENT_URL=$(gh issue comment $ISSUE_NUMBER --body "$(cat <<'EOF'
+COMMENT_URL=$(uv run maverick gh-app gh -- issue comment $ISSUE_NUMBER --body "$(cat <<'EOF'
 ## Section Title
 
 Content here
@@ -128,7 +137,7 @@ jq ".comments.design = $COMMENT_ID" .claude/issue-state.json > .claude/issue-sta
 ### Post Design Comment
 
 ```bash
-COMMENT_URL=$(gh issue comment $ISSUE_NUMBER --body "$(cat <<'DESIGN_EOF'
+COMMENT_URL=$(uv run maverick gh-app gh -- issue comment $ISSUE_NUMBER --body "$(cat <<'DESIGN_EOF'
 ## Solution Design
 
 ### Approach
@@ -155,7 +164,7 @@ jq ".comments.design = $COMMENT_ID | .phase = \"design\"" .claude/issue-state.js
 ### Post Plan Comment
 
 ```bash
-COMMENT_URL=$(gh issue comment $ISSUE_NUMBER --body "$(cat <<'PLAN_EOF'
+COMMENT_URL=$(uv run maverick gh-app gh -- issue comment $ISSUE_NUMBER --body "$(cat <<'PLAN_EOF'
 ## Implementation Plan
 
 1. **Step name**
@@ -182,7 +191,7 @@ jq ".comments.plan = $COMMENT_ID | .phase = \"plan\"" .claude/issue-state.json >
 ```bash
 BRANCH=$(jq -r '.branch' .claude/issue-state.json)
 
-COMMENT_URL=$(gh issue comment $ISSUE_NUMBER --body "$(cat <<DONE_EOF
+COMMENT_URL=$(uv run maverick gh-app gh -- issue comment $ISSUE_NUMBER --body "$(cat <<DONE_EOF
 ## Implementation Complete
 
 **Branch:** \`$BRANCH\`
@@ -211,7 +220,7 @@ When a design or plan is revised, update the existing comment instead of posting
 REPO=$(jq -r '.repo' .claude/issue-state.json)
 COMMENT_ID=$(jq -r '.comments.design' .claude/issue-state.json)
 
-gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
+uv run maverick gh-app gh -- api "repos/$REPO/issues/comments/$COMMENT_ID" \
   -X PATCH \
   -f body="$(cat <<'EOF'
 ## Solution Design (Revised)
@@ -223,6 +232,8 @@ gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
 EOF
 )"
 ```
+
+The update goes through the same App identity as the original post, so the comment author stays consistent across edits.
 
 ## Branching
 

--- a/src/maverick/skills/mav-plan-execution/body.md.j2
+++ b/src/maverick/skills/mav-plan-execution/body.md.j2
@@ -103,8 +103,10 @@ REPO=$(jq -r '.repo' .claude/issue-state.json)
 COMMENT_ID=$(jq -r '.comments.tasks' .claude/issue-state.json)
 
 CURRENT_BODY=$(gh api "repos/$REPO/issues/comments/$COMMENT_ID" --jq '.body')
-# Update the checkbox for the completed task
-gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
+# Update the checkbox for the completed task — write goes through the App
+# identity so the comment's edit history matches its original author (see
+# {{ SKILLS.MAV_GITHUB_ISSUE_WORKFLOW }} for the full identity rule).
+uv run maverick gh-app gh -- api "repos/$REPO/issues/comments/$COMMENT_ID" \
   -X PATCH \
   -f body="$UPDATED_BODY"
 ```

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -191,14 +191,21 @@ class TestRenderHuman:
         assert "init" in text
 
     def test_missing_flag_includes_remediation(self):
-        """Each missing flag is rendered with its FLAG_REMEDIATION entry."""
+        """Each missing flag is rendered with its FLAG_REMEDIATION entry.
+
+        code_review_workflow is no longer a hard prereq for any skill, but
+        the remediation entry still has to exist (TestPrereqsTableConsistency
+        enforces that), and it must read sensibly when surfaced.
+        """
         result = preflight.PreflightResult(
             skill="do-issue-solo",
             missing_flags=["code_review_workflow"],
         )
         text = preflight.render_human(result)
         assert "code_review_workflow" in text
-        assert "do-init" in text  # remediation suggests running /maverick:do-init
+        # New remediation text points users at the optional-gate skill rather
+        # than do-init, since do-init no longer scaffolds the workflow.
+        assert "code-review.yml" in text
 
     def test_missing_flag_with_no_remediation_falls_back(self, monkeypatch):
         """Defensive: a flag without an entry doesn't crash render."""


### PR DESCRIPTION
## Summary

Three related ergonomics changes for fresh-machine / fresh-repo Maverick setup, after observing that on a clean install the workflows hit two friction points (mid-workflow prompts about the bot lacking issues:write, and the cloud code-review workflow missing `id-token: write` + `ANTHROPIC_API_KEY`):

- **Bot identity for comments** (`feat: post Maverick-generated comments as the GitHub App identity`) — issue/PR comments (design, plan, tasks, completion, PR-review verdict, and updates to those) now route through `uv run maverick gh-app gh -- ...` so they're authored by the Maverick GitHub App instead of the human user. Reads stay as plain `gh`; PR creation stays as the human user so the "PR author cannot self-approve" rule that auto-merge depends on still holds. Two failure modes are documented so the LLM doesn't switch identity mid-workflow: App-not-configured falls back to plain `gh` (single-machine ad-hoc), App-configured-with-403 stops as a setup error.
- **Workflow template fix** (`fix: add id-token: write to code-review workflow template`) — `anthropics/claude-code-action@v1` needs OIDC even in API-key mode; without it, the first PR opened against a freshly initialised project failed the mandatory code-review gate.
- **Local PR review becomes the default** (`feat: make remote code review optional; local review is the gate`) — the local `agent-code-reviewer` subagent's verdict is now the binding review gate. The cloud `code-review.yml` workflow demotes to optional: `do-init` no longer scaffolds it, preflight no longer requires the `code_review_workflow` flag, and `do-maverick-alignment` treats absence as INFO rather than FAIL. Auto-merge still waits on remaining required CI checks (lint/tests/build) via branch protection — only the AI-review gate moves local. The reference template stays in place as an opt-in for teams that want a CI gate (multi-machine fleets, untrusted environments, audit needs).

Required App permissions for the new comment-author flow: `issues: write`, `pull_requests: write`, `metadata: read`. Existing Apps created under the older PR-approval-only scope need these granted before the change takes effect.

## Test plan

- [x] `make build` regenerates skills/agents cleanly.
- [x] `uv run pytest tests/unit/` — all 337 tests pass (including updated `test_missing_flag_includes_remediation`).
- [ ] On a repo without `.github/workflows/code-review.yml`: `uv run maverick preflight do-issue-solo` should now succeed (was failing before).
- [ ] `uv run maverick init --dry-run` on a fresh project: no Step-7 scaffolding fires, no `code-review.yml` written.
- [ ] End-to-end on a test repo without the workflow: local `agent-code-reviewer` PASS triggers bot approval; `gh pr merge --auto --squash` waits for project's other CI (lint/tests) but not for any AI-review check; merge completes once CI is green.
- [ ] Open a PR via `do-issue-solo` end-to-end and confirm the design / tasks / completion comments appear authored by the Maverick GitHub App, not the human user.
- [ ] On the in-flight remote repo: delete `.github/workflows/code-review.yml` and confirm subsequent PRs merge without needing `ANTHROPIC_API_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)