### PR TITLE
fix: durable do-issue-solo with checkpoints, existing-PR detection, non-blocking browser verification

### DIFF
--- a/skills/do-issue-solo/SKILL.md
+++ b/skills/do-issue-solo/SKILL.md
@@ -71,11 +71,34 @@ This phase is new in the workflow overhaul. Before any other phase.
    that as claim-lost and abort (do not push further work).
 4. Register a release handler that fires on every exit path (success,
    eject, abort): `uv run maverick coord release <repo>  --reason <reason>`.
-5. Cold-start hydrate per `mav-durability-on-gh`:
-   - Read open PRs: `gh pr list --head <branch> --json number,state`
-   - Read the tasks comment on the issue
-   - Check for an existing worktree for this issue under `.maverick/worktrees/`
-   - If any state exists, resume at the appropriate phase rather than re-doing work.
+5. Cold-start hydrate per `mav-durability-on-gh`. The
+   skill is fully resumable — a fresh agent re-entering after a crash,
+   stop, or context-exhaustion must skip phases that already completed
+   rather than re-running them against an in-flight or merged PR (#41).
+
+   Read **all** of:
+   - `uv run maverick task-progress read <repo> ` — the
+     phase boundary the previous agent last passed.
+   - `gh pr list --head <branch> --json number,state,mergedAt` — open or
+     merged PR for this issue's branch.
+   - The tasks comment on the issue.
+   - Existing worktree for this issue under `.maverick/worktrees/`.
+
+   **Resume rules** (apply the first match, in this order):
+
+   | Observed state | Resume at |
+   |---|---|
+   | PR exists, state=`MERGED` | Phase 10 step 4 (post completion comment, close issue, release claim, destroy worktree) |
+   | PR exists, state=`OPEN`, CI failing | Phase 8 step 4 (fix CI, push) |
+   | PR exists, state=`OPEN`, CI green, no review verdict | Phase 9 (dispatch reviewer) |
+   | PR exists, state=`OPEN`, FAIL verdict on PR | Phase 11 (eject) |
+   | task-progress phase ≥ `branch`, no PR | Phase 5 (continue tasks from last completion) |
+   | task-progress phase = `tasks` | Phase 4 (create worktree + branch) |
+   | task-progress phase = `design` | Phase 3 (create tasks) |
+   | nothing | Phase 1 (start fresh) |
+
+   Each phase below ends with a `task-progress set` write so re-entry can
+   advance one boundary at a time without re-running anything.
 
 ## Phase 1-2: Understand the Issue and Solution Design (subagent)
 
@@ -92,6 +115,7 @@ implementation.
    - `.claude/issue-state.json` has `comments.design` set to a comment ID
 4. If the agent flagged ambiguities it could not resolve, ask the user.
    Otherwise continue.
+5. **Checkpoint**: `uv run maverick task-progress set <repo>  design`.
 
 ## Phase 3: Create Tasks (subagent)
 
@@ -105,6 +129,7 @@ Run Phase 3 as a subagent.
    - If < 5 tasks: `.claude/issue-state.json` has `comments.tasks` set to a comment ID
    - If >= 5 tasks: `.claude/issue-state.json` has `has_sub_issues` set to `true`
 3. If the agent flagged scope concerns, ask the user.
+4. **Checkpoint**: `uv run maverick task-progress set <repo>  tasks`.
 
 ## Phase 4: Create Worktree + Branch
 
@@ -120,6 +145,7 @@ dedicated worktree**, not in the main checkout.
    From this point on, all file edits happen inside the worktree path.
 4. `cd` into the worktree path for the rest of the story.
 5. Update phase to `branch` in the state file.
+6. **Checkpoint**: `uv run maverick task-progress set <repo>  branch`.
 
 ## Phase 5: Execute Tasks (push after every task)
 
@@ -149,6 +175,8 @@ This phase has changed. **Push after every task, not at the end.** See
 
 After the last task, run the full verification suite once more.
 
+**Checkpoint**: `uv run maverick task-progress set <repo>  implement`.
+
 Follow `mav-plan-execution` for the broader execution loop,
 verification discipline, failure handling, and crash recovery.
 
@@ -177,6 +205,7 @@ whether work is needed; the workflow decides whether the agent runs.
    per the push-per-task rule.
 5. The PR cannot proceed to Phase 7 until this phase has produced
    either committed doc changes or the auditable no-op record.
+6. **Checkpoint**: `uv run maverick task-progress set <repo>  docs`.
 
 ## Phase 7: Pre-push Cybersecurity Review (mandatory)
 
@@ -221,8 +250,17 @@ changes (callers, importers, dependents) must be reviewed by
        --title "<conventional title referencing #>" \
        --body "<summary + closes #>"
    ```
-4. Monitor CI per `mav-bp-cicd`. If CI fails, read logs, fix
+4. **Checkpoint**: `uv run maverick task-progress set <repo>  pr_open`.
+5. Monitor CI per `mav-bp-cicd`. If CI fails, read logs, fix
    locally, push. Do not proceed to Phase 9 until CI is green.
+6. **Browser/UI verification is non-blocking.** If the change touches UI
+   and Claude's global instructions or a project skill ask for browser
+   verification, run it with a strict timeout (e.g. 5 min total). On
+   hang, timeout, or failure, post the outcome as a non-blocking PR
+   comment and proceed to Phase 9 — do **not** wait indefinitely (#41).
+   Phase 9's reviewer is the binding gate; CI is the binding regression
+   check; ad-hoc browser runs are advisory.
+7. **Checkpoint**: `uv run maverick task-progress set <repo>  ci_green`.
 
 ## Phase 9: Code Review (binary, hard gate)
 
@@ -237,6 +275,7 @@ the open PR, not a local-diff advisory loop.
    - **PASS** — proceed to Phase 10 (merge).
    - **FAIL** — proceed to Phase 11 (eject). Do not attempt to auto-fix.
 3. Update phase to `review` in the state file.
+4. **Checkpoint**: `uv run maverick task-progress set <repo>  review`.
 
 There is no fix-and-re-review loop. If the reviewer FAILs the PR, the
 next step is eject-to-human, not iterate.
@@ -261,9 +300,10 @@ next step is eject-to-human, not iterate.
 3. **Wait for the merge to land** before continuing — poll
    `gh pr view <pr-url> --json state -q .state` until it reports
    `MERGED`. Cleanup steps below assume the PR is no longer in flight.
-4. Post the completion comment on the issue per
+4. **Checkpoint**: `uv run maverick task-progress set <repo>  merged`.
+5. Post the completion comment on the issue per
    `mav-github-issue-workflow`.
-5. **Close the issue.** GitHub's `Closes #N` auto-close only fires when
+6. **Close the issue.** GitHub's `Closes #N` auto-close only fires when
    the PR merges to the default branch — projects using a `develop`
    tracking branch leave the issue OPEN until the next promotion.
    Always close explicitly so the issue's lifecycle matches the PR's
@@ -273,11 +313,12 @@ next step is eject-to-human, not iterate.
    gh issue close  \
        --comment "Resolved in PR #<P>; merged to <target-branch>."
    ```
-6. Update phase to `complete` in the state file.
-7. Release the claim: `uv run maverick coord release <repo>  --reason merged`.
-8. Clean up:
+7. Update phase to `complete` in the state file.
+8. Release the claim: `uv run maverick coord release <repo>  --reason merged`.
+9. Clean up:
    - Local state file
    - Destroy the worktree: `uv run maverick worktree destroy <worktree-path>`.
+10. **Checkpoint**: `uv run maverick task-progress set <repo>  complete`.
 
 ## Phase 11: Eject (on FAIL)
 

--- a/src/maverick/coord_cli.py
+++ b/src/maverick/coord_cli.py
@@ -22,6 +22,8 @@ Usage shape:
     uv run maverick worktree destroy <path>
     uv run maverick gh-app status
     uv run maverick gh-app gh -- <gh args…>
+    uv run maverick task-progress read <repo> <issue>
+    uv run maverick task-progress set  <repo> <issue> <phase>
 """
 
 from __future__ import annotations
@@ -214,6 +216,40 @@ def _gh_state_read(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# task-progress (#41)
+# ---------------------------------------------------------------------------
+
+
+def _task_progress_read(args: argparse.Namespace) -> int:
+    """Print the latest do-issue-solo phase checkpoint for an issue."""
+    m = gh_state.latest_marker(args.repo, args.issue, "maverick-task-progress")
+    _json_print(m.payload if m else None)
+    return 0
+
+
+def _task_progress_set(args: argparse.Namespace) -> int:
+    """Upsert the do-issue-solo phase checkpoint marker. Always rolls one
+    marker per issue, so re-entering instances see the latest phase rather
+    than a paginated history."""
+    from datetime import datetime, timezone
+
+    payload = {
+        "phase": args.phase,
+        "instance_id": coordinator.instance_id(),
+        "updated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    gh_state.upsert_marker(
+        args.repo,
+        args.issue,
+        "maverick-task-progress",
+        payload,
+        preamble="<!-- maverick task-progress -->",
+    )
+    _json_print(payload)
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # wiring
 # ---------------------------------------------------------------------------
 
@@ -361,15 +397,31 @@ def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
     p.add_argument("issue", type=int)
     p.add_argument(
         "kind",
-        choices=[
-            "maverick-dag",
-            "maverick-state",
-            "maverick-claim",
-            "maverick-lease",
-            "maverick-bprop",
-        ],
+        choices=list(gh_state.MARKER_KINDS),
     )
     p.set_defaults(_handler=_gh_state_read)
+
+    # task-progress — per-issue do-issue-solo phase checkpoint (#41)
+    tp = subparsers.add_parser(
+        "task-progress",
+        help="Read or update the do-issue-solo phase checkpoint for an issue",
+    )
+    tp_sub = tp.add_subparsers(dest="tp_cmd", required=True)
+
+    p = tp_sub.add_parser("read", help="Print the latest task-progress marker")
+    p.add_argument("repo")
+    p.add_argument("issue", type=int)
+    p.set_defaults(_handler=_task_progress_read)
+
+    p = tp_sub.add_parser("set", help="Upsert the task-progress marker")
+    p.add_argument("repo")
+    p.add_argument("issue", type=int)
+    p.add_argument(
+        "phase",
+        choices=list(gh_state.TASK_PROGRESS_PHASES),
+        help="The do-issue-solo phase boundary just completed",
+    )
+    p.set_defaults(_handler=_task_progress_set)
 
 
 def dispatch(args: argparse.Namespace) -> int:

--- a/src/maverick/gh_state.py
+++ b/src/maverick/gh_state.py
@@ -11,6 +11,8 @@ Marker kinds (see docs/conventions/github-markers.md):
 - maverick-claim: atomic claim record on a claimed issue
 - maverick-lease: heartbeat lease record on a claimed issue
 - maverick-bprop: block-propagation in-flight marker on the epic issue
+- maverick-task-progress: per-issue do-issue-solo phase checkpoint, so
+  a fresh agent re-entering can resume from N+1 instead of restarting (#41)
 
 Each marker is a fenced code block with a kind-specific language tag, e.g.:
 
@@ -33,6 +35,25 @@ MARKER_KINDS = (
     "maverick-claim",
     "maverick-lease",
     "maverick-bprop",
+    "maverick-task-progress",
+)
+
+# Phase names that may appear in a maverick-task-progress payload's `phase`
+# field. The list mirrors do-issue-solo's phase boundaries; agents resume
+# from the next phase after the recorded one (#41).
+TASK_PROGRESS_PHASES = (
+    "claimed",
+    "design",
+    "tasks",
+    "branch",
+    "implement",
+    "docs",
+    "security",
+    "pr_open",
+    "ci_green",
+    "review",
+    "merged",
+    "complete",
 )
 
 

--- a/src/maverick/skills/do-issue-solo/body.md.j2
+++ b/src/maverick/skills/do-issue-solo/body.md.j2
@@ -64,11 +64,34 @@ This phase is new in the workflow overhaul. Before any other phase.
    that as claim-lost and abort (do not push further work).
 4. Register a release handler that fires on every exit path (success,
    eject, abort): `uv run maverick coord release <repo> {{ ARGUMENTS }} --reason <reason>`.
-5. Cold-start hydrate per `{{ SKILLS.MAV_DURABILITY_ON_GH }}`:
-   - Read open PRs: `gh pr list --head <branch> --json number,state`
-   - Read the tasks comment on the issue
-   - Check for an existing worktree for this issue under `.maverick/worktrees/`
-   - If any state exists, resume at the appropriate phase rather than re-doing work.
+5. Cold-start hydrate per `{{ SKILLS.MAV_DURABILITY_ON_GH }}`. The
+   skill is fully resumable — a fresh agent re-entering after a crash,
+   stop, or context-exhaustion must skip phases that already completed
+   rather than re-running them against an in-flight or merged PR (#41).
+
+   Read **all** of:
+   - `uv run maverick task-progress read <repo> {{ ARGUMENTS }}` — the
+     phase boundary the previous agent last passed.
+   - `gh pr list --head <branch> --json number,state,mergedAt` — open or
+     merged PR for this issue's branch.
+   - The tasks comment on the issue.
+   - Existing worktree for this issue under `.maverick/worktrees/`.
+
+   **Resume rules** (apply the first match, in this order):
+
+   | Observed state | Resume at |
+   |---|---|
+   | PR exists, state=`MERGED` | Phase 10 step 4 (post completion comment, close issue, release claim, destroy worktree) |
+   | PR exists, state=`OPEN`, CI failing | Phase 8 step 4 (fix CI, push) |
+   | PR exists, state=`OPEN`, CI green, no review verdict | Phase 9 (dispatch reviewer) |
+   | PR exists, state=`OPEN`, FAIL verdict on PR | Phase 11 (eject) |
+   | task-progress phase ≥ `branch`, no PR | Phase 5 (continue tasks from last completion) |
+   | task-progress phase = `tasks` | Phase 4 (create worktree + branch) |
+   | task-progress phase = `design` | Phase 3 (create tasks) |
+   | nothing | Phase 1 (start fresh) |
+
+   Each phase below ends with a `task-progress set` write so re-entry can
+   advance one boundary at a time without re-running anything.
 
 ## Phase 1-2: Understand the Issue and Solution Design (subagent)
 
@@ -85,6 +108,7 @@ implementation.
    - `.claude/issue-state.json` has `comments.design` set to a comment ID
 4. If the agent flagged ambiguities it could not resolve, ask the user.
    Otherwise continue.
+5. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} design`.
 
 ## Phase 3: Create Tasks (subagent)
 
@@ -98,6 +122,7 @@ Run Phase 3 as a subagent.
    - If < 5 tasks: `.claude/issue-state.json` has `comments.tasks` set to a comment ID
    - If >= 5 tasks: `.claude/issue-state.json` has `has_sub_issues` set to `true`
 3. If the agent flagged scope concerns, ask the user.
+4. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} tasks`.
 
 ## Phase 4: Create Worktree + Branch
 
@@ -113,6 +138,7 @@ dedicated worktree**, not in the main checkout.
    From this point on, all file edits happen inside the worktree path.
 4. `cd` into the worktree path for the rest of the story.
 5. Update phase to `branch` in the state file.
+6. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} branch`.
 
 ## Phase 5: Execute Tasks (push after every task)
 
