### PR TITLE
fix: self-terminating coord heartbeat-loop + explicit post-merge issue close

### DIFF
--- a/skills/do-epic/SKILL.md
+++ b/skills/do-epic/SKILL.md
@@ -57,8 +57,18 @@ a single story, dispatch `do-issue-solo` instead.
 4. **Claim**: `uv run maverick coord claim <repo>  --scope <csv-of-issues>`.
    On `ClaimRejected`, abort and report per
    `mav-multi-instance-coordination`.
-5. **Start heartbeat** for every issue in the claim scope.
-6. **Register release handler** for every exit path.
+5. **Start heartbeat** for every issue in the claim scope. Run the
+   self-terminating foreground loop in the background — it exits cleanly
+   when the matching `coord release` runs at session end, so there is no
+   manual `kill` step:
+   ```bash
+   for issue in <epic> <story1> <story2> …; do
+     uv run maverick coord heartbeat-loop <repo> $issue >/dev/null 2>&1 &
+   done
+   ```
+6. **Register release handler** for every exit path. Run
+   `coord release` for every claimed issue; the matching `heartbeat-loop`
+   detects the cleared label on its next iteration and exits.
 
 ## Phase 1: Design + task decomposition (if needed)
 
@@ -211,7 +221,9 @@ When every story in the wave is terminal (merged or ejected):
 3. Update `maverick-state` one last time.
 4. Release the epic-level claim:
    `uv run maverick coord release <repo>  --reason complete`.
-5. Stop the heartbeat loop.
+5. The `heartbeat-loop` background processes self-terminate within one
+   `--interval` window once their claims are released — `wait` for them
+   if you backgrounded them with PIDs, or just let the parent shell exit.
 6. Close the epic issue only if **no stories were ejected**. If any were
    ejected, leave the epic open for the human to resolve the ejected
    stories and close manually.

--- a/skills/do-issue-solo/SKILL.md
+++ b/skills/do-issue-solo/SKILL.md
@@ -61,8 +61,14 @@ This phase is new in the workflow overhaul. Before any other phase.
    abort.
 3. Start a heartbeat loop that refreshes the lease every
    `HEARTBEAT_INTERVAL_MINUTES` minutes for as long as you hold the
-   claim. If two consecutive heartbeats fail, treat the claim as lost
-   and abort (do not push further work).
+   claim. The CLI provides a self-terminating foreground loop — run it
+   in the background and let it exit on its own when `coord release`
+   clears the claim label:
+   ```bash
+   uv run maverick coord heartbeat-loop <repo>  >/dev/null 2>&1 &
+   ```
+   If two consecutive heartbeats fail, the loop exits non-zero — treat
+   that as claim-lost and abort (do not push further work).
 4. Register a release handler that fires on every exit path (success,
    eject, abort): `uv run maverick coord release <repo>  --reason <reason>`.
 5. Cold-start hydrate per `mav-durability-on-gh`:
@@ -252,11 +258,24 @@ next step is eject-to-human, not iterate.
    adopted) the CI-side re-run of agent-code-reviewer. If all required
    checks were already green, GitHub merges immediately; otherwise it
    merges when they pass.
-3. Post the completion comment on the issue per
+3. **Wait for the merge to land** before continuing — poll
+   `gh pr view <pr-url> --json state -q .state` until it reports
+   `MERGED`. Cleanup steps below assume the PR is no longer in flight.
+4. Post the completion comment on the issue per
    `mav-github-issue-workflow`.
