### PR TITLE
fix(cli): four coord/worktree/gh-app papercuts

### DIFF
--- a/src/maverick/coord_cli.py
+++ b/src/maverick/coord_cli.py
@@ -76,8 +76,11 @@ def _coord_release(args: argparse.Namespace) -> int:
 
 
 def _coord_takeover(args: argparse.Namespace) -> int:
+    scope = args.scope.split(",") if args.scope else None
     try:
-        c = coordinator.takeover(args.repo, args.issue)
+        c = coordinator.takeover(
+            args.repo, args.issue, scope=scope, reason=args.reason
+        )
     except coordinator.ClaimRejected as e:
         print(f"takeover rejected: {e}", file=sys.stderr)
         return 2
@@ -175,8 +178,15 @@ def _gh_app_status(args: argparse.Namespace) -> int:
 
 
 def _gh_app_gh(args: argparse.Namespace) -> int:
+    # POSIX "end of options" — argparse.REMAINDER preserves the literal `--`
+    # as the first element. The skill docs (and most users) write
+    # `gh-app gh -- <gh args>` to make the boundary explicit; strip it so
+    # both forms produce the same downstream invocation. (#44)
+    gh_args = list(args.gh_args)
+    if gh_args and gh_args[0] == "--":
+        gh_args = gh_args[1:]
     try:
-        result = gh_app.gh_app_gh(*args.gh_args)
+        result = gh_app.gh_app_gh(*gh_args)
     except gh_app.GhAppNotConfigured as e:
         print(f"GitHub App not configured: {e}", file=sys.stderr)
         return 4
@@ -207,7 +217,11 @@ def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
     coord = subparsers.add_parser("coord", help="Multi-instance claim/lease primitives")
     coord_sub = coord.add_subparsers(dest="coord_cmd", required=True)
 
-    p = coord_sub.add_parser("read", help="Read claim state for an issue")
+    p = coord_sub.add_parser(
+        "read",
+        aliases=["status"],
+        help="Read claim state for an issue (alias: status)",
+    )
     p.add_argument("repo")
     p.add_argument("issue", type=int)
     p.set_defaults(_handler=_coord_read)
@@ -232,6 +246,14 @@ def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
     p = coord_sub.add_parser("takeover", help="Take over a stale lease")
     p.add_argument("repo")
     p.add_argument("issue", type=int)
+    p.add_argument(
+        "--scope",
+        help="Comma-separated issue numbers in scope (mirrors `coord claim`)",
+    )
+    p.add_argument(
+        "--reason",
+        help="Free-form audit-trail note recorded on the takeover marker",
+    )
     p.set_defaults(_handler=_coord_takeover)
 
     # dag
@@ -282,9 +304,18 @@ def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
     p = w_sub.add_parser("list", help="List worktrees")
     p.set_defaults(_handler=_worktree_list)
 
-    p = w_sub.add_parser("destroy", help="Destroy a worktree")
+    p = w_sub.add_parser(
+        "destroy",
+        help="Destroy a worktree (force-removes by default; --no-force to opt out)",
+    )
     p.add_argument("path")
-    p.add_argument("--force", action="store_true")
+    p.add_argument(
+        "--force",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Force-remove dirty worktrees (default). Use --no-force to keep "
+        "the conservative `git worktree remove` behaviour.",
+    )
     p.set_defaults(_handler=_worktree_destroy)
 
     # gh-app

