### PR TITLE
fix(#56): surface gh-app gh stderr + pin Closes #N in PR body

### DIFF
--- a/skills/do-issue-solo/SKILL.md
+++ b/skills/do-issue-solo/SKILL.md
@@ -244,11 +244,26 @@ changes (callers, importers, dependents) must be reviewed by
 2. Stacked-PR retarget check per `mav-stacked-prs` if the branch
    stacks on a sibling. Retarget before opening the PR if the sibling is now
    merged.
-3. Open the PR:
+3. Open the PR. The body **must** end with a literal `Closes #`
+   line (capitalised; not `Refs`, `Related to`, or any other phrasing).
+   `gh pr merge --squash` carries the PR body verbatim into the squash
+   commit body; GitHub only auto-closes the linked issue when one of
+   `Closes`/`Fixes`/`Resolves` appears in a commit on the default
+   branch. If multiple PRs land via a non-squash promotion (Gitflow:
+   `develop` → `main`), each squash commit's body is what GitHub scans
+   — so omitting the keyword on a single PR leaves *that* story open
+   even after promotion (#56). Use `Refs #N` only for cross-references
+   to *other* issues, never for the primary story:
    ```bash
    gh pr create --base <resolved-base> --head <branch> \
        --title "<conventional title referencing #>" \
-       --body "<summary + closes #>"
+       --body "$(cat <<'PR_EOF'
+   ## Summary
+   <1-3 bullet points>
+
+   Closes #
+   PR_EOF
+   )"
    ```
 4. **Checkpoint**: `uv run maverick task-progress set <repo>  pr_open`.
 5. Monitor CI per `mav-bp-cicd`. If CI fails, read logs, fix
@@ -282,12 +297,22 @@ next step is eject-to-human, not iterate.
 
 ## Phase 10: Auto-merge (on PASS)
 
-1. The Maverick GitHub App posts the approval:
+1. **Verify the PR body still carries the closing keyword.** The body
+   becomes the squash commit body, and the closing keyword must survive
+   into the commit that lands on the default branch (#56). If the body
+   was edited after Phase 8 — by a reviewer, by another subagent, or by
+   a force-push — re-add the line before merging:
+   ```bash
+   uv run maverick gh-app gh -- pr view <pr-url> --json body -q .body \
+       | grep -Eq '(Closes|Fixes|Resolves) #\b' \
+       || { echo "PR body missing 'Closes #' — re-add before merging"; exit 1; }
+   ```
+2. The Maverick GitHub App posts the approval:
    ```bash
    uv run maverick gh-app gh -- pr review <pr-url> --approve \
        --body "Approved by agent-code-reviewer at $(date -u +%FT%TZ)"
    ```
-2. Enable auto-merge (squash):
+3. Enable auto-merge (squash):
    ```bash
    uv run maverick gh-app gh -- pr merge <pr-url> --auto --squash
    ```
@@ -297,13 +322,13 @@ next step is eject-to-human, not iterate.
    adopted) the CI-side re-run of agent-code-reviewer. If all required
    checks were already green, GitHub merges immediately; otherwise it
    merges when they pass.
-3. **Wait for the merge to land** before continuing — poll
+4. **Wait for the merge to land** before continuing — poll
    `gh pr view <pr-url> --json state -q .state` until it reports
    `MERGED`. Cleanup steps below assume the PR is no longer in flight.
-4. **Checkpoint**: `uv run maverick task-progress set <repo>  merged`.
-5. Post the completion comment on the issue per
+5. **Checkpoint**: `uv run maverick task-progress set <repo>  merged`.
+6. Post the completion comment on the issue per
    `mav-github-issue-workflow`.
-6. **Run the post-merge issue-lifecycle step.** This always posts an
+7. **Run the post-merge issue-lifecycle step.** This always posts an
    audit comment ("Resolved in PR #<P>; merged to <branch>.") and
    applies a `merged-to-<branch>` label, then closes the issue per the
    per-project policy in `.maverick/config.json`'s
@@ -319,12 +344,12 @@ next step is eject-to-human, not iterate.
    uv run maverick issue close-on-merge <repo>  \
        --pr <pr-num> --target <target-branch>
    ```
-7. Update phase to `complete` in the state file.
-8. Release the claim: `uv run maverick coord release <repo>  --reason merged`.
-9. Clean up:
-   - Local state file
-   - Destroy the worktree: `uv run maverick worktree destroy <worktree-path>`.
-10. **Checkpoint**: `uv run maverick task-progress set <repo>  complete`.
+8. Update phase to `complete` in the state file.
+9. Release the claim: `uv run maverick coord release <repo>  --reason merged`.
+10. Clean up:
+    - Local state file
+    - Destroy the worktree: `uv run maverick worktree destroy <worktree-path>`.
+11. **Checkpoint**: `uv run maverick task-progress set <repo>  complete`.
 
 ## Phase 11: Eject (on FAIL)
 

--- a/src/maverick/gh_app.py
+++ b/src/maverick/gh_app.py
@@ -207,9 +207,15 @@ bot_env = gh_app_env
 
 
 def gh_app_gh(*args: str) -> subprocess.CompletedProcess[str]:
-    """Run `gh` as the Maverick GitHub App. Raises on non-zero exit."""
+    """Run `gh` as the Maverick GitHub App.
+
+    Returns the CompletedProcess regardless of exit code so the caller can
+    relay the underlying `gh` stderr verbatim — we used to pass `check=True`,
+    which masked the real error behind a Python `CalledProcessError`
+    traceback (#56).
+    """
     return subprocess.run(
-        ["gh", *args], capture_output=True, text=True, check=True, env=gh_app_env()
+        ["gh", *args], capture_output=True, text=True, env=gh_app_env()
     )
 
 

--- a/src/maverick/skills/do-issue-solo/body.md.j2
+++ b/src/maverick/skills/do-issue-solo/body.md.j2
@@ -237,11 +237,26 @@ changes (callers, importers, dependents) must be reviewed by
 2. Stacked-PR retarget check per `{{ SKILLS.MAV_STACKED_PRS }}` if the branch
    stacks on a sibling. Retarget before opening the PR if the sibling is now
    merged.
-3. Open the PR:
+3. Open the PR. The body **must** end with a literal `Closes #{{ ARGUMENTS }}`
+   line (capitalised; not `Refs`, `Related to`, or any other phrasing).
+   `gh pr merge --squash` carries the PR body verbatim into the squash
+   commit body; GitHub only auto-closes the linked issue when one of
+   `Closes`/`Fixes`/`Resolves` appears in a commit on the default
+   branch. If multiple PRs land via a non-squash promotion (Gitflow:
+   `develop` → `main`), each squash commit's body is what GitHub scans
+   — so omitting the keyword on a single PR leaves *that* story open
+   even after promotion (#56). Use `Refs #N` only for cross-references
+   to *other* issues, never for the primary story:
    ```bash
    gh pr create --base <resolved-base> --head <branch> \
        --title "<conventional title referencing #{{ ARGUMENTS }}>" \
-       --body "<summary + closes #{{ ARGUMENTS }}>"
+       --body "$(cat <<'PR_EOF'
+   ## Summary
+   <1-3 bullet points>
+
+   Closes #{{ ARGUMENTS }}
+   PR_EOF
+   )"
    ```
 4. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} pr_open`.
 5. Monitor CI per `{{ SKILLS.MAV_BP_CICD }}`. If CI fails, read logs, fix
@@ -275,12 +290,22 @@ next step is eject-to-human, not iterate.
 
 ## Phase 10: Auto-merge (on PASS)
 
-1. The Maverick GitHub App posts the approval:
+1. **Verify the PR body still carries the closing keyword.** The body
+   becomes the squash commit body, and the closing keyword must survive
+   into the commit that lands on the default branch (#56). If the body
+   was edited after Phase 8 — by a reviewer, by another subagent, or by
+   a force-push — re-add the line before merging:
+   ```bash
+   uv run maverick gh-app gh -- pr view <pr-url> --json body -q .body \
+       | grep -Eq '(Closes|Fixes|Resolves) #{{ ARGUMENTS }}\b' \
+       || { echo "PR body missing 'Closes #{{ ARGUMENTS }}' — re-add before merging"; exit 1; }
+   ```
+2. The Maverick GitHub App posts the approval:
    ```bash
    uv run maverick gh-app gh -- pr review <pr-url> --approve \
        --body "Approved by agent-code-reviewer at $(date -u +%FT%TZ)"
    ```
-2. Enable auto-merge (squash):
+3. Enable auto-merge (squash):
    ```bash
    uv run maverick gh-app gh -- pr merge <pr-url> --auto --squash
    ```
@@ -290,13 +315,13 @@ next step is eject-to-human, not iterate.
    adopted) the CI-side re-run of agent-code-reviewer. If all required
    checks were already green, GitHub merges immediately; otherwise it
    merges when they pass.
-3. **Wait for the merge to land** before continuing — poll
+4. **Wait for the merge to land** before continuing — poll
    `gh pr view <pr-url> --json state -q .state` until it reports
    `MERGED`. Cleanup steps below assume the PR is no longer in flight.
-4. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} merged`.
-5. Post the completion comment on the issue per
+5. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} merged`.
+6. Post the completion comment on the issue per
    `{{ SKILLS.MAV_GITHUB_ISSUE_WORKFLOW }}`.
-6. **Run the post-merge issue-lifecycle step.** This always posts an
+7. **Run the post-merge issue-lifecycle step.** This always posts an
    audit comment ("Resolved in PR #<P>; merged to <branch>.") and
    applies a `merged-to-<branch>` label, then closes the issue per the
    per-project policy in `.maverick/config.json`'s
@@ -312,12 +337,12 @@ next step is eject-to-human, not iterate.
    uv run maverick issue close-on-merge <repo> {{ ARGUMENTS }} \
        --pr <pr-num> --target <target-branch>
    ```
-7. Update phase to `complete` in the state file.
-8. Release the claim: `uv run maverick coord release <repo> {{ ARGUMENTS }} --reason merged`.
-9. Clean up:
-   - Local state file
-   - Destroy the worktree: `uv run maverick worktree destroy <worktree-path>`.
-10. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} complete`.
+8. Update phase to `complete` in the state file.
+9. Release the claim: `uv run maverick coord release <repo> {{ ARGUMENTS }} --reason merged`.
+10. Clean up:
+    - Local state file
+    - Destroy the worktree: `uv run maverick worktree destroy <worktree-path>`.
+11. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} complete`.
 
 ## Phase 11: Eject (on FAIL)
 

