### PR TITLE
perf: stop auto-listing internal-only skills

### DIFF
--- a/skills/mav-block-propagation/SKILL.md
+++ b/skills/mav-block-propagation/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-block-propagation
 description: Idempotent, resumable propagation of a `blocked-by:#N` block from an ejected story to every transitive downstream story in the epic DAG. Triggered when agent-code-reviewer ejects a PR for human handling.
-disable-model-invocation: false
 ---
 
 **Depends on:** mav-durability-on-gh

--- a/skills/mav-bp-accessibility/SKILL.md
+++ b/skills/mav-bp-accessibility/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-accessibility
 description: Accessibility conventions for projects with user-facing interfaces. Covers WCAG 2.1 AA compliance, semantic HTML, keyboard navigation, colour contrast, screen reader support, and automated a11y testing. Applied when building or reviewing user-facing web or mobile applications.
-disable-model-invocation: false
 ---
 
 # Accessibility Standards

--- a/skills/mav-bp-alerting/SKILL.md
+++ b/skills/mav-bp-alerting/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-alerting
 description: Alerting conventions for fatal errors in applications. Covers severity levels, alert context, centralised notification, and project alerting guidance. Applied when writing error handling or reviewing code.
-disable-model-invocation: false
 ---
 
 # Alerting Standards

--- a/skills/mav-bp-api-design/SKILL.md
+++ b/skills/mav-bp-api-design/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-api-design
 description: API design conventions for projects with API surfaces. Covers REST and GraphQL standards, versioning, error formats, pagination, documentation as code, and backwards compatibility. Applied when designing, implementing, or reviewing APIs.
-disable-model-invocation: false
 ---
 
 # API Design Standards

--- a/skills/mav-bp-application-security/SKILL.md
+++ b/skills/mav-bp-application-security/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-application-security
 description: Application security conventions for all projects. Covers OWASP Top 10 awareness, input validation, secrets management, dependency scanning, SAST/DAST integration, and security headers. Applied when writing or reviewing any code.
-disable-model-invocation: false
 ---
 
 # Application Security Standards

--- a/skills/mav-bp-cicd-azure/SKILL.md
+++ b/skills/mav-bp-cicd-azure/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-cicd-azure
 description: Monitoring Azure DevOps pipelines after pushing. Covers checking pipeline status, diagnosing build/release failures, and respecting pipeline boundaries. Used as a dependency from workflow skills.
-disable-model-invocation: false
 ---
 
 # CI Awareness — Azure DevOps

--- a/skills/mav-bp-cicd-bitbucket/SKILL.md
+++ b/skills/mav-bp-cicd-bitbucket/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-cicd-bitbucket
 description: Monitoring Bitbucket Pipelines after pushing. Covers checking pipeline status, diagnosing build failures, and respecting pipeline boundaries. Used as a dependency from workflow skills.
-disable-model-invocation: false
 ---
 
 # CI Awareness — Bitbucket Pipelines

--- a/skills/mav-bp-cicd-github/SKILL.md
+++ b/skills/mav-bp-cicd-github/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-cicd-github
 description: Monitoring GitHub Actions pipelines after pushing. Covers checking workflow status, diagnosing CI failures, and respecting pipeline boundaries. Used as a dependency from workflow skills.
-disable-model-invocation: false
 ---
 
 # CI Awareness — GitHub Actions

--- a/skills/mav-bp-cicd-gitlab/SKILL.md
+++ b/skills/mav-bp-cicd-gitlab/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-cicd-gitlab
 description: Monitoring GitLab CI/CD pipelines after pushing. Covers checking pipeline status, diagnosing job failures, and respecting pipeline boundaries. Used as a dependency from workflow skills.
-disable-model-invocation: false
 ---
 
 # CI Awareness — GitLab CI