@@ -142,6 +168,8 @@ This phase has changed. **Push after every task, not at the end.** See
 
 After the last task, run the full verification suite once more.
 
+**Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} implement`.
+
 Follow `{{ SKILLS.MAV_PLAN_EXECUTION }}` for the broader execution loop,
 verification discipline, failure handling, and crash recovery.
 
@@ -170,6 +198,7 @@ whether work is needed; the workflow decides whether the agent runs.
    per the push-per-task rule.
 5. The PR cannot proceed to Phase 7 until this phase has produced
    either committed doc changes or the auditable no-op record.
+6. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} docs`.
 
 ## Phase 7: Pre-push Cybersecurity Review (mandatory)
 
@@ -214,8 +243,17 @@ changes (callers, importers, dependents) must be reviewed by
        --title "<conventional title referencing #{{ ARGUMENTS }}>" \
        --body "<summary + closes #{{ ARGUMENTS }}>"
    ```
-4. Monitor CI per `{{ SKILLS.MAV_BP_CICD }}`. If CI fails, read logs, fix
+4. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} pr_open`.
+5. Monitor CI per `{{ SKILLS.MAV_BP_CICD }}`. If CI fails, read logs, fix
    locally, push. Do not proceed to Phase 9 until CI is green.
+6. **Browser/UI verification is non-blocking.** If the change touches UI
+   and Claude's global instructions or a project skill ask for browser
+   verification, run it with a strict timeout (e.g. 5 min total). On
+   hang, timeout, or failure, post the outcome as a non-blocking PR
+   comment and proceed to Phase 9 — do **not** wait indefinitely (#41).
+   Phase 9's reviewer is the binding gate; CI is the binding regression
+   check; ad-hoc browser runs are advisory.
+7. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} ci_green`.
 
 ## Phase 9: Code Review (binary, hard gate)
 
@@ -230,6 +268,7 @@ the open PR, not a local-diff advisory loop.
    - **PASS** — proceed to Phase 10 (merge).
    - **FAIL** — proceed to Phase 11 (eject). Do not attempt to auto-fix.
 3. Update phase to `review` in the state file.
+4. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} review`.
 
 There is no fix-and-re-review loop. If the reviewer FAILs the PR, the
 next step is eject-to-human, not iterate.