--- a/src/maverick/coordinator.py
+++ b/src/maverick/coordinator.py
@@ -294,13 +294,18 @@ def release(
 def takeover(
     repo: str,
     issue: int,
+    scope: list[str] | None = None,
+    reason: str | None = None,
     env: dict[str, str] | None = None,
 ) -> Claim:
     """Take over a stale lease from a crashed instance.
 
     Posts an explicit takeover comment naming the prior instance, then runs
     the normal claim flow with allow_takeover=True to bypass the live-lease
-    check (it is known stale).
+    check (it is known stale). `scope` is forwarded to the inner claim so a
+    multi-story epic can be taken over and re-scoped in one call rather
+    than forcing N+1 round-trips (#42). `reason` is recorded on the
+    takeover marker for the audit trail.
     """
     state = read_claim_state(repo, issue)
     prior_instance = (state["claim"] or {}).get("instance_id", "unknown")
@@ -312,19 +317,24 @@ def takeover(
         f"<!-- maverick takeover -->\n"
         f"Taking over #{issue} from instance `{prior_instance}` — prior lease stale."
     )
+    if reason:
+        preamble += f"\nReason: {reason}"
+    payload: dict[str, Any] = {
+        "instance_id": instance_id(),
+        "takeover_of": prior_instance,
+        "claimed_at": _now_iso(),
+    }
+    if reason:
+        payload["reason"] = reason
     post_marker(
         repo,
         issue,
         "maverick-claim",
-        {
-            "instance_id": instance_id(),
-            "takeover_of": prior_instance,
-            "claimed_at": _now_iso(),
-        },
+        payload,
         preamble=preamble,
         env=env,
     )
-    return claim(repo, issue, env=env, allow_takeover=True)
+    return claim(repo, issue, scope=scope, env=env, allow_takeover=True)
 
 
 def format_lease_summary(lease_payload: dict[str, Any] | None) -> str:

--- a/src/maverick/worktree.py
+++ b/src/maverick/worktree.py
@@ -67,9 +67,12 @@ def create(branch: str, base: str | None = None) -> Worktree:
     return Worktree(path=path, branch=branch, head=head)
 
 
-def destroy(path: Path, force: bool = False) -> None:
-    """Remove a worktree. Use `force=True` only if a clean removal fails
-    because the working tree is dirty."""
+def destroy(path: Path, force: bool = True) -> None:
+    """Remove a worktree. Force-removes by default (#45) — the only documented
+    caller is post-merge cleanup, by which point any uncommitted state in
+    the worktree is by definition not part of the merged change. Pass
+    `force=False` for the rare case where dirty-state preservation matters.
+    """
     root = repo_root()
     args = ["worktree", "remove", str(path)]
     if force:

--- a/tests/unit/test_coord_cli.py
+++ b/tests/unit/test_coord_cli.py
@@ -1,0 +1,244 @@
+"""Argparse-level tests for the coord/worktree/gh-app CLI surface.
+
+Covers the small papercut fixes from Wave 2 (#42, #43, #44, #45):
+the `coord status` alias, the `gh-app gh -- <args>` separator handling,
+the `worktree destroy --force` default, and the `coord takeover`
+--scope/--reason flags. Handlers are stubbed so we can assert what
+arguments would have been forwarded without hitting the network.
+"""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import MagicMock
+
+import pytest
+
+from maverick import coord_cli
+
+
+def _parse(*argv: str) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    coord_cli.build_subparsers(sub)
+    return parser.parse_args(list(argv))
+
+
+class TestCoordStatusAlias:
+    """#43: `coord status` is an alias for `coord read`."""
+
+    def test_status_dispatches_to_read_handler(self):
+        args = _parse("coord", "status", "owner/repo", "42")
+        assert args._handler is coord_cli._coord_read
+        assert args.repo == "owner/repo"
+        assert args.issue == 42
+
+    def test_read_still_works(self):
+        args = _parse("coord", "read", "owner/repo", "42")
+        assert args._handler is coord_cli._coord_read
+
+
+class TestGhAppGhSeparator:
+    """#44: `gh-app gh -- <args>` and `gh-app gh <args>` produce the same
+    downstream `gh` invocation. argparse.REMAINDER captures the literal
+    `--` as the first element, so the handler must strip it."""
+
+    def test_strips_leading_double_dash(self, monkeypatch):
+        captured: dict = {}
+
+        def fake_gh_app_gh(*args):
+            captured["args"] = args
+            r = MagicMock()
+            r.stdout = ""
+            r.stderr = ""
+            r.returncode = 0
+            return r
+
+        monkeypatch.setattr(coord_cli.gh_app, "gh_app_gh", fake_gh_app_gh)
+        args = _parse("gh-app", "gh", "--", "issue", "comment", "42", "--body", "hi")
+
+        coord_cli._gh_app_gh(args)
+
+        assert captured["args"] == ("issue", "comment", "42", "--body", "hi")
+
+    def test_without_double_dash_unchanged(self, monkeypatch):
+        captured: dict = {}
+
+        def fake_gh_app_gh(*args):
+            captured["args"] = args
+            r = MagicMock()
+            r.stdout = ""
+            r.stderr = ""
+            r.returncode = 0
+            return r
+
+        monkeypatch.setattr(coord_cli.gh_app, "gh_app_gh", fake_gh_app_gh)
+        args = _parse("gh-app", "gh", "issue", "comment", "42", "--body", "hi")
+
+        coord_cli._gh_app_gh(args)
+
+        assert captured["args"] == ("issue", "comment", "42", "--body", "hi")
+
+    def test_only_first_double_dash_stripped(self, monkeypatch):
+        """A `--` deeper in the arg list (e.g. as a value) must NOT be stripped."""
+        captured: dict = {}
+
+        def fake_gh_app_gh(*args):
+            captured["args"] = args
+            r = MagicMock()
+            r.stdout = ""
+            r.stderr = ""
+            r.returncode = 0
+            return r
+
+        monkeypatch.setattr(coord_cli.gh_app, "gh_app_gh", fake_gh_app_gh)
+        args = _parse("gh-app", "gh", "--", "api", "--", "/repos/x/y")
+
+        coord_cli._gh_app_gh(args)
+
+        assert captured["args"] == ("api", "--", "/repos/x/y")
+
+
+class TestWorktreeDestroyForce:
+    """#45: destroy is force-by-default; --no-force opts out."""
+
+    def test_force_default_true(self):
+        args = _parse("worktree", "destroy", ".maverick/worktrees/foo")
+        assert args.force is True
+
+    def test_no_force_opts_out(self):
+        args = _parse("worktree", "destroy", "--no-force", ".maverick/worktrees/foo")
+        assert args.force is False
+
+    def test_explicit_force_still_accepted(self):
+        args = _parse("worktree", "destroy", "--force", ".maverick/worktrees/foo")
+        assert args.force is True
+
+
+class TestCoordTakeoverFlags:
+    """#42: takeover accepts --scope (CSV) and --reason (audit-trail note)."""
+
+    def test_takeover_accepts_scope_and_reason(self):
+        args = _parse(
+            "coord",
+            "takeover",
+            "owner/repo",
+            "3",
+            "--scope",
+            "3,28,30,32",
+            "--reason",
+            "previous lease expired 2026-05-01T12:34:11Z",
+        )
+        assert args.repo == "owner/repo"
+        assert args.issue == 3
+        assert args.scope == "3,28,30,32"
+        assert args.reason == "previous lease expired 2026-05-01T12:34:11Z"
+
+    def test_takeover_flags_are_optional(self):
+        args = _parse("coord", "takeover", "owner/repo", "3")
+        assert args.scope is None
+        assert args.reason is None
+
+    def test_handler_forwards_scope_and_reason(self, monkeypatch):
+        """The handler splits scope on commas and forwards both flags to
+        coordinator.takeover()."""
+        captured: dict = {}
+
+        class FakeClaim:
+            def to_payload(self):
+                return {"ok": True}
+
+        def fake_takeover(repo, issue, *, scope=None, reason=None):
+            captured["repo"] = repo
+            captured["issue"] = issue
+            captured["scope"] = scope
+            captured["reason"] = reason
+            return FakeClaim()
+
+        monkeypatch.setattr(coord_cli.coordinator, "takeover", fake_takeover)
+        args = _parse(
+            "coord", "takeover", "owner/repo", "3",
+            "--scope", "3,28,30",
+            "--reason", "stale",
+        )
+
+        rc = coord_cli._coord_takeover(args)
+
+        assert rc == 0
+        assert captured == {
+            "repo": "owner/repo",
+            "issue": 3,
+            "scope": ["3", "28", "30"],
+            "reason": "stale",
+        }
+
+
+class TestCoordTakeoverCoordinatorAPI:
+    """#42 at the library level: coordinator.takeover() must accept and
+    plumb through scope and reason without hitting the network."""
+
+    def test_scope_forwarded_and_reason_recorded(self, monkeypatch):
+        from maverick import coordinator, gh_state
+
+        monkeypatch.setenv("MAVERICK_INSTANCE_ID", "us")
+        # Stale lease, prior holder is 'a-stale'.
+        from datetime import datetime, timedelta, timezone
+        expired = (datetime.now(timezone.utc) - timedelta(hours=1)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        fake_state = {
+            "labels": [coordinator.CLAIM_LABEL],
+            "block_label": None,
+            "in_progress": True,
+            "claim": {"instance_id": "a-stale"},
+            "lease": {"instance_id": "a-stale", "expires_at": expired},
+            "lease_live": False,
+        }
+        monkeypatch.setattr(coordinator, "read_claim_state", lambda *a, **k: fake_state)
+        monkeypatch.setattr(coordinator, "_issue_labels", lambda *a, **k: [])
+        monkeypatch.setattr(coordinator, "latest_marker", lambda *a, **k: None)
+        monkeypatch.setattr(coordinator, "_gh", lambda *a, **k: "")
+        monkeypatch.setattr(coordinator, "upsert_marker", lambda *a, **k: 1)
+        monkeypatch.setattr(
+            gh_state,
+            "find_markers",
+            lambda *a, **k: [
+                gh_state.Marker(
+                    kind="maverick-claim",
+                    payload={"instance_id": "us"},
+                    comment_id=1,
+                    issue_number=3,
+                )
+            ],
+        )
+
+        posted: list[dict] = []
+
+        def fake_post_marker(repo, issue, kind, payload, preamble="", env=None):
+            posted.append({"kind": kind, "payload": payload, "preamble": preamble})
+            return 1
+
+        monkeypatch.setattr(coordinator, "post_marker", fake_post_marker)
+
+        c = coordinator.takeover(
+            "me/r", 3, scope=["3", "28", "30"], reason="prior lease expired"
+        )
+
+        # scope landed on the resulting claim object via the inner claim() call.
+        assert c.scope == ["3", "28", "30"]
+        # The takeover-marker payload includes reason + takeover_of.
+        takeover_marker = posted[0]
+        assert takeover_marker["payload"]["takeover_of"] == "a-stale"
+        assert takeover_marker["payload"]["reason"] == "prior lease expired"
+        # And the audit-trail preamble carries the reason.
+        assert "prior lease expired" in takeover_marker["preamble"]
+
+
+@pytest.fixture(autouse=True)
+def _no_instance_id_persistence(monkeypatch, tmp_path):
+    """Keep these tests from touching the user's real ~/.maverick/instance_id."""
+    from maverick import coordinator
+
+    monkeypatch.setattr(
+        coordinator, "_instance_id_path", lambda: tmp_path / "instance_id"
+    )


### PR DESCRIPTION
## Summary

Four small, independent fixes bundled in one PR. Each is documented in its own issue.

- **#43** — `coord status` is now an alias for `coord read`. Users (and the docs) write "check coordination status"; the CLI now matches.
- **#44** — `gh-app gh -- <gh args>` no longer fails. argparse.REMAINDER preserves the literal `--` as the first element, so the handler now strips a leading `--` and both forms produce the same downstream invocation. The skill docs (do-epic Phase 2) become correct again.
- **#45** — `worktree destroy` is force-by-default; `--no-force` opts out. The only documented caller is post-merge cleanup, by which point any uncommitted state in the worktree is by definition not part of the merged change.
- **#42** — `coord takeover` accepts `--scope <csv>` and `--reason <text>`, mirroring `coord claim`. Taking over a multi-story epic now needs a single call instead of \`1 × takeover\` + \`N × claim\`. The reason is recorded on the takeover marker payload and the audit-trail preamble.

## Test plan

- [x] \`make lint\` — clean
- [x] \`make typecheck\` — clean
- [x] \`make test\` — 355 passed (12 new in \`tests/unit/test_coord_cli.py\`)
- [x] \`make build\` — no skill/agent edits

Closes #42
Closes #43
Closes #44
Closes #45