--- a/skills/mav-bp-cicd/SKILL.md
+++ b/skills/mav-bp-cicd/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-cicd
 description: Platform-agnostic CI/CD conventions. Covers pipeline stages, quality gates, environment promotion, secrets management, artifact handling, and deployment boundaries. Applied when configuring or reviewing CI/CD pipelines.
-disable-model-invocation: false
 ---
 
 # CI/CD Standards

--- a/skills/mav-bp-code-review/SKILL.md
+++ b/skills/mav-bp-code-review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-code-review
 description: Code review conventions for all projects. Covers mandatory review requirements, review scope, PR sizing, reviewer and author responsibilities, and automated review integration. Applied when creating or reviewing pull requests.
-disable-model-invocation: false
 ---
 
 # Code Review Standards

--- a/skills/mav-bp-database-management/SKILL.md
+++ b/skills/mav-bp-database-management/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-database-management
 description: Database and data management conventions for all projects using databases. Covers schema migrations, backup strategy, data lifecycle, index management, and connection pooling. Applied when designing, implementing, or reviewing database interactions.
-disable-model-invocation: false
 ---
 
 # Database & Data Management Standards

--- a/skills/mav-bp-dependency-management/SKILL.md
+++ b/skills/mav-bp-dependency-management/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-dependency-management
 description: Dependency management conventions for all projects. Covers lock files, version pinning, vulnerability scanning, license compliance, update strategy, and minimal dependency principle. Applied when adding, updating, or reviewing dependencies.
-disable-model-invocation: false
 ---
 
 # Dependency Management Standards

--- a/skills/mav-bp-documentation/SKILL.md
+++ b/skills/mav-bp-documentation/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-documentation
 description: Documentation conventions for all projects. Covers minimum documentation requirements, documentation freshness enforcement, AI-readable structure, and the relationship between human and machine audiences. Applied when creating or reviewing project documentation.
-disable-model-invocation: false
 ---
 
 # Documentation Standards

--- a/skills/mav-bp-environment-management/SKILL.md
+++ b/skills/mav-bp-environment-management/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-environment-management
 description: Environment management conventions for all projects. Covers reproducible local development, environment parity, .env patterns, developer onboarding, and containerised development. Applied when setting up or reviewing development environments.
-disable-model-invocation: false
 ---
 
 # Environment Management Standards

--- a/skills/mav-bp-error-handling/SKILL.md
+++ b/skills/mav-bp-error-handling/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-error-handling
 description: Error handling conventions for all applications. Covers error propagation, retry strategies, circuit breakers, graceful degradation, error boundaries, and typed errors. Applied when writing or reviewing error handling code.
-disable-model-invocation: false
 ---
 
 # Error Handling Standards

--- a/skills/mav-bp-infrastructure-as-code/SKILL.md
+++ b/skills/mav-bp-infrastructure-as-code/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-infrastructure-as-code
 description: Infrastructure as Code conventions for all deployed projects. Covers IaC principles, environment parity, secrets management in IaC, version control, and runbook fallback for unsupported platforms. Applied when reviewing or configuring infrastructure.
-disable-model-invocation: false
 ---
 
 # Infrastructure as Code Standards

--- a/skills/mav-bp-integration-testing/SKILL.md
+++ b/skills/mav-bp-integration-testing/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-integration-testing
 description: Integration testing conventions for applications. Covers test scope, external dependency management, environment setup, data isolation, and project testing guidance. Applied when writing or reviewing integration tests.
-disable-model-invocation: false
 ---
 
 # Integration Testing Standards

--- a/skills/mav-bp-linting/SKILL.md
+++ b/skills/mav-bp-linting/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-linting
 description: Linting conventions for applications. Covers linter selection, rule configuration, auto-formatting, CI integration, and project linting guidance. Applied when writing or reviewing code, or configuring developer tooling.
-disable-model-invocation: false
 ---
 
 # Linting Standards