@@ -254,9 +293,10 @@ next step is eject-to-human, not iterate.
 3. **Wait for the merge to land** before continuing — poll
    `gh pr view <pr-url> --json state -q .state` until it reports
    `MERGED`. Cleanup steps below assume the PR is no longer in flight.
-4. Post the completion comment on the issue per
+4. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} merged`.
+5. Post the completion comment on the issue per
    `{{ SKILLS.MAV_GITHUB_ISSUE_WORKFLOW }}`.
-5. **Close the issue.** GitHub's `Closes #N` auto-close only fires when
+6. **Close the issue.** GitHub's `Closes #N` auto-close only fires when
    the PR merges to the default branch — projects using a `develop`
    tracking branch leave the issue OPEN until the next promotion.
    Always close explicitly so the issue's lifecycle matches the PR's
@@ -266,11 +306,12 @@ next step is eject-to-human, not iterate.
    gh issue close {{ ARGUMENTS }} \
        --comment "Resolved in PR #<P>; merged to <target-branch>."
    ```
-6. Update phase to `complete` in the state file.
-7. Release the claim: `uv run maverick coord release <repo> {{ ARGUMENTS }} --reason merged`.
-8. Clean up:
+7. Update phase to `complete` in the state file.
+8. Release the claim: `uv run maverick coord release <repo> {{ ARGUMENTS }} --reason merged`.
+9. Clean up:
    - Local state file
    - Destroy the worktree: `uv run maverick worktree destroy <worktree-path>`.
+10. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} complete`.
 
 ## Phase 11: Eject (on FAIL)
 

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -404,3 +404,75 @@ class TestHeartbeatLoop:
 
         assert rc == 0
         assert captured == {"repo": "me/r", "issue": 7, "interval_seconds": 5}
