### PR TITLE
fix: import order + pre-push hook to catch parallel-merge breakage

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Pre-push: run the same fast checks CI runs, fail-fast before bytes hit
+# origin. Lint + typecheck + tests + build-sync. Total budget ~5s.
+#
+# Skip in genuine emergencies with `git push --no-verify` — but if you're
+# reaching for that flag, the better answer is almost always to fix the
+# failure.
+set -euo pipefail
+
+# Run from the repo root regardless of where git invoked the hook.
+cd "$(git rev-parse --show-toplevel)"
+
+echo "==> pre-push: lint"
+make lint
+
+echo "==> pre-push: typecheck"
+make typecheck
+
+echo "==> pre-push: tests"
+make test
+
+echo "==> pre-push: build sync"
+make build > /dev/null
+if ! git diff --exit-code --quiet -- skills/ agents/ docs/skills/ hooks/ infra/; then
+    echo
+    echo "ERROR: 'make build' produced uncommitted changes — generated"
+    echo "output is out of sync with src/. Run 'make build', commit the"
+    echo "result, and re-push."
+    git diff --stat -- skills/ agents/ docs/skills/ hooks/ infra/
+    exit 1
+fi
+
+echo "==> pre-push: all checks passed"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,11 @@ claude --plugin-dir ./maverick-plugin
 bash tests/integration/test_cli.sh
 bash tests/integration/test_real_repos.sh
 
+# Wire up local git hooks (one-time per clone). Installs:
+#   - pre-commit: auto-rebuilds skills/agents when src/ templates change
+#   - pre-push:   runs `make lint typecheck test` + build-sync check
+make install-hooks
+
 # Create a release (two-phase: local prep + CI finalize)
 # Phase 1 — run locally from the main branch:
 ./scripts/release.sh patch   # or: minor, major

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: generate generate-topics build release lint format typecheck test infra
+.PHONY: generate generate-topics build release lint format typecheck test infra install-hooks
+
+install-hooks: ## Wire the .githooks/ directory into this clone (one-time setup)
+	git config core.hooksPath .githooks
+	@echo "Hooks installed. pre-commit auto-rebuilds on src/ edits; pre-push runs lint+typecheck+tests+build-sync."
 
 lint: ## Run ruff linter
 	uv run ruff check .

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import json
 from argparse import Namespace
 from pathlib import Path
-from unittest.mock import patch
-
 from subprocess import CompletedProcess
+from unittest.mock import patch
 
 from maverick import preflight, preflight_cli
 


### PR DESCRIPTION
## Summary

- **Lint fix**: `tests/unit/test_preflight.py` had an out-of-order import after PR #29 and PR #30 merged in parallel — `from subprocess import CompletedProcess` ended up between the stdlib block and the local-package block, breaking `ruff I001`. Moved into the stdlib group.
- **Pre-push hook**: tracked at `.githooks/pre-push`, runs `make lint`, `make typecheck`, `make test`, then `make build` with a check that no generated output is left uncommitted. Total budget ~5s.
- **Wire-up target**: `make install-hooks` sets `git config core.hooksPath .githooks` — a one-time setup per clone. `CLAUDE.md` mentions it under Build & Run Commands.

The PR itself was the first end-to-end exercise of the new hook: the `git push` for this branch ran lint, typecheck, 340 tests, and the build-sync check before bytes hit origin.

## Test plan

- [x] `make lint` clean locally.
- [x] `make typecheck` clean locally.
- [x] `make test` — 340 passed.
- [x] `make install-hooks` wires `core.hooksPath` correctly (verified via `git config --get core.hooksPath`).
- [x] Pre-push hook fired on this branch's `git push` and all four stages reported PASS.
- [ ] CI passes lint / typecheck / test / build-check / install-smoke jobs.
- [ ] Deliberately break something on a throwaway branch and confirm `git push` is blocked by the hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)