--- a/skills/mav-bp-logging/SKILL.md
+++ b/skills/mav-bp-logging/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-logging
 description: Logging conventions for backend and frontend applications. Covers log levels, structured logging, centralised aggregation, and project logging guidance. Applied when writing or reviewing code that includes logging.
-disable-model-invocation: false
 ---
 
 # Logging Standards

--- a/skills/mav-bp-observability/SKILL.md
+++ b/skills/mav-bp-observability/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-observability
 description: Observability conventions for deployed applications. Covers metrics collection, distributed tracing, health checks, SLIs/SLOs, and dashboards. Complements the logging and alerting skills to complete the observability picture. Applied when designing or reviewing operational aspects of services.
-disable-model-invocation: false
 ---
 
 # Observability Standards

--- a/skills/mav-bp-remote-code-review/SKILL.md
+++ b/skills/mav-bp-remote-code-review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-remote-code-review
 description: Mandatory remote code review on every pull request. Defines the contract for a GitHub Actions workflow that runs the agent-code-reviewer in CI when a PR is opened, synchronized, or reopened. Used as a dependency by do-issue-solo and do-epic to enforce the review gate, and by do-maverick-alignment to audit the workflow's presence.
-disable-model-invocation: false
 ---
 
 # Remote Code Review (Optional CI Gate)

--- a/skills/mav-bp-solutions-design/SKILL.md
+++ b/skills/mav-bp-solutions-design/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-solutions-design
 description: Solutions design conventions for all projects. Covers the requirement for design before implementation, design documentation persistence, requirements traceability, and Architecture Decision Records. Applied before starting implementation of any non-trivial change.
-disable-model-invocation: false
 ---
 
 # Solutions Design Standards

--- a/skills/mav-bp-source-control/SKILL.md
+++ b/skills/mav-bp-source-control/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-source-control
 description: Source control conventions for all projects. Covers the requirement for remote repositories, repository hygiene, .gitignore standards, and sensitive file protection. Applied as a foundational requirement for all projects.
-disable-model-invocation: false
 ---
 
 # Source Control Standards

--- a/skills/mav-bp-task-tracking/SKILL.md
+++ b/skills/mav-bp-task-tracking/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-task-tracking
 description: Task tracking and management conventions for all projects. Covers the requirement for external task tracking, issue hygiene, workflow integration, and traceability between tasks and code changes. Applied as a foundational project management requirement.
-disable-model-invocation: false
 ---
 
 # Task Tracking Standards

--- a/skills/mav-bp-unit-testing/SKILL.md
+++ b/skills/mav-bp-unit-testing/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-unit-testing
 description: Unit testing conventions for applications. Covers test design, isolation, structure, mocking discipline, and project testing guidance. Applied when writing or reviewing unit tests.
-disable-model-invocation: false
 ---
 
 # Unit Testing Standards

--- a/skills/mav-bp-versioning/SKILL.md
+++ b/skills/mav-bp-versioning/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-bp-versioning
 description: Versioning and deprecation conventions for projects producing libraries, APIs, or SDKs. Covers semantic versioning, changelog maintenance, deprecation policies, and breaking change management. Applied when releasing or reviewing versioned artifacts.
-disable-model-invocation: false
 ---
 
 # Versioning & Deprecation Standards

--- a/skills/mav-claude-code-recovery/SKILL.md
+++ b/skills/mav-claude-code-recovery/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-claude-code-recovery
 description: Patterns for Claude Code workflow resilience — state persistence, crash recovery, command failure handling, subagent failure handling, and artefact durability. Not about application-level error handling.
-disable-model-invocation: false
 ---
 
 # Claude Code Error Handling and Recovery

--- a/skills/mav-create-solution-design/SKILL.md
+++ b/skills/mav-create-solution-design/SKILL.md
@@ -2,7 +2,6 @@
 name: mav-create-solution-design
 description: How to produce a solution design for a GitHub issue or task. Covers codebase exploration, design structure, and validation. Used as a dependency from workflow skills.
 user-invocable: true