+
+
+class TestTaskProgressCli:
+    """#41: `task-progress read|set` are the durability primitives that
+    let do-issue-solo resume from a phase checkpoint instead of replaying
+    work against an in-flight or merged PR."""
+
+    def test_set_writes_marker_with_phase_and_instance_id(
+        self, monkeypatch, tmp_path
+    ):
+        import argparse
+
+        from maverick import coord_cli, gh_state
+
+        monkeypatch.setattr(
+            coordinator, "_instance_id_path", lambda: tmp_path / "instance_id"
+        )
+        monkeypatch.setenv("MAVERICK_INSTANCE_ID", "i-abc")
+
+        captured: dict = {}
+
+        def fake_upsert(repo, issue, kind, payload, preamble="", env=None):
+            captured["repo"] = repo
+            captured["issue"] = issue
+            captured["kind"] = kind
+            captured["payload"] = payload
+            captured["preamble"] = preamble
+            return 1
+
+        monkeypatch.setattr(gh_state, "upsert_marker", fake_upsert)
+        args = argparse.Namespace(repo="me/r", issue=42, phase="review")
+
+        rc = coord_cli._task_progress_set(args)
+
+        assert rc == 0
+        assert captured["repo"] == "me/r"
+        assert captured["issue"] == 42
+        assert captured["kind"] == "maverick-task-progress"
+        assert captured["payload"]["phase"] == "review"
+        assert captured["payload"]["instance_id"] == "i-abc"
+        assert captured["payload"]["updated_at"].endswith("Z")
+        assert "task-progress" in captured["preamble"]
+
+    def test_read_returns_latest_marker_payload(self, monkeypatch):
+        import argparse
+
+        from maverick import coord_cli, gh_state
+
+        fake_marker = gh_state.Marker(
+            kind="maverick-task-progress",
+            payload={"phase": "review", "instance_id": "x"},
+            comment_id=99,
+            issue_number=42,
+        )
+        monkeypatch.setattr(gh_state, "latest_marker", lambda *a, **k: fake_marker)
+        args = argparse.Namespace(repo="me/r", issue=42)
+
+        rc = coord_cli._task_progress_read(args)
+
+        assert rc == 0
+
+    def test_read_returns_none_when_no_marker(self, monkeypatch):
+        import argparse
+
+        from maverick import coord_cli, gh_state
+
+        monkeypatch.setattr(gh_state, "latest_marker", lambda *a, **k: None)
+        args = argparse.Namespace(repo="me/r", issue=42)
+
+        rc = coord_cli._task_progress_read(args)
+
+        assert rc == 0

