### PR TITLE
fix: persist instance_id across CLI invocations (#34)

### DIFF
--- a/src/maverick/coordinator.py
+++ b/src/maverick/coordinator.py
@@ -28,6 +28,7 @@ import subprocess
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any
 
 from maverick.gh_state import (
@@ -87,12 +88,47 @@ def _parse_iso(ts: str) -> datetime | None:
         return None
 
 
+def _instance_id_path() -> Path:
+    """Where the per-user instance id is persisted between CLI invocations."""
+    return Path("~/.maverick/instance_id").expanduser()
+
+
 def instance_id() -> str:
-    """Short, unique id for this Maverick instance. Stable within a session."""
+    """Short, unique id for this Maverick instance.
+
+    Stable across separate CLI invocations on the same machine: persisted to
+    ``~/.maverick/instance_id`` and reused on subsequent calls. Without
+    persistence, harnesses that exec the CLI per call (Claude Code's Bash
+    tool, CI step runners, etc.) see a fresh id every invocation, which
+    breaks heartbeat / claim-retry — every call looks like a different
+    instance.
+
+    Resolution order:
+    1. ``MAVERICK_INSTANCE_ID`` env var — explicit override, wins.
+    2. Cached file at ``~/.maverick/instance_id`` — created on first call.
+    3. Fresh random id — generated, written to the file.
+    """
     cached = os.environ.get("MAVERICK_INSTANCE_ID")
     if cached:
         return cached
+    path = _instance_id_path()
+    try:
+        value = path.read_text().strip()
+        if value:
+            os.environ["MAVERICK_INSTANCE_ID"] = value
+            return value
+    except OSError:
+        # Missing file, unreadable parent, etc — fall through and generate.
+        pass
     value = uuid.uuid4().hex[:10]
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(value)
+    except OSError:
+        # Persistence failed (read-only home, sandbox, parent is a file).
+        # Fall back to env-only caching so the value is at least stable
+        # within this process.
+        pass
     os.environ["MAVERICK_INSTANCE_ID"] = value
     return value
 

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -12,16 +12,69 @@ from maverick import coordinator
 
 
 class TestInstanceId:
-    def test_stable_within_session(self, monkeypatch):
+    def test_stable_within_session(self, monkeypatch, tmp_path):
         monkeypatch.delenv("MAVERICK_INSTANCE_ID", raising=False)
+        monkeypatch.setattr(
+            coordinator, "_instance_id_path", lambda: tmp_path / "instance_id"
+        )
         a = coordinator.instance_id()
         b = coordinator.instance_id()
         assert a == b
         assert len(a) == 10
 
-    def test_respects_env_override(self, monkeypatch):
+    def test_respects_env_override(self, monkeypatch, tmp_path):
         monkeypatch.setenv("MAVERICK_INSTANCE_ID", "explicit-id")
+        monkeypatch.setattr(
+            coordinator, "_instance_id_path", lambda: tmp_path / "instance_id"
+        )
         assert coordinator.instance_id() == "explicit-id"
+
+    def test_persists_across_processes(self, monkeypatch, tmp_path):
+        """First call writes the id to disk; a fresh process (env cleared)
+        reads the same id back. This is what protects heartbeat and
+        claim-retry under per-call subprocess harnesses like Claude Code.
+        """
+        path = tmp_path / "instance_id"
+        monkeypatch.setattr(coordinator, "_instance_id_path", lambda: path)
+
+        # First "process": no env var, no file — generate and persist.
+        monkeypatch.delenv("MAVERICK_INSTANCE_ID", raising=False)
+        first = coordinator.instance_id()
+        assert path.read_text() == first
+
+        # Second "process": env var cleared, file present — read from file.
+        monkeypatch.delenv("MAVERICK_INSTANCE_ID", raising=False)
+        second = coordinator.instance_id()
+        assert second == first
+
+    def test_env_overrides_persisted_file(self, monkeypatch, tmp_path):
+        """An explicit MAVERICK_INSTANCE_ID env var must win over a
+        previously-persisted id, so callers can pin a specific instance
+        for tests or recovery scenarios.
+        """
+        path = tmp_path / "instance_id"
+        path.write_text("file-id")
+        monkeypatch.setattr(coordinator, "_instance_id_path", lambda: path)
+        monkeypatch.setenv("MAVERICK_INSTANCE_ID", "env-id")
+        assert coordinator.instance_id() == "env-id"
+
+    def test_persistence_failure_falls_back_to_env_cache(
+        self, monkeypatch, tmp_path
+    ):
+        """If the persistence path is unwritable, the call still returns a
+        stable id within the current process via env caching — it just
+        won't survive subprocess boundaries on this run.
+        """
+        unwritable = tmp_path / "no-such-dir" / "instance_id"
+        # Force the parent to be a file so mkdir(parents=True) fails.
+        (tmp_path / "no-such-dir").write_text("blocking file")
+        monkeypatch.setattr(coordinator, "_instance_id_path", lambda: unwritable)
+        monkeypatch.delenv("MAVERICK_INSTANCE_ID", raising=False)
+        a = coordinator.instance_id()
+        b = coordinator.instance_id()
+        assert a == b
+        assert len(a) == 10
+        assert not unwritable.exists()
 
 
 class TestBlockLabel:


### PR DESCRIPTION
## Summary

Fixes #34. `coordinator.instance_id()` previously cached the generated id only in `os.environ`, which is per-Python-process. Harnesses that exec the CLI per call (Claude Code's Bash tool, CI step runners) get a fresh id on every invocation, which:

- breaks `coord heartbeat` after `coord claim` (heartbeat sees \"another instance\" — actually the same caller from a previous Bash call),
- triggers spurious \`ClaimRejected\` races on retry (the new claim posts a new id, race-detection sees ≥2 holders, picks lower → loser-aborts even though no other process exists),
- effectively makes \`/do-epic\` and \`/do-issue-solo\` unreliable under Claude Code, since both rely on multiple sequential Bash invocations of \`maverick coord\`.

## Fix

\`instance_id()\` now resolves in this order:

1. \`MAVERICK_INSTANCE_ID\` env var (explicit override — wins).
2. \`~/.maverick/instance_id\` (per-user persistence — created on first call, read on subsequent calls).
3. Generate fresh, write to file, return.

If the persistence path is unwritable (read-only home, sandbox, parent collision), the call falls back to env-only caching so the value is at least stable within the current Python process.

## Test plan

- [x] New unit tests in \`tests/unit/test_coordinator.py::TestInstanceId\`:
  - \`test_persists_across_processes\` — env cleared between calls, file consulted, same id returned (the bug case).
  - \`test_env_overrides_persisted_file\` — explicit env var wins over a previously-persisted id.
  - \`test_persistence_failure_falls_back_to_env_cache\` — unwritable path doesn't crash, env cache still gives stable id within the process.
- [x] Existing \`test_stable_within_session\` and \`test_respects_env_override\` updated to redirect the path via \`monkeypatch.setattr(coordinator, \"_instance_id_path\", ...)\` so they don't pollute the developer's real \`~/.maverick/instance_id\`.
- [x] \`make lint typecheck test\` — all 343 tests pass, ruff clean, pyright clean.
- [x] Pre-push hook (lint + typecheck + test + build-sync) — passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)