-disable-model-invocation: false
 ---
 
 # Create Solution Design

--- a/skills/mav-create-tasks/SKILL.md
+++ b/skills/mav-create-tasks/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-create-tasks
 description: How to decompose a solution design into discrete, independently implementable tasks. Used as a dependency from workflow skills.
-disable-model-invocation: false
 ---
 
 # Create Tasks

--- a/skills/mav-durability-on-gh/SKILL.md
+++ b/skills/mav-durability-on-gh/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-durability-on-gh
 description: Durability conventions for multi-instance Maverick workflows. Covers cold-start hydration from GitHub, marker-write protocols, push-per-task cadence, and recreating worktrees from remote branches. GitHub is the source of truth; local files are a cache.
-disable-model-invocation: false
 ---
 
 # Durability on GitHub

--- a/skills/mav-git-workflow/SKILL.md
+++ b/skills/mav-git-workflow/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-git-workflow
 description: Git branching strategy, commit conventions, merge conflict handling, and branch lifecycle. Implements a simplified Gitflow with protected branches and conventional commits. Covers worktree-based multi-story workflows and cross-references stacked-PR handling.
-disable-model-invocation: false
 ---
 
 # Git Workflow

--- a/skills/mav-github-issue-workflow/SKILL.md
+++ b/skills/mav-github-issue-workflow/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-github-issue-workflow
 description: Standard patterns for interacting with GitHub issues — reading, commenting, updating, state tracking, branching, and PR creation. Use as a dependency from workflow skills, not directly.
-disable-model-invocation: false
 ---
 
 **Depends on:** mav-git-workflow

--- a/skills/mav-local-verification/SKILL.md
+++ b/skills/mav-local-verification/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-local-verification
 description: Pre-push code quality verification — lint, typecheck, and tests run locally before pushing. Covers discovering project verification commands, run order, scope-appropriate checks, and fixing failures. Used as a dependency from workflow skills.
-disable-model-invocation: false
 ---
 
 # Local Verification

--- a/skills/mav-multi-instance-coordination/SKILL.md
+++ b/skills/mav-multi-instance-coordination/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-multi-instance-coordination
 description: Claim, lease, heartbeat, and release protocols for when multiple Claude Code instances may act on the same issue or epic concurrently. GitHub labels and marker comments are the coordination surface; local state is a cache.
-disable-model-invocation: false
 ---
 
 **Depends on:** mav-durability-on-gh, mav-block-propagation

--- a/skills/mav-plan-execution/SKILL.md
+++ b/skills/mav-plan-execution/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-plan-execution
 description: How to execute an implementation plan step-by-step. Covers the execution loop, verification discipline, failure handling, progress tracking, crash recovery, and acceptance criteria. Adapts behaviour based on whether the caller is solo (autonomous) or guided (human checkpoints). Used as a dependency from workflow skills.
-disable-model-invocation: false
 ---
 
 # Plan Execution

--- a/skills/mav-scope-boundaries/SKILL.md
+++ b/skills/mav-scope-boundaries/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-scope-boundaries
 description: Defines what Claude Code must refuse to do without explicit authorisation. Covers infrastructure, auth, destructive git, and production systems. Applied automatically to all workflows.
-disable-model-invocation: false
 ---
 
 # Scope Boundaries

--- a/skills/mav-stacked-prs/SKILL.md
+++ b/skills/mav-stacked-prs/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mav-stacked-prs
 description: How to stack a PR on top of an unmerged sibling branch, and how to retarget it to the repo's default branch once the sibling merges. Prevents orphan-merge incidents when a dependent story is ready before its parent.
-disable-model-invocation: false
 ---
 
 **Depends on:** mav-git-workflow

--- a/src/maverick/skills/mav-block-propagation/config.py
+++ b/src/maverick/skills/mav-block-propagation/config.py
@@ -9,6 +9,6 @@ CONFIG = SkillConfig(
         " agent-code-reviewer ejects a PR for human handling."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[MAV_DURABILITY_ON_GH],
 )