-4. Update phase to `complete` in the state file.
-5. Release the claim: `uv run maverick coord release <repo>  --reason merged`.
-6. Clean up:
+5. **Close the issue.** GitHub's `Closes #N` auto-close only fires when
+   the PR merges to the default branch — projects using a `develop`
+   tracking branch leave the issue OPEN until the next promotion.
+   Always close explicitly so the issue's lifecycle matches the PR's
+   (#46). `gh issue close` on an already-closed issue is a no-op, so
+   this is safe even on default-branch merges:
+   ```bash
+   gh issue close  \
+       --comment "Resolved in PR #<P>; merged to <target-branch>."
+   ```
+6. Update phase to `complete` in the state file.
+7. Release the claim: `uv run maverick coord release <repo>  --reason merged`.
+8. Clean up:
    - Local state file
    - Destroy the worktree: `uv run maverick worktree destroy <worktree-path>`.
 

--- a/src/maverick/coord_cli.py
+++ b/src/maverick/coord_cli.py
@@ -9,8 +9,9 @@ Usage shape:
     uv run maverick coord read     <repo> <issue>
     uv run maverick coord claim    <repo> <issue> [--scope N,N,N]
     uv run maverick coord heartbeat <repo> <issue>
+    uv run maverick coord heartbeat-loop <repo> <issue> [--interval SECS]
     uv run maverick coord release  <repo> <issue> [--reason R]
-    uv run maverick coord takeover <repo> <issue>
+    uv run maverick coord takeover <repo> <issue> [--scope N,N,N] [--reason R]
     uv run maverick dag show       <repo> <epic>
     uv run maverick dag waves      <repo> <epic>
     uv run maverick dag descendants <repo> <epic> <story>
@@ -67,6 +68,12 @@ def _coord_heartbeat(args: argparse.Namespace) -> int:
         return 3
     print("ok")
     return 0
+
+
+def _coord_heartbeat_loop(args: argparse.Namespace) -> int:
+    return coordinator.heartbeat_loop(
+        args.repo, args.issue, interval_seconds=args.interval
+    )
 
 
 def _coord_release(args: argparse.Namespace) -> int:
@@ -232,10 +239,24 @@ def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
     p.add_argument("--scope", help="Comma-separated issue numbers in scope")
     p.set_defaults(_handler=_coord_claim)
 
-    p = coord_sub.add_parser("heartbeat", help="Refresh a lease")
+    p = coord_sub.add_parser("heartbeat", help="Refresh a lease (one shot)")
     p.add_argument("repo")
     p.add_argument("issue", type=int)
     p.set_defaults(_handler=_coord_heartbeat)
+
+    p = coord_sub.add_parser(
+        "heartbeat-loop",
+        help="Refresh the lease in a foreground loop until the claim is released",
+    )
+    p.add_argument("repo")
+    p.add_argument("issue", type=int)
+    p.add_argument(
+        "--interval",
+        type=int,
+        default=coordinator.HEARTBEAT_INTERVAL_MINUTES * 60,
+        help="Seconds between heartbeats (default: HEARTBEAT_INTERVAL_MINUTES * 60)",
+    )
+    p.set_defaults(_handler=_coord_heartbeat_loop)
 
     p = coord_sub.add_parser("release", help="Release a claim")
     p.add_argument("repo")

--- a/src/maverick/coordinator.py
+++ b/src/maverick/coordinator.py
@@ -276,6 +276,51 @@ def heartbeat(repo: str, issue: int, env: dict[str, str] | None = None) -> None:
     _write_lease(repo, issue, env=env)
 
 
+def heartbeat_loop(
+    repo: str,
+    issue: int,
+    interval_seconds: int = HEARTBEAT_INTERVAL_MINUTES * 60,
+    env: dict[str, str] | None = None,
+) -> int:
+    """Run heartbeat in a foreground loop, exiting cleanly when the claim
+    is released or otherwise lost.
+
+    Designed to be backgrounded by a single skill step (e.g. `do-epic`
+    Phase 0) so that the loop owns its own lifecycle: when `coord release`
+    runs at session end the claim label is removed, the next heartbeat
+    raises `ClaimLost`, and this function returns 0 — no separate `kill`
+    step needed (#47).
+
+    Also handles SIGINT/SIGTERM so a parent process killing it gets a
+    clean exit. Sleeps in 1-second slices to keep signals responsive.
+    """
+    import signal
+    import time
+
+    stopping = False
+
+    def _stop(_signum: int, _frame: object | None) -> None:
+        nonlocal stopping
+        stopping = True
+
+    prev_int = signal.signal(signal.SIGINT, _stop)
+    prev_term = signal.signal(signal.SIGTERM, _stop)
+    try:
+        while not stopping:
+            try:
+                heartbeat(repo, issue, env=env)
+            except ClaimLost:
+                return 0
+            slept = 0
+            while slept < interval_seconds and not stopping:
+                time.sleep(1)
+                slept += 1
+        return 0
+    finally:
+        signal.signal(signal.SIGINT, prev_int)
+        signal.signal(signal.SIGTERM, prev_term)
+
+
 def release(
     repo: str,
     issue: int,

--- a/src/maverick/skills/do-epic/body.md.j2
+++ b/src/maverick/skills/do-epic/body.md.j2
@@ -50,8 +50,18 @@ a single story, dispatch `{{ SKILLS.DO_ISSUE_SOLO }}` instead.
 4. **Claim**: `uv run maverick coord claim <repo> {{ ARGUMENTS }} --scope <csv-of-issues>`.
    On `ClaimRejected`, abort and report per
    `{{ SKILLS.MAV_MULTI_INSTANCE_COORDINATION }}`.
-5. **Start heartbeat** for every issue in the claim scope.
-6. **Register release handler** for every exit path.
+5. **Start heartbeat** for every issue in the claim scope. Run the
+   self-terminating foreground loop in the background — it exits cleanly
+   when the matching `coord release` runs at session end, so there is no
+   manual `kill` step:
+   ```bash
+   for issue in <epic> <story1> <story2> …; do
+     uv run maverick coord heartbeat-loop <repo> $issue >/dev/null 2>&1 &
+   done
+   ```
+6. **Register release handler** for every exit path. Run
+   `coord release` for every claimed issue; the matching `heartbeat-loop`
+   detects the cleared label on its next iteration and exits.
 
 ## Phase 1: Design + task decomposition (if needed)
 
@@ -204,7 +214,9 @@ When every story in the wave is terminal (merged or ejected):
 3. Update `maverick-state` one last time.
 4. Release the epic-level claim:
    `uv run maverick coord release <repo> {{ ARGUMENTS }} --reason complete`.
-5. Stop the heartbeat loop.
+5. The `heartbeat-loop` background processes self-terminate within one
+   `--interval` window once their claims are released — `wait` for them
+   if you backgrounded them with PIDs, or just let the parent shell exit.
 6. Close the epic issue only if **no stories were ejected**. If any were
    ejected, leave the epic open for the human to resolve the ejected
    stories and close manually.

--- a/src/maverick/skills/do-issue-solo/body.md.j2
+++ b/src/maverick/skills/do-issue-solo/body.md.j2
@@ -54,8 +54,14 @@ This phase is new in the workflow overhaul. Before any other phase.
    abort.
 3. Start a heartbeat loop that refreshes the lease every
    `HEARTBEAT_INTERVAL_MINUTES` minutes for as long as you hold the
-   claim. If two consecutive heartbeats fail, treat the claim as lost
-   and abort (do not push further work).
+   claim. The CLI provides a self-terminating foreground loop — run it
+   in the background and let it exit on its own when `coord release`
+   clears the claim label:
+   ```bash
+   uv run maverick coord heartbeat-loop <repo> {{ ARGUMENTS }} >/dev/null 2>&1 &
+   ```
+   If two consecutive heartbeats fail, the loop exits non-zero — treat
+   that as claim-lost and abort (do not push further work).
 4. Register a release handler that fires on every exit path (success,
    eject, abort): `uv run maverick coord release <repo> {{ ARGUMENTS }} --reason <reason>`.
 5. Cold-start hydrate per `{{ SKILLS.MAV_DURABILITY_ON_GH }}`:
@@ -245,11 +251,24 @@ next step is eject-to-human, not iterate.
    adopted) the CI-side re-run of agent-code-reviewer. If all required
    checks were already green, GitHub merges immediately; otherwise it
    merges when they pass.
-3. Post the completion comment on the issue per
+3. **Wait for the merge to land** before continuing — poll
+   `gh pr view <pr-url> --json state -q .state` until it reports
+   `MERGED`. Cleanup steps below assume the PR is no longer in flight.
+4. Post the completion comment on the issue per
    `{{ SKILLS.MAV_GITHUB_ISSUE_WORKFLOW }}`.
-4. Update phase to `complete` in the state file.
-5. Release the claim: `uv run maverick coord release <repo> {{ ARGUMENTS }} --reason merged`.
-6. Clean up:
+5. **Close the issue.** GitHub's `Closes #N` auto-close only fires when
+   the PR merges to the default branch — projects using a `develop`
+   tracking branch leave the issue OPEN until the next promotion.
+   Always close explicitly so the issue's lifecycle matches the PR's
+   (#46). `gh issue close` on an already-closed issue is a no-op, so
+   this is safe even on default-branch merges:
+   ```bash
+   gh issue close {{ ARGUMENTS }} \
+       --comment "Resolved in PR #<P>; merged to <target-branch>."
+   ```
+6. Update phase to `complete` in the state file.
+7. Release the claim: `uv run maverick coord release <repo> {{ ARGUMENTS }} --reason merged`.
+8. Clean up:
    - Local state file
    - Destroy the worktree: `uv run maverick worktree destroy <worktree-path>`.
 

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -323,3 +323,84 @@ class TestClaimRaceDetection:
         c = coordinator.takeover("me/r", 3)
 
         assert c.instance_id == "z-takeover"
+
+
+class TestHeartbeatLoop:
+    """#47: foreground loop self-terminates when the claim is released, so
+    skills don't have to track and kill a backgrounded shell loop."""
+
+    def test_exits_when_heartbeat_raises_claim_lost(self, monkeypatch):
+        """Simulates `coord release` clearing the claim label — the next
+        heartbeat raises ClaimLost and the loop returns 0."""
+        calls = {"n": 0}
+
+        def fake_heartbeat(repo, issue, env=None):
+            calls["n"] += 1
+            raise coordinator.ClaimLost("released")
+
+        monkeypatch.setattr(coordinator, "heartbeat", fake_heartbeat)
+        # Ensure no real sleeping happens.
+        monkeypatch.setattr("time.sleep", lambda _s: None)
+
+        rc = coordinator.heartbeat_loop("me/r", 42, interval_seconds=1)
+
+        assert rc == 0
+        assert calls["n"] == 1
+
+    def test_loops_until_claim_lost(self, monkeypatch):
+        """Heartbeats refresh on a live claim; loop exits once heartbeat
+        signals the claim is gone."""
+        results = iter([None, None, coordinator.ClaimLost("gone")])
+
+        def fake_heartbeat(repo, issue, env=None):
+            r = next(results)
+            if isinstance(r, Exception):
+                raise r
+
+        monkeypatch.setattr(coordinator, "heartbeat", fake_heartbeat)
+        monkeypatch.setattr("time.sleep", lambda _s: None)
+
+        rc = coordinator.heartbeat_loop("me/r", 42, interval_seconds=1)
+
+        assert rc == 0
+
+    def test_restores_signal_handlers(self, monkeypatch):
+        """SIGINT/SIGTERM handlers are restored on exit so the loop doesn't
+        leak handler state into the parent process."""
+        import signal
+
+        original_int = signal.getsignal(signal.SIGINT)
+        original_term = signal.getsignal(signal.SIGTERM)
+
+        def fake_heartbeat(repo, issue, env=None):
+            raise coordinator.ClaimLost("done")
+
+        monkeypatch.setattr(coordinator, "heartbeat", fake_heartbeat)
+        monkeypatch.setattr("time.sleep", lambda _s: None)
+
+        coordinator.heartbeat_loop("me/r", 42, interval_seconds=1)
+
+        assert signal.getsignal(signal.SIGINT) == original_int
+        assert signal.getsignal(signal.SIGTERM) == original_term
+
+    def test_cli_handler_forwards_to_loop(self, monkeypatch):
+        """`coord heartbeat-loop` CLI handler delegates to coordinator.heartbeat_loop."""
+        import argparse
+
+        from maverick import coord_cli
+
+        captured: dict = {}
+
+        def fake_loop(repo, issue, *, interval_seconds):
+            captured["repo"] = repo
+            captured["issue"] = issue
+            captured["interval_seconds"] = interval_seconds
+            return 0
+
+        monkeypatch.setattr(coord_cli.coordinator, "heartbeat_loop", fake_loop)
+        args = argparse.Namespace(repo="me/r", issue=7, interval=5)
+
+        rc = coord_cli._coord_heartbeat_loop(args)
+
+        assert rc == 0
+        assert captured == {"repo": "me/r", "issue": 7, "interval_seconds": 5}


### PR DESCRIPTION
## Summary

- **#47** — heartbeat loops were started as backgrounded shell loops the dispatcher had to remember to \`kill\` at session end. If the dispatcher session died (CC crash, terminal closed, OOM), the loop kept running, posting heartbeats to released claims.
  
  Adds \`uv run maverick coord heartbeat-loop <repo> <issue> [--interval SECS]\` — a foreground loop that exits cleanly the instant the matching \`coord release\` clears the claim label (next heartbeat raises \`ClaimLost\`). Skills now background it once and forget about it; no \`kill\` step at the end.

- **#46** — GitHub's \"Closes #N\" auto-close only fires for default-branch merges. Projects using a \`develop\` tracking branch leave child issues OPEN until the next promotion. \`do-issue-solo\` Phase 10 now waits for the merge to land, then calls \`gh issue close\` explicitly with a comment linking the PR. Always-close per option 1 in the issue (idempotent).

## Skill changes

- \`do-epic\` Phase 0 step 5 + Phase 6 step 5: background \`coord heartbeat-loop\`, let it self-terminate.
- \`do-issue-solo\` Phase 0 step 3: same.
- \`do-issue-solo\` Phase 10: insert merge-wait + explicit \`gh issue close\` between auto-merge and cleanup.

## Test plan

- [x] \`make lint\` — clean
- [x] \`make typecheck\` — clean
- [x] \`make test\` — 347 passed (4 new in \`TestHeartbeatLoop\`)
- [x] \`make build\` — skill rendering applied to root \`/skills/\` mirror

Closes #46
Closes #47