### PR TITLE
fix: BSD-compatible sed -i in release.sh

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -125,7 +125,7 @@ git checkout -b "$RELEASE_BRANCH"
 # Step 2: Bump version, update changelog, rebuild
 # =============================================================================
 
-sed -i "s/^version = \"${CURRENT_VERSION}\"/version = \"${NEW_VERSION}\"/" "$PYPROJECT"
+sed -i.bak "s/^version = \"${CURRENT_VERSION}\"/version = \"${NEW_VERSION}\"/" "$PYPROJECT" && rm "${PYPROJECT}.bak"
 python3 "$SCRIPT_DIR/bump_json_versions.py" "$NEW_VERSION"
 python3 "$SCRIPT_DIR/update_changelog.py" "$NEW_VERSION" "$(date +%Y-%m-%d)" "$CURRENT_TAG"
 


### PR DESCRIPTION
## Summary
- macOS BSD sed treats the first argument after `-i` as a backup-file extension, so `sed -i "s/.../"` interprets the sed script as the extension and fails with `extra characters at the end of p command`.
- Switch to `sed -i.bak "..." && rm file.bak`, which works on both BSD (macOS) and GNU sed.

This is the second portability fix in `release.sh` after a prior commit replaced `grep -Po` with `awk`. Encountered while attempting to cut the 2.0.2 release on macOS.

## Test plan
- [ ] After this merges, run `./scripts/release.sh patch` from main on macOS and confirm the version bump succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)