--- a/tests/unit/test_gh_state.py
+++ b/tests/unit/test_gh_state.py
@@ -2,7 +2,12 @@
 
 import pytest
 
-from maverick.gh_state import MARKER_KINDS, format_marker, parse_body
+from maverick.gh_state import (
+    MARKER_KINDS,
+    TASK_PROGRESS_PHASES,
+    format_marker,
+    parse_body,
+)
 
 
 class TestParseBody:
@@ -71,4 +76,27 @@ class TestMarkerKinds:
             "maverick-claim",
             "maverick-lease",
             "maverick-bprop",
+            "maverick-task-progress",
         }
+
+
+class TestTaskProgressMarker:
+    """#41: per-issue do-issue-solo phase checkpoint, so a fresh agent
+    re-entering can resume from N+1 instead of restarting."""
+
+    def test_round_trip(self):
+        payload = {
+            "phase": "review",
+            "instance_id": "abc1234567",
+            "updated_at": "2026-05-02T10:00:00Z",
+        }
+        block = format_marker("maverick-task-progress", payload)
+        assert parse_body(block, "maverick-task-progress") == payload
+
+    def test_phase_choices_are_in_order(self):
+        # The CLI's `task-progress set <phase>` validates against this list,
+        # and the do-issue-solo skill's resume table assumes this ordering.
+        assert TASK_PROGRESS_PHASES[0] == "claimed"
+        assert TASK_PROGRESS_PHASES[-1] == "complete"
+        # Each phase must be unique.
+        assert len(TASK_PROGRESS_PHASES) == len(set(TASK_PROGRESS_PHASES))