--- a/src/maverick/skills/mav-bp-accessibility/config.py
+++ b/src/maverick/skills/mav-bp-accessibility/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Accessibility conventions for projects with user-facing interfaces. Covers WCAG 2.1 AA compliance, semantic HTML, keyboard navigation, colour contrast, screen reader support, and automated a11y testing. Applied when building or reviewing user-facing web or mobile applications."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-alerting/config.py
+++ b/src/maverick/skills/mav-bp-alerting/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Alerting conventions for fatal errors in applications. Covers severity levels, alert context, centralised notification, and project alerting guidance. Applied when writing error handling or reviewing code."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-api-design/config.py
+++ b/src/maverick/skills/mav-bp-api-design/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "API design conventions for projects with API surfaces. Covers REST and GraphQL standards, versioning, error formats, pagination, documentation as code, and backwards compatibility. Applied when designing, implementing, or reviewing APIs."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-application-security/config.py
+++ b/src/maverick/skills/mav-bp-application-security/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Application security conventions for all projects. Covers OWASP Top 10 awareness, input validation, secrets management, dependency scanning, SAST/DAST integration, and security headers. Applied when writing or reviewing any code."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-cicd-azure/config.py
+++ b/src/maverick/skills/mav-bp-cicd-azure/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Monitoring Azure DevOps pipelines after pushing. Covers checking pipeline status, diagnosing build/release failures, and respecting pipeline boundaries. Used as a dependency from workflow skills."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-cicd-bitbucket/config.py
+++ b/src/maverick/skills/mav-bp-cicd-bitbucket/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Monitoring Bitbucket Pipelines after pushing. Covers checking pipeline status, diagnosing build failures, and respecting pipeline boundaries. Used as a dependency from workflow skills."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-cicd-github/config.py
+++ b/src/maverick/skills/mav-bp-cicd-github/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Monitoring GitHub Actions pipelines after pushing. Covers checking workflow status, diagnosing CI failures, and respecting pipeline boundaries. Used as a dependency from workflow skills."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-cicd-gitlab/config.py
+++ b/src/maverick/skills/mav-bp-cicd-gitlab/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Monitoring GitLab CI/CD pipelines after pushing. Covers checking pipeline status, diagnosing job failures, and respecting pipeline boundaries. Used as a dependency from workflow skills."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-cicd/config.py
+++ b/src/maverick/skills/mav-bp-cicd/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Platform-agnostic CI/CD conventions. Covers pipeline stages, quality gates, environment promotion, secrets management, artifact handling, and deployment boundaries. Applied when configuring or reviewing CI/CD pipelines."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-code-review/config.py
+++ b/src/maverick/skills/mav-bp-code-review/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Code review conventions for all projects. Covers mandatory review requirements, review scope, PR sizing, reviewer and author responsibilities, and automated review integration. Applied when creating or reviewing pull requests."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-database-management/config.py
+++ b/src/maverick/skills/mav-bp-database-management/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Database and data management conventions for all projects using databases. Covers schema migrations, backup strategy, data lifecycle, index management, and connection pooling. Applied when designing, implementing, or reviewing database interactions."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-dependency-management/config.py
+++ b/src/maverick/skills/mav-bp-dependency-management/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Dependency management conventions for all projects. Covers lock files, version pinning, vulnerability scanning, license compliance, update strategy, and minimal dependency principle. Applied when adding, updating, or reviewing dependencies."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-documentation/config.py
+++ b/src/maverick/skills/mav-bp-documentation/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Documentation conventions for all projects. Covers minimum documentation requirements, documentation freshness enforcement, AI-readable structure, and the relationship between human and machine audiences. Applied when creating or reviewing project documentation."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-environment-management/config.py
+++ b/src/maverick/skills/mav-bp-environment-management/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Environment management conventions for all projects. Covers reproducible local development, environment parity, .env patterns, developer onboarding, and containerised development. Applied when setting up or reviewing development environments."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-error-handling/config.py
+++ b/src/maverick/skills/mav-bp-error-handling/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Error handling conventions for all applications. Covers error propagation, retry strategies, circuit breakers, graceful degradation, error boundaries, and typed errors. Applied when writing or reviewing error handling code."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-infrastructure-as-code/config.py
+++ b/src/maverick/skills/mav-bp-infrastructure-as-code/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Infrastructure as Code conventions for all deployed projects. Covers IaC principles, environment parity, secrets management in IaC, version control, and runbook fallback for unsupported platforms. Applied when reviewing or configuring infrastructure."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-integration-testing/config.py
+++ b/src/maverick/skills/mav-bp-integration-testing/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Integration testing conventions for applications. Covers test scope, external dependency management, environment setup, data isolation, and project testing guidance. Applied when writing or reviewing integration tests."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-linting/config.py
+++ b/src/maverick/skills/mav-bp-linting/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Linting conventions for applications. Covers linter selection, rule configuration, auto-formatting, CI integration, and project linting guidance. Applied when writing or reviewing code, or configuring developer tooling."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-logging/config.py
+++ b/src/maverick/skills/mav-bp-logging/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Logging conventions for backend and frontend applications. Covers log levels, structured logging, centralised aggregation, and project logging guidance. Applied when writing or reviewing code that includes logging."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-observability/config.py
+++ b/src/maverick/skills/mav-bp-observability/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Observability conventions for deployed applications. Covers metrics collection, distributed tracing, health checks, SLIs/SLOs, and dashboards. Complements the logging and alerting skills to complete the observability picture. Applied when designing or reviewing operational aspects of services."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-remote-code-review/config.py
+++ b/src/maverick/skills/mav-bp-remote-code-review/config.py
@@ -11,7 +11,7 @@ CONFIG = SkillConfig(
         "the workflow's presence."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
     assets=["code-review.yml"],
 )

