### PR TITLE
feat(issue-lifecycle): per-project issue close policy

### DIFF
--- a/skills/do-epic/SKILL.md
+++ b/skills/do-epic/SKILL.md
@@ -224,9 +224,22 @@ When every story in the wave is terminal (merged or ejected):
 5. The `heartbeat-loop` background processes self-terminate within one
    `--interval` window once their claims are released — `wait` for them
    if you backgrounded them with PIDs, or just let the parent shell exit.
-6. Close the epic issue only if **no stories were ejected**. If any were
-   ejected, leave the epic open for the human to resolve the ejected
-   stories and close manually.
+6. Close the epic issue only if **no stories were ejected** AND the
+   per-project close policy allows it (#52). Per-PR closes for child
+   stories already ran via `do-issue-solo` Phase 10, but the epic
+   itself spans multiple branches/PRs, so the simple `close-on-merge`
+   CLI doesn't fit — query the policy and decide:
+   ```bash
+   policy=$(uv run maverick issue policy)
+   if [ "$policy" != "manual" ] && [ "$ejected_count" -eq 0 ]; then
+     gh issue close  \
+       --comment "Epic complete: $merged_count stories merged."
+   fi
+   ```
+   If any stories were ejected, leave the epic open for the human to
+   resolve them and close manually. If the policy is `manual`, leave
+   the epic open regardless — the team's promotion workflow handles
+   final close.
 
 ## Resumption
 

--- a/skills/do-issue-solo/SKILL.md
+++ b/skills/do-issue-solo/SKILL.md
@@ -303,15 +303,21 @@ next step is eject-to-human, not iterate.
 4. **Checkpoint**: `uv run maverick task-progress set <repo>  merged`.
 5. Post the completion comment on the issue per
    `mav-github-issue-workflow`.
-6. **Close the issue.** GitHub's `Closes #N` auto-close only fires when
-   the PR merges to the default branch — projects using a `develop`
-   tracking branch leave the issue OPEN until the next promotion.
-   Always close explicitly so the issue's lifecycle matches the PR's
-   (#46). `gh issue close` on an already-closed issue is a no-op, so
-   this is safe even on default-branch merges:
+6. **Run the post-merge issue-lifecycle step.** This always posts an
+   audit comment ("Resolved in PR #<P>; merged to <branch>.") and
+   applies a `merged-to-<branch>` label, then closes the issue per the
+   per-project policy in `.maverick/config.json`'s
+   `issue_lifecycle.close_policy` (#52). The default policy
+   (`on_pr_merge`) closes the issue immediately, which is right for
+   trunk-based and GitHub Flow repos. Repos using Gitflow or custom
+   promotion gates can set the policy to `on_default_branch_merge` or
+   `manual` to keep the issue open until promotion — the audit comment
+   and label still surface the merge so `gh issue list -l merged-to-develop`
+   finds work pending promotion. The CLI is idempotent (re-running it
+   on a closed issue is a no-op), so it is safe to retry:
    ```bash
-   gh issue close  \
-       --comment "Resolved in PR #<P>; merged to <target-branch>."
+   uv run maverick issue close-on-merge <repo>  \
+       --pr <pr-num> --target <target-branch>
    ```
 7. Update phase to `complete` in the state file.
 8. Release the claim: `uv run maverick coord release <repo>  --reason merged`.

--- a/src/maverick/cli.py
+++ b/src/maverick/cli.py
@@ -265,7 +265,16 @@ def main():
 
         _sys.exit(preflight_main(args))
 
-    elif args.command in ("coord", "dag", "state", "worktree", "gh-app", "gh-state"):
+    elif args.command in (
+        "coord",
+        "dag",
+        "state",
+        "worktree",
+        "gh-app",
+        "gh-state",
+        "task-progress",
+        "issue",
+    ):
         import sys as _sys
 
         from maverick.coord_cli import dispatch as _dispatch

--- a/src/maverick/config.py
+++ b/src/maverick/config.py
@@ -95,6 +95,37 @@ class AmiConfig(TypedDict):
     description: str  # Description for built AMIs
 
 
+class IssueLifecycleConfig(TypedDict):
+    """Per-project policy for what happens to GitHub issues after their PR
+    merges. Different repos use different merge patterns (trunk-based vs
+    Gitflow vs custom promotion chains), so the close decision can't be
+    hard-coded in the skill.
+
+    Fields:
+        close_policy:
+            One of:
+              - "on_pr_merge" (default): close the issue as soon as the PR
+                merges, regardless of which branch was the merge target.
+                Right for trunk-based, GitHub Flow, and Gitflow teams who
+                treat "merged to develop" as "done".
+              - "on_default_branch_merge": only close when the PR target
+                is the repo's default branch. Lets GitHub's native
+                ``Closes #N`` handle default-branch merges; Maverick
+                stays out of the way for non-default merges so the issue
+                stays open until the team's promotion gate runs.
+              - "manual": never close from the skill. Always post the
+                audit comment and apply the ``merged-to-<branch>`` label,
+                but leave the close to the team's own workflow (release
+                tag, environment promotion, manual sign-off).
+    """
+
+    close_policy: str  # "on_pr_merge" | "on_default_branch_merge" | "manual"
+
+
+# Recognised values for issue_lifecycle.close_policy.
+ISSUE_CLOSE_POLICIES = ("on_pr_merge", "on_default_branch_merge", "manual")
+
+
 class IntegrationStatus(TypedDict):
     """Per-project record of which Maverick adoption milestones have been
     carried out. Each flag defaults to ``false`` and is flipped to ``true``
@@ -130,6 +161,7 @@ class MaverickConfig(TypedDict):
     instance: InstanceConfig
     ami: AmiConfig
     integration: IntegrationStatus
+    issue_lifecycle: IssueLifecycleConfig
 
 
 # Defaults applied when sections or keys are missing.
@@ -168,6 +200,9 @@ CONFIG_DEFAULTS: MaverickConfig = {
         "tech_docs_scaffolded": False,
         "code_review_workflow": False,
         "cybersecurity_reviewed": False,
+    },
+    "issue_lifecycle": {
+        "close_policy": "on_pr_merge",
     },
 }
 
@@ -283,6 +318,13 @@ def validate_config(cfg: MaverickConfig, require_aws: bool = True) -> list[str]:
     max_attempts = cfg.get("queue", {}).get("max_attempts")
     if max_attempts is not None and not isinstance(max_attempts, int):
         errors.append("queue.max_attempts must be an integer")
+
+    policy = cfg.get("issue_lifecycle", {}).get("close_policy")
+    if policy is not None and policy not in ISSUE_CLOSE_POLICIES:
+        errors.append(
+            f"issue_lifecycle.close_policy must be one of "
+            f"{', '.join(ISSUE_CLOSE_POLICIES)} (got {policy!r})"
+        )
 
     return errors
 

--- a/src/maverick/coord_cli.py
+++ b/src/maverick/coord_cli.py
@@ -24,6 +24,7 @@ Usage shape:
     uv run maverick gh-app gh -- <gh args…>
     uv run maverick task-progress read <repo> <issue>
     uv run maverick task-progress set  <repo> <issue> <phase>
+    uv run maverick issue close-on-merge <repo> <issue> --pr N --target B
 """
 
 from __future__ import annotations
@@ -33,7 +34,15 @@ import json
 import sys
 from pathlib import Path
 
-from maverick import coordinator, dag, epic_state, gh_app, gh_state, worktree
+from maverick import (
+    coordinator,
+    dag,
+    epic_state,
+    gh_app,
+    gh_state,
+    issue_lifecycle,
+    worktree,
+)
 
 
 def _json_print(obj: object) -> None:
@@ -250,6 +259,35 @@ def _task_progress_set(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# issue (#52)
+# ---------------------------------------------------------------------------
+
+
+def _issue_close_on_merge(args: argparse.Namespace) -> int:
+    """Run the post-merge issue-lifecycle steps: audit comment + label
+    are unconditional, close decision follows the per-project policy."""
+    default_branch = args.default_branch or worktree.default_branch()
+    decision = issue_lifecycle.close_on_merge(
+        args.repo,
+        args.issue,
+        pr_num=args.pr,
+        target_branch=args.target,
+        default_branch=default_branch,
+    )
+    print(issue_lifecycle.decision_to_json(decision))
+    return 0
+
+
+def _issue_policy(args: argparse.Namespace) -> int:
+    """Print the per-project issue close policy. Skill bodies query this
+    when they need to make their own close decisions for cases that
+    don't fit `close-on-merge` (notably epic-level close, which spans
+    multiple PRs)."""
+    print(issue_lifecycle.get_policy())
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # wiring
 # ---------------------------------------------------------------------------
 
@@ -422,6 +460,48 @@ def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
         help="The do-issue-solo phase boundary just completed",
     )
     p.set_defaults(_handler=_task_progress_set)
+
+    # issue — per-project close policy (#52)
+    iss = subparsers.add_parser(
+        "issue",
+        help="Issue lifecycle operations (post-merge close per project policy)",
+    )
+    iss_sub = iss.add_subparsers(dest="issue_cmd", required=True)
+
+    p = iss_sub.add_parser(
+        "close-on-merge",
+        help=(
+            "Run the post-merge issue-lifecycle steps. Always posts the audit "
+            "comment and applies a `merged-to-<branch>` label. Closes the issue "
+            "based on issue_lifecycle.close_policy in .maverick/config.json: "
+            "on_pr_merge (default) closes always; on_default_branch_merge "
+            "closes only when target is the default branch; manual never closes."
+        ),
+    )
+    p.add_argument("repo")
+    p.add_argument("issue", type=int)
+    p.add_argument(
+        "--pr",
+        type=int,
+        required=True,
+        help="Number of the PR that just merged (referenced in the audit comment)",
+    )
+    p.add_argument(
+        "--target",
+        required=True,
+        help="The branch the PR merged into (e.g. main, develop)",
+    )
+    p.add_argument(
+        "--default-branch",
+        help="Repo's default branch. If omitted, detected via `gh repo view`.",
+    )
+    p.set_defaults(_handler=_issue_close_on_merge)
+
+    p = iss_sub.add_parser(
+        "policy",
+        help="Print the per-project issue close policy from .maverick/config.json",
+    )
+    p.set_defaults(_handler=_issue_policy)
 
 
 def dispatch(args: argparse.Namespace) -> int:

--- a/src/maverick/issue_lifecycle.py
+++ b/src/maverick/issue_lifecycle.py
@@ -1,0 +1,192 @@
+"""Per-project issue close policy — what happens to a GitHub issue once
+its PR has merged.
+
+#46 originally hard-coded "always close on PR merge". That works for
+trunk-based and GitHub Flow, but is wrong for repos that:
+
+- Use Gitflow and treat issues as "resolved" only after promotion to
+  the default/release branch (not after merge to ``develop``).
+- Run a ``develop → staging → main`` chain with environment-specific
+  gates and want issues to track promotion state rather than PR state.
+- Have policy reasons to keep issues open until a release tag
+  (compliance, customer-facing changelog, manual sign-off).
+
+This module externalises the close decision to a per-project config
+field so different repos can run the same skill with different policies.
+The audit comment and the ``merged-to-<branch>`` label fire
+unconditionally — that piece of the trail is policy-independent so
+``label:merged-to-develop`` lets humans find work pending promotion
+even when the close itself is deferred.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from typing import Any
+
+from maverick.config import ISSUE_CLOSE_POLICIES, init_config
+
+DEFAULT_POLICY = "on_pr_merge"
+
+
+@dataclass
+class CloseDecision:
+    """Outcome of an issue-close-on-merge run, returned to the caller for
+    audit-trail JSON output."""
+
+    policy: str
+    target_branch: str
+    default_branch: str
+    closed: bool
+    skip_reason: str  # empty when closed=True
+    comment_posted: bool
+    label_applied: str  # the label name actually applied
+
+
+def get_policy(cfg: dict[str, Any] | None = None) -> str:
+    """Return the project's issue close policy. Falls back to the default
+    if the field is missing or unrecognised. Never raises — `init_config`
+    handles missing files and `_apply_defaults` fills missing keys.
+    """
+    loaded: Any = cfg if cfg is not None else init_config(require_aws=False)
+    raw = loaded.get("issue_lifecycle", {}).get("close_policy", DEFAULT_POLICY)
+    if raw not in ISSUE_CLOSE_POLICIES:
+        return DEFAULT_POLICY
+    return raw
+
+
+def decide_close(
+    policy: str, target_branch: str, default_branch: str
+) -> tuple[bool, str]:
+    """Pure decision function — given the policy and the branch the PR
+    merged into, return ``(should_close, skip_reason)``. ``skip_reason``
+    is empty when ``should_close`` is True.
+
+    Centralised here (rather than inlined in ``close_on_merge``) so the
+    decision is independently testable and so other surfaces (e.g.
+    ``do-epic`` Phase 6) can reuse the same logic.
+    """
+    if policy == "manual":
+        return False, "policy=manual"
+    if policy == "on_default_branch_merge":
+        if target_branch == default_branch:
+            return True, ""
+        return (
+            False,
+            f"policy=on_default_branch_merge and target {target_branch!r} "
+            f"is not the default branch {default_branch!r}",
+        )
+    # on_pr_merge (and any unrecognised value, which get_policy already
+    # collapses to the default).
+    return True, ""
+
+
+def _label_for_branch(target_branch: str) -> str:
+    """The label applied to every closed-or-pending issue, naming the
+    branch the PR merged into. Lets ``gh issue list -l merged-to-develop``
+    surface work pending promotion when ``manual`` or
+    ``on_default_branch_merge`` defers the close.
+    """
+    return f"merged-to-{target_branch}"
+
+
+def close_on_merge(
+    repo: str,
+    issue: int,
+    pr_num: int,
+    target_branch: str,
+    default_branch: str,
+    *,
+    cfg: dict[str, Any] | None = None,
+    gh_runner: Any = None,
+) -> CloseDecision:
+    """Run the post-merge issue-lifecycle steps and return what was done.
+
+    Always (regardless of policy):
+      1. Posts an audit comment on the issue:
+         "Resolved in PR #<P>; merged to <branch>."
+      2. Applies the ``merged-to-<branch>`` label.
+
+    Then, per policy, optionally closes the issue. ``gh issue close`` on
+    an already-closed issue is a no-op, so this is safe even on
+    default-branch merges where GitHub's native ``Closes #N`` already
+    closed it.
+
+    `gh_runner` is the function used to execute `gh` (default: subprocess).
+    Tests can inject a fake to avoid network calls.
+    """
+    if gh_runner is None:
+        gh_runner = _default_gh_runner
+
+    label = _label_for_branch(target_branch)
+    comment = f"Resolved in PR #{pr_num}; merged to {target_branch}."
+
+    # Audit comment + label fire unconditionally so the trail is
+    # policy-independent.
+    gh_runner(
+        "issue", "comment", str(issue), "--repo", repo, "--body", comment
+    )
+    # `gh` exits non-zero if the label doesn't exist. Create-if-missing
+    # is part of the contract: humans can grep for `merged-to-<branch>`
+    # without having to seed the label set in advance.
+    _ensure_label(repo, label, gh_runner=gh_runner)
+    gh_runner(
+        "issue", "edit", str(issue), "--repo", repo, "--add-label", label
+    )
+
+    policy = get_policy(cfg)
+    should_close, skip_reason = decide_close(policy, target_branch, default_branch)
+    if should_close:
+        gh_runner("issue", "close", str(issue), "--repo", repo)
+
+    return CloseDecision(
+        policy=policy,
+        target_branch=target_branch,
+        default_branch=default_branch,
+        closed=should_close,
+        skip_reason=skip_reason,
+        comment_posted=True,
+        label_applied=label,
+    )
+
+
+def _default_gh_runner(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run the user's ``gh`` (not the App's ``gh-app gh``) — issue close +
+    comment are author-attributed actions and the App identity is
+    deliberately reserved for review/merge gates.
+    """
+    return subprocess.run(
+        ["gh", *args], capture_output=True, text=True, check=True
+    )
+
+
+def _ensure_label(repo: str, label: str, gh_runner: Any) -> None:
+    """Create the label if it doesn't already exist on the repo. ``gh
+    label create`` exits non-zero if the label is already present, so
+    catch that and proceed.
+    """
+    try:
+        gh_runner("label", "create", label, "--repo", repo, "--color", "ededed")
+    except subprocess.CalledProcessError:
+        # Already exists — fine.
+        pass
+
+
+def decision_to_json(d: CloseDecision) -> str:
+    """JSON serialisation for the CLI surface — emits a stable shape so
+    skill bodies can parse and audit the outcome."""
+    return json.dumps(
+        {
+            "policy": d.policy,
+            "target_branch": d.target_branch,
+            "default_branch": d.default_branch,
+            "closed": d.closed,
+            "skip_reason": d.skip_reason,
+            "comment_posted": d.comment_posted,
+            "label_applied": d.label_applied,
+        },
+        indent=2,
+        sort_keys=True,
+    )

--- a/src/maverick/skills/do-epic/body.md.j2
+++ b/src/maverick/skills/do-epic/body.md.j2
@@ -217,9 +217,22 @@ When every story in the wave is terminal (merged or ejected):
 5. The `heartbeat-loop` background processes self-terminate within one
    `--interval` window once their claims are released — `wait` for them
    if you backgrounded them with PIDs, or just let the parent shell exit.
-6. Close the epic issue only if **no stories were ejected**. If any were
-   ejected, leave the epic open for the human to resolve the ejected
-   stories and close manually.
+6. Close the epic issue only if **no stories were ejected** AND the
+   per-project close policy allows it (#52). Per-PR closes for child
+   stories already ran via `do-issue-solo` Phase 10, but the epic
+   itself spans multiple branches/PRs, so the simple `close-on-merge`
+   CLI doesn't fit — query the policy and decide:
+   ```bash
+   policy=$(uv run maverick issue policy)
+   if [ "$policy" != "manual" ] && [ "$ejected_count" -eq 0 ]; then
+     gh issue close {{ ARGUMENTS }} \
+       --comment "Epic complete: $merged_count stories merged."
+   fi
+   ```
+   If any stories were ejected, leave the epic open for the human to
+   resolve them and close manually. If the policy is `manual`, leave
+   the epic open regardless — the team's promotion workflow handles
+   final close.
 
 ## Resumption
 

--- a/src/maverick/skills/do-issue-solo/body.md.j2
+++ b/src/maverick/skills/do-issue-solo/body.md.j2
@@ -296,15 +296,21 @@ next step is eject-to-human, not iterate.
 4. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} merged`.
 5. Post the completion comment on the issue per
    `{{ SKILLS.MAV_GITHUB_ISSUE_WORKFLOW }}`.
-6. **Close the issue.** GitHub's `Closes #N` auto-close only fires when
-   the PR merges to the default branch — projects using a `develop`
-   tracking branch leave the issue OPEN until the next promotion.
-   Always close explicitly so the issue's lifecycle matches the PR's
-   (#46). `gh issue close` on an already-closed issue is a no-op, so
-   this is safe even on default-branch merges:
+6. **Run the post-merge issue-lifecycle step.** This always posts an
+   audit comment ("Resolved in PR #<P>; merged to <branch>.") and
+   applies a `merged-to-<branch>` label, then closes the issue per the
+   per-project policy in `.maverick/config.json`'s
+   `issue_lifecycle.close_policy` (#52). The default policy
+   (`on_pr_merge`) closes the issue immediately, which is right for
+   trunk-based and GitHub Flow repos. Repos using Gitflow or custom
+   promotion gates can set the policy to `on_default_branch_merge` or
+   `manual` to keep the issue open until promotion — the audit comment
+   and label still surface the merge so `gh issue list -l merged-to-develop`
+   finds work pending promotion. The CLI is idempotent (re-running it
+   on a closed issue is a no-op), so it is safe to retry:
    ```bash
-   gh issue close {{ ARGUMENTS }} \
-       --comment "Resolved in PR #<P>; merged to <target-branch>."
+   uv run maverick issue close-on-merge <repo> {{ ARGUMENTS }} \
+       --pr <pr-num> --target <target-branch>
    ```
 7. Update phase to `complete` in the state file.
 8. Release the claim: `uv run maverick coord release <repo> {{ ARGUMENTS }} --reason merged`.

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -66,3 +66,28 @@ class TestCliParsing:
         with patch("sys.argv", ["maverick", "plugin", "invalid"]):
             with pytest.raises(SystemExit):
                 main()
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["maverick", "issue", "policy"],
+            ["maverick", "task-progress", "read", "owner/repo", "1"],
+            ["maverick", "coord", "read", "owner/repo", "1"],
+        ],
+    )
+    def test_subcommand_dispatches_to_coord_cli(self, monkeypatch, argv):
+        """All coord_cli-owned top-level subcommands must be in the dispatch
+        allow-list in cli.py. Regression for the silent-exit bug where
+        `maverick issue policy` would exit 0 without running anything
+        because the subcommand wasn't routed."""
+        from unittest.mock import MagicMock, patch
+
+        mock_dispatch = MagicMock(return_value=0)
+        monkeypatch.setattr("sys.argv", argv)
+
+        with patch("maverick.coord_cli.dispatch", mock_dispatch):
+            with pytest.raises(SystemExit) as excinfo:
+                main()
+
+        assert excinfo.value.code == 0
+        assert mock_dispatch.called

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -159,6 +159,26 @@ class TestValidateConfig:
         errors = config.validate_config(cfg, require_aws=False)
         assert any("queue.max_attempts" in e for e in errors)
 
+    def test_default_close_policy_is_valid(self):
+        cfg = config._apply_defaults({})
+        assert cfg["issue_lifecycle"]["close_policy"] == "on_pr_merge"
+        errors = config.validate_config(cfg, require_aws=False)
+        assert all("issue_lifecycle" not in e for e in errors)
+
+    def test_recognised_close_policies(self):
+        for policy in config.ISSUE_CLOSE_POLICIES:
+            cfg = config._apply_defaults({"issue_lifecycle": {"close_policy": policy}})
+            errors = config.validate_config(cfg, require_aws=False)
+            assert all("issue_lifecycle" not in e for e in errors), (
+                f"valid policy {policy!r} flagged as error: {errors}"
+            )
+
+    def test_unknown_close_policy_is_error(self):
+        cfg = config._apply_defaults({})
+        cfg["issue_lifecycle"]["close_policy"] = "on_full_moon"  # type: ignore[typeddict-item]
+        errors = config.validate_config(cfg, require_aws=False)
+        assert any("issue_lifecycle.close_policy" in e for e in errors)
+
 
 class TestLoadAndHeal:
     def test_clean_config_unchanged(self, tmp_path: Path):

--- a/tests/unit/test_issue_lifecycle.py
+++ b/tests/unit/test_issue_lifecycle.py
@@ -1,0 +1,311 @@
+"""Tests for maverick.issue_lifecycle — per-project issue close policy.
+
+Covers the pure decision logic (decide_close), the get_policy fallback
+behaviour, and the side-effecting close_on_merge with a stubbed gh
+runner so the network never engages.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from maverick import issue_lifecycle
+
+
+class TestDecideClose:
+    """Pure-logic close decision. The skill bodies and the CLI both
+    consume this, so the policy semantics live in one place."""
+
+    def test_on_pr_merge_always_closes(self):
+        should, reason = issue_lifecycle.decide_close("on_pr_merge", "develop", "main")
+        assert should is True
+        assert reason == ""
+
+    def test_on_pr_merge_closes_even_when_target_is_default(self):
+        should, _ = issue_lifecycle.decide_close("on_pr_merge", "main", "main")
+        assert should is True
+
+    def test_on_default_branch_merge_closes_only_for_default(self):
+        should, _ = issue_lifecycle.decide_close(
+            "on_default_branch_merge", "main", "main"
+        )
+        assert should is True
+
+    def test_on_default_branch_merge_skips_for_non_default(self):
+        should, reason = issue_lifecycle.decide_close(
+            "on_default_branch_merge", "develop", "main"
+        )
+        assert should is False
+        assert "develop" in reason
+        assert "main" in reason
+
+    def test_manual_never_closes(self):
+        should, reason = issue_lifecycle.decide_close("manual", "main", "main")
+        assert should is False
+        assert "manual" in reason
+
+
+class TestGetPolicy:
+    def test_default_when_field_absent(self, tmp_path, monkeypatch):
+        # Empty cfg — get_policy must fall back to the default.
+        cfg = {"aws": {"region": "us-east-1"}}
+        assert issue_lifecycle.get_policy(cfg) == "on_pr_merge"
+
+    def test_returns_explicit_policy(self):
+        cfg = {"issue_lifecycle": {"close_policy": "manual"}}
+        assert issue_lifecycle.get_policy(cfg) == "manual"
+
+    def test_unknown_value_falls_back_to_default(self):
+        """Forward-compat / hand-edited config — never raise, never
+        accidentally turn into a third semantic. Default to on_pr_merge."""
+        cfg = {"issue_lifecycle": {"close_policy": "on_full_moon"}}
+        assert issue_lifecycle.get_policy(cfg) == "on_pr_merge"
+
+
+class _FakeGh:
+    """Records every gh invocation. ``raise_on`` lets a single call sequence
+    raise CalledProcessError to simulate ``gh label create`` failing because
+    the label already exists."""
+
+    def __init__(self, raise_on: tuple[str, ...] | None = None):
+        self.calls: list[tuple[str, ...]] = []
+        self.raise_on = raise_on
+
+    def __call__(self, *args: str) -> subprocess.CompletedProcess[str]:
+        self.calls.append(args)
+        if self.raise_on and args[: len(self.raise_on)] == self.raise_on:
+            raise subprocess.CalledProcessError(1, list(args))
+        return subprocess.CompletedProcess(args=list(args), returncode=0, stdout="", stderr="")
+
+    def call_args(self, *prefix: str) -> list[tuple[str, ...]]:
+        return [c for c in self.calls if c[: len(prefix)] == prefix]
+
+
+class TestCloseOnMerge:
+    """Audit comment + label fire unconditionally; close fires per policy."""
+
+    def test_default_policy_closes_and_emits_comment_and_label(self):
+        gh = _FakeGh()
+        cfg = {"issue_lifecycle": {"close_policy": "on_pr_merge"}}
+
+        decision = issue_lifecycle.close_on_merge(
+            "me/r", 42,
+            pr_num=99, target_branch="develop", default_branch="main",
+            cfg=cfg, gh_runner=gh,
+        )
+
+        assert decision.closed is True
+        assert decision.skip_reason == ""
+        assert decision.policy == "on_pr_merge"
+        assert decision.label_applied == "merged-to-develop"
+        # Comment posted with the resolved-in template.
+        comments = gh.call_args("issue", "comment")
+        assert len(comments) == 1
+        assert "PR #99" in " ".join(comments[0])
+        assert "develop" in " ".join(comments[0])
+        # Label applied.
+        assert gh.call_args("issue", "edit") and any(
+            "--add-label" in c for c in gh.call_args("issue", "edit")
+        )
+        # Close called.
+        assert gh.call_args("issue", "close")
+
+    def test_manual_policy_skips_close_but_keeps_audit_trail(self):
+        gh = _FakeGh()
+        cfg = {"issue_lifecycle": {"close_policy": "manual"}}
+
+        decision = issue_lifecycle.close_on_merge(
+            "me/r", 42,
+            pr_num=99, target_branch="develop", default_branch="main",
+            cfg=cfg, gh_runner=gh,
+        )
+
+        assert decision.closed is False
+        assert "manual" in decision.skip_reason
+        # Comment + label still posted — that's the policy-independent trail.
+        assert gh.call_args("issue", "comment")
+        assert gh.call_args("issue", "edit")
+        # No close.
+        assert not gh.call_args("issue", "close")
+
+    def test_default_branch_policy_closes_on_main(self):
+        gh = _FakeGh()
+        cfg = {"issue_lifecycle": {"close_policy": "on_default_branch_merge"}}
+
+        decision = issue_lifecycle.close_on_merge(
+            "me/r", 42,
+            pr_num=99, target_branch="main", default_branch="main",
+            cfg=cfg, gh_runner=gh,
+        )
+
+        assert decision.closed is True
+        assert gh.call_args("issue", "close")
+
+    def test_default_branch_policy_skips_on_develop(self):
+        gh = _FakeGh()
+        cfg = {"issue_lifecycle": {"close_policy": "on_default_branch_merge"}}
+
+        decision = issue_lifecycle.close_on_merge(
+            "me/r", 42,
+            pr_num=99, target_branch="develop", default_branch="main",
+            cfg=cfg, gh_runner=gh,
+        )
+
+        assert decision.closed is False
+        assert "default" in decision.skip_reason
+        # Audit trail still present.
+        assert gh.call_args("issue", "comment")
+        assert decision.label_applied == "merged-to-develop"
+
+    def test_label_already_exists_does_not_break_flow(self):
+        """``gh label create`` exits non-zero when the label is already
+        present. The helper swallows that and proceeds with apply + close."""
+        gh = _FakeGh(raise_on=("label", "create"))
+        cfg = {"issue_lifecycle": {"close_policy": "on_pr_merge"}}
+
+        decision = issue_lifecycle.close_on_merge(
+            "me/r", 42,
+            pr_num=99, target_branch="main", default_branch="main",
+            cfg=cfg, gh_runner=gh,
+        )
+
+        assert decision.closed is True
+        assert gh.call_args("issue", "close")
+
+
+class TestDecisionToJson:
+    def test_emits_stable_keys(self):
+        d = issue_lifecycle.CloseDecision(
+            policy="on_pr_merge",
+            target_branch="develop",
+            default_branch="main",
+            closed=True,
+            skip_reason="",
+            comment_posted=True,
+            label_applied="merged-to-develop",
+        )
+        out = json.loads(issue_lifecycle.decision_to_json(d))
+        assert out["policy"] == "on_pr_merge"
+        assert out["closed"] is True
+        assert out["label_applied"] == "merged-to-develop"
+        assert out["skip_reason"] == ""
+
+
+class TestCliHandler:
+    """The CLI handler is a thin wrapper — assert it forwards args and
+    prints the JSON decision."""
+
+    def test_close_on_merge_handler(self, monkeypatch, capsys):
+        import argparse
+
+        from maverick import coord_cli
+
+        def fake_default_branch():
+            return "main"
+
+        captured: dict = {}
+
+        def fake_close_on_merge(repo, issue, *, pr_num, target_branch, default_branch):
+            captured.update(
+                repo=repo,
+                issue=issue,
+                pr_num=pr_num,
+                target_branch=target_branch,
+                default_branch=default_branch,
+            )
+            return issue_lifecycle.CloseDecision(
+                policy="on_pr_merge",
+                target_branch=target_branch,
+                default_branch=default_branch,
+                closed=True,
+                skip_reason="",
+                comment_posted=True,
+                label_applied=f"merged-to-{target_branch}",
+            )
+
+        monkeypatch.setattr(coord_cli.worktree, "default_branch", fake_default_branch)
+        monkeypatch.setattr(
+            coord_cli.issue_lifecycle, "close_on_merge", fake_close_on_merge
+        )
+        args = argparse.Namespace(
+            repo="me/r", issue=42, pr=99, target="develop", default_branch=None
+        )
+
+        rc = coord_cli._issue_close_on_merge(args)
+
+        assert rc == 0
+        assert captured == {
+            "repo": "me/r",
+            "issue": 42,
+            "pr_num": 99,
+            "target_branch": "develop",
+            "default_branch": "main",
+        }
+        out = capsys.readouterr().out
+        assert "on_pr_merge" in out
+        assert "merged-to-develop" in out
+
+    def test_explicit_default_branch_skips_detection(self, monkeypatch, capsys):
+        """Passing --default-branch lets the skill avoid an extra gh API
+        call when it already knows the value (it does, post-merge)."""
+        import argparse
+
+        from maverick import coord_cli
+
+        def boom():
+            raise AssertionError("default_branch should not be invoked")
+
+        captured: dict = {}
+
+        def fake_close_on_merge(repo, issue, *, pr_num, target_branch, default_branch):
+            captured["default_branch"] = default_branch
+            return issue_lifecycle.CloseDecision(
+                policy="on_pr_merge",
+                target_branch=target_branch,
+                default_branch=default_branch,
+                closed=True,
+                skip_reason="",
+                comment_posted=True,
+                label_applied=f"merged-to-{target_branch}",
+            )
+
+        monkeypatch.setattr(coord_cli.worktree, "default_branch", boom)
+        monkeypatch.setattr(
+            coord_cli.issue_lifecycle, "close_on_merge", fake_close_on_merge
+        )
+        args = argparse.Namespace(
+            repo="me/r", issue=42, pr=99, target="main", default_branch="trunk"
+        )
+
+        coord_cli._issue_close_on_merge(args)
+
+        assert captured["default_branch"] == "trunk"
+
+    def test_policy_handler_prints_policy(self, monkeypatch, capsys):
+        import argparse
+
+        from maverick import coord_cli
+
+        monkeypatch.setattr(coord_cli.issue_lifecycle, "get_policy", lambda: "manual")
+
+        rc = coord_cli._issue_policy(argparse.Namespace())
+
+        assert rc == 0
+        assert capsys.readouterr().out.strip() == "manual"
+
+
+@pytest.fixture(autouse=True)
+def _no_real_gh(monkeypatch):
+    """Defence in depth: even if a test forgets to inject a fake runner,
+    the real ``subprocess.run`` for ``gh`` must not fire from this file."""
+    real_run = subprocess.run
+
+    def guarded_run(cmd, *args, **kwargs):
+        if isinstance(cmd, list) and cmd and cmd[0] == "gh":
+            raise AssertionError(f"unexpected gh call from test: {cmd}")
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", guarded_run)


### PR DESCRIPTION
## Summary

Implements #52. Different repos use different merge patterns (trunk-based vs Gitflow vs custom promotion chains), so the post-merge close decision can't be hard-coded in the skill. Adds \`issue_lifecycle.close_policy\` to \`.maverick/config.json\` with three values:

| Value | Behaviour |
|---|---|
| \`on_pr_merge\` (default) | Close as soon as the PR merges. Trunk-based, GitHub Flow, Gitflow-with-develop-as-done. |
| \`on_default_branch_merge\` | Only close when target is the repo's default branch. Let GitHub's native auto-close handle defaults; keep issues open through promotion gates for non-default merges. |
| \`manual\` | Never close from the skill. Team's own workflow handles final close. |

The audit comment (\"Resolved in PR #N; merged to <branch>.\") and the \`merged-to-<branch>\` label fire **unconditionally** regardless of policy, so \`gh issue list -l merged-to-develop\` surfaces work pending promotion even when the close is deferred. The label is auto-created if absent.

## CLI

\`\`\`bash
uv run maverick issue close-on-merge <repo> <issue> --pr N --target B
uv run maverick issue policy
\`\`\`

The first replaces the inlined \`gh issue close\` step from the original #46 fix and emits structured JSON describing what it did. The second is a query primitive for skill bodies that need to make their own decisions for cases that don't fit \`close-on-merge\` (notably \`do-epic\` Phase 6, which spans multiple PRs and branches).

## Skill body changes

- \`do-issue-solo\` Phase 10 step 6 now calls \`maverick issue close-on-merge\` instead of inlining \`gh issue close\`.
- \`do-epic\` Phase 6 step 6 queries the policy and skips the epic-level close when \`policy=manual\` (keeps the no-ejections precondition).

## Latent bug fix

\`cli.py\`'s top-level dispatch list was missing \`task-progress\` (introduced in #41) and the new \`issue\` subcommand. Both subcommands would silently exit 0 without running their handlers when invoked from the top-level CLI — handler tests in those PRs called the handler functions directly with manually-constructed \`Namespace\` objects, so the routing bug never surfaced. Added a parametrised regression test that verifies every coord_cli-owned subcommand reaches \`coord_cli.dispatch\`.

## Test plan

- [x] \`make lint\` — clean
- [x] \`make typecheck\` — clean (was 2 errors mid-implementation, fixed)
- [x] \`make test\` — 393 passed (28 new across \`test_issue_lifecycle.py\`, \`test_config.py\`, \`test_cli.py\`)
- [x] \`make build\` — skill rendering applied to root \`/skills/\` mirror
- [x] Smoke-tested \`uv run maverick issue policy\` against this repo's config (returns \`on_pr_merge\`, the default)

## Open question (deferred)

A repo running \`develop → staging → main\` with separate gates per environment doesn't fit any of the three policies — they want \"close on tag\" or \"close on environment promotion\". The \`manual\` escape + a project-skill hook is the documented answer for those, rather than encoding a full promotion state machine in the config. Worth revisiting if it shows up in practice.

Closes #52