### PR DESCRIPTION
## Summary

Closes the largest of the four open issues. When \`do-issue-solo\`'s main subagent stopped mid-flow (context exhaustion, hung browser test, ran out of budget), Phases 9+ silently dropped on the floor — review, auto-merge, claim release, state update, worktree destroy. The skill claimed to be \"idempotent on every entry\" but fresh-agent re-entry meant re-doing the implementation against an already-merged-or-merging PR.

Three reinforcing fixes (corresponding to options 1–3 in the issue; option 4 — splitting the skill into \`do-issue-implement\` + \`do-issue-finalise\` — is deferred since these three address the symptom without an interface change to the dispatcher contract):

### 1. Task-progress checkpoint marker

New \`maverick-task-progress\` marker kind. Written after each phase boundary by the skill body. Read at Phase 0 cold-start to resume from N+1 instead of restarting.

- \`uv run maverick task-progress set <repo> <issue> <phase>\` — upserts the marker.
- \`uv run maverick task-progress read <repo> <issue>\` — prints the latest payload.
- \`gh-state read\` now resolves its \`kind\` choices from \`gh_state.MARKER_KINDS\` directly, so any new marker kind is automatically reachable from the raw-read CLI.

### 2. Explicit existing-PR detection on entry

Phase 0 now has a tabular resume rule:

| Observed state | Resume at |
|---|---|
| PR exists, state=\`MERGED\` | Phase 10 cleanup |
| PR exists, state=\`OPEN\`, CI failing | Phase 8 step 4 |
| PR exists, state=\`OPEN\`, CI green, no review | Phase 9 |
| PR exists, state=\`OPEN\`, FAIL verdict | Phase 11 |
| task-progress phase ≥ \`branch\`, no PR | Phase 5 |
| etc. | … |

No more accidental replay against an in-flight PR.

### 3. Browser verification off the merge critical path

Phase 8 now says explicitly: browser/UI runs are advisory, must use a strict timeout, and on hang/timeout/failure surface as a non-blocking PR comment. Phase 9's reviewer is the binding gate; CI is the binding regression check; ad-hoc browser runs are advisory. A hung Playwright run can no longer stop the workflow before review even runs.

## Test plan

- [x] \`make lint\` — clean
- [x] \`make typecheck\` — clean
- [x] \`make test\` — 348 passed
- [x] \`make build\` — skill rendering applied to root \`/skills/\` mirror

Closes #41