--- a/src/maverick/skills/mav-bp-solutions-design/config.py
+++ b/src/maverick/skills/mav-bp-solutions-design/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Solutions design conventions for all projects. Covers the requirement for design before implementation, design documentation persistence, requirements traceability, and Architecture Decision Records. Applied before starting implementation of any non-trivial change."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-source-control/config.py
+++ b/src/maverick/skills/mav-bp-source-control/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Source control conventions for all projects. Covers the requirement for remote repositories, repository hygiene, .gitignore standards, and sensitive file protection. Applied as a foundational requirement for all projects."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-task-tracking/config.py
+++ b/src/maverick/skills/mav-bp-task-tracking/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Task tracking and management conventions for all projects. Covers the requirement for external task tracking, issue hygiene, workflow integration, and traceability between tasks and code changes. Applied as a foundational project management requirement."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-unit-testing/config.py
+++ b/src/maverick/skills/mav-bp-unit-testing/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Unit testing conventions for applications. Covers test design, isolation, structure, mocking discipline, and project testing guidance. Applied when writing or reviewing unit tests."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-bp-versioning/config.py
+++ b/src/maverick/skills/mav-bp-versioning/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Versioning and deprecation conventions for projects producing libraries, APIs, or SDKs. Covers semantic versioning, changelog maintenance, deprecation policies, and breaking change management. Applied when releasing or reviewing versioned artifacts."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-claude-code-recovery/config.py
+++ b/src/maverick/skills/mav-claude-code-recovery/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Patterns for Claude Code workflow resilience — state persistence, crash recovery, command failure handling, subagent failure handling, and artefact durability. Not about application-level error handling."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-create-solution-design/config.py
+++ b/src/maverick/skills/mav-create-solution-design/config.py
@@ -9,5 +9,5 @@ CONFIG = SkillConfig(
         " workflow skills."
     ),
     user_invocable=True,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
 )