--- a/tests/unit/test_coord_cli.py
+++ b/tests/unit/test_coord_cli.py
@@ -99,6 +99,29 @@ class TestGhAppGhSeparator:
         assert captured["args"] == ("api", "--", "/repos/x/y")
 
 
+class TestGhAppGhStderrRelay:
+    """#56: when `gh` exits non-zero the wrapper must surface gh's own
+    stderr (so the operator sees `unknown flag --foo` etc.) and return
+    gh's exit code — not bury it under a Python CalledProcessError."""
+
+    def test_nonzero_exit_relays_stderr_and_returncode(self, monkeypatch, capsys):
+        def fake_gh_app_gh(*args):
+            r = MagicMock()
+            r.stdout = ""
+            r.stderr = "gh: unknown flag --bogus\n"
+            r.returncode = 1
+            return r
+
+        monkeypatch.setattr(coord_cli.gh_app, "gh_app_gh", fake_gh_app_gh)
+        args = _parse("gh-app", "gh", "--", "issue", "comment", "42", "--bogus")
+
+        rc = coord_cli._gh_app_gh(args)
+
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "gh: unknown flag --bogus" in captured.err
+
+
 class TestWorktreeDestroyForce:
     """#45: destroy is force-by-default; --no-force opts out."""
 


### PR DESCRIPTION
## Summary