--- a/src/maverick/skills/mav-create-tasks/config.py
+++ b/src/maverick/skills/mav-create-tasks/config.py
@@ -8,5 +8,5 @@ CONFIG = SkillConfig(
         " implementable tasks. Used as a dependency from workflow skills."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
 )

--- a/src/maverick/skills/mav-durability-on-gh/config.py
+++ b/src/maverick/skills/mav-durability-on-gh/config.py
@@ -10,6 +10,6 @@ CONFIG = SkillConfig(
         " local files are a cache."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-git-workflow/config.py
+++ b/src/maverick/skills/mav-git-workflow/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Git branching strategy, commit conventions, merge conflict handling, and branch lifecycle. Implements a simplified Gitflow with protected branches and conventional commits. Covers worktree-based multi-story workflows and cross-references stacked-PR handling."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-github-issue-workflow/config.py
+++ b/src/maverick/skills/mav-github-issue-workflow/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Standard patterns for interacting with GitHub issues — reading, commenting, updating, state tracking, branching, and PR creation. Use as a dependency from workflow skills, not directly."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-local-verification/config.py
+++ b/src/maverick/skills/mav-local-verification/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Pre-push code quality verification — lint, typecheck, and tests run locally before pushing. Covers discovering project verification commands, run order, scope-appropriate checks, and fixing failures. Used as a dependency from workflow skills."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-multi-instance-coordination/config.py
+++ b/src/maverick/skills/mav-multi-instance-coordination/config.py
@@ -13,6 +13,6 @@ CONFIG = SkillConfig(
         " marker comments are the coordination surface; local state is a cache."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[MAV_DURABILITY_ON_GH, MAV_BLOCK_PROPAGATION],
 )

--- a/src/maverick/skills/mav-plan-execution/config.py
+++ b/src/maverick/skills/mav-plan-execution/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "How to execute an implementation plan step-by-step. Covers the execution loop, verification discipline, failure handling, progress tracking, crash recovery, and acceptance criteria. Adapts behaviour based on whether the caller is solo (autonomous) or guided (human checkpoints). Used as a dependency from workflow skills."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-scope-boundaries/config.py
+++ b/src/maverick/skills/mav-scope-boundaries/config.py
@@ -7,6 +7,6 @@ CONFIG = SkillConfig(
         "Defines what Claude Code must refuse to do without explicit authorisation. Covers infrastructure, auth, destructive git, and production systems. Applied automatically to all workflows."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[],
 )

--- a/src/maverick/skills/mav-stacked-prs/config.py
+++ b/src/maverick/skills/mav-stacked-prs/config.py
@@ -9,6 +9,6 @@ CONFIG = SkillConfig(
         " orphan-merge incidents when a dependent story is ready before its parent."
     ),
     user_invocable=False,
-    disable_model_invocation=False,
+    disable_model_invocation=True,
     depends_on=[MAV_GIT_WORKFLOW],
 )


### PR DESCRIPTION
## Summary
- Flips `disable_model_invocation=True` on 38 internal `mav-bp-*` and `mav-*` skills so they drop out of the model's auto-invocation listing
- Frees skill-listing token budget for downstream consumers — only the user-facing `do-*` workflow skills remain auto-invocable
- Internal skills stay readable on disk; `do-*` workflows that reference them by name continue to work unchanged
- One-line frontmatter change per skill (driven by `config.py` flip + rebuild)

## Test plan
- [x] `make build` — rebuilt all skills/agents/topics cleanly
- [x] `uv run pytest tests/unit/` — 394 passed
- [x] `uv run ruff check .` — passed
- [x] `uv run pyright` — 0 errors
- [x] Verified rendered output: no `disable-model-invocation: false` in any internal `mav-*` skill frontmatter
- [x] Verified rendered output: `do-*` skills still expose `disable-model-invocation: false` so model can route to them

🤖 Generated with [Claude Code](https://claude.com/claude-code)