Resolves the two remaining items from #56 that were not already
covered by the v3.0.0 release work (#41, #42-#45, #52). The other
items (`task-progress`, `issue policy`/`close-on-merge`, `coord
status` alias, `gh-app gh --` separator) were already shipped on
`main` — verified via the current CLI surface and existing tests.

### Issue 1 — `gh-app gh` swallows `gh` stderr (gh_app.py:211)

`subprocess.run(..., check=True)` raised `CalledProcessError` before
the `_gh_app_gh` wrapper at `coord_cli.py:198-213` could write the
captured stderr. Operators saw a Python traceback instead of the
real gh CLI error (\`unknown flag\`, missing perms, parse error,
self-approval rejection, etc).

Fix: drop `check=True` from `gh_app.gh_app_gh`. The wrapper already
inspects `result.returncode` and writes both `stdout` and `stderr`
on the way out — it just never got there.

### Issue 4 — Inconsistent closing keywords in squash commits

In the original `do-epic` run, three of four child story PRs landed
on `main` (via Gitflow promotion) without auto-closing because their
squash commit bodies used `Refs #N` instead of `Closes #N`. GitHub
scans each merged commit on the default branch for closing keywords
— so omitting the keyword on a single PR leaves that story open
even after promotion.

Fix in `do-issue-solo/body.md.j2`:
- **Phase 8** (PR creation): require the body to end with literal
  \`Closes #<issue>\`, with a HEREDOC example. Explain why this
  matters for Gitflow promotion. \`Refs\` is reserved for
  cross-references to *other* issues, never for the primary story.
- **Phase 10** (auto-merge): add a pre-merge guard that greps the
  PR body for one of \`Closes/Fixes/Resolves #<issue>\` and aborts
  the merge if missing — so a reviewer's edit or a force-push
  doesn't silently drop the keyword.

## Test plan

- [x] \`make lint typecheck test\` — 394 passed, 0 errors
- [x] New unit test: \`TestGhAppGhStderrRelay::test_nonzero_exit_relays_stderr_and_returncode\`
  asserts the wrapper writes captured stderr and returns gh's exit
  code rather than raising.
- [x] \`make build\` — skill output regenerated and verified.
- [ ] Manual: \`uv run maverick gh-app gh issue view 999999\` (or
  any failing gh args) should print gh's own error message and exit
  non-zero, no Python traceback.