### PR TITLE
feat(worktree): add hooks.worktree_post_create config + invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`hooks.worktree_post_create` config field** — projects can declare a repo-relative path to an executable script that runs after `maverick worktree create` succeeds. The script receives the worktree absolute path as `$1` plus `MAVERICK_WORKTREE_PATH`, `MAVERICK_BRANCH`, `MAVERICK_BASE_BRANCH`, and `MAVERICK_REPO_ROOT` env vars. Non-zero exit, missing script, or non-executable script causes `worktree create` to fail with a clear `RuntimeError`; the worktree is left on disk for inspection. The field is optional and empty by default, so repos that don't declare a hook see today's behaviour. The Maverick CLI stays language-agnostic — hooks can be any executable. Useful for repos that need to materialise per-worktree state (e.g. `pnpm install`, symlinks to untracked secrets) before the first build runs.
+
 ## [3.1.1] - 2026-05-14
 
 ## [3.1.0] - 2026-05-09

--- a/skills/mav-git-workflow/SKILL.md
+++ b/skills/mav-git-workflow/SKILL.md
@@ -67,6 +67,41 @@ Leaving stale worktrees inflates disk usage and confuses future
 if a PR was ejected and the human may want to inspect the in-flight
 state — note the path in the eject comment.
 
+### Repo-specific post-create setup
+
+A freshly created worktree shares the main checkout's `.git`, but **not**
+its dependency installs, generated files, or untracked secrets. Many repos
+need to materialise those before the first build can run inside the new
+worktree (e.g. `pnpm install`, `pip install -e .`, symlinking `.env`).
+
+If `.maverick/config.json` declares `hooks.worktree_post_create`, the CLI
+runs that script after `git worktree add` succeeds. The hook receives:
+
+- `$1` — absolute worktree path
+- `MAVERICK_WORKTREE_PATH` — same as `$1`
+- `MAVERICK_BRANCH` — newly created branch name
+- `MAVERICK_BASE_BRANCH` — branch the new branch was forked from
+- `MAVERICK_REPO_ROOT` — main checkout's absolute path
+
+A non-zero exit, missing script, or non-executable script causes
+`maverick worktree create` to exit non-zero with a clear error. The
+worktree is **left on disk** so an engineer can inspect what the hook
+produced — clean up with `maverick worktree destroy` once diagnosed.
+
+Example wiring (`.maverick/config.json`):
+
+```json
+{
+  "hooks": {
+    "worktree_post_create": "scripts/worktree-setup.sh"
+  }
+}
+```
+
+The hook is optional. Repos that don't declare one see exactly today's
+behaviour. The Maverick CLI stays language-agnostic — the hook can be
+any executable.
+
 ### Stacked branches
 
 If a story depends on a sibling story whose PR is still open, stack per

--- a/src/maverick/config.py
+++ b/src/maverick/config.py
@@ -172,6 +172,25 @@ _DEFAULT_BRANCH_PREFIXES: dict[str, str] = {
 }
 
 
+class HooksConfig(TypedDict):
+    """Repo-specific scripts to run at maverick CLI lifecycle points.
+
+    Each value is a path (relative to the repo root) to an executable.
+    An empty string disables the hook.
+
+    Fields:
+        worktree_post_create: Runs after ``maverick worktree create`` succeeds.
+                              Receives the worktree path as ``$1`` plus the
+                              env vars ``MAVERICK_WORKTREE_PATH``,
+                              ``MAVERICK_BRANCH``, ``MAVERICK_BASE_BRANCH``,
+                              and ``MAVERICK_REPO_ROOT``. A non-zero exit
+                              causes ``worktree create`` to fail with the
+                              worktree left on disk for inspection.
+    """
+
+    worktree_post_create: str
+
+
 class IntegrationStatus(TypedDict):
     """Per-project record of which Maverick adoption milestones have been
     carried out. Each flag defaults to ``false`` and is flipped to ``true``
@@ -209,6 +228,7 @@ class MaverickConfig(TypedDict):
     integration: IntegrationStatus
     issue_lifecycle: IssueLifecycleConfig
     git_workflow: GitWorkflowConfig
+    hooks: HooksConfig
 
 
 # Defaults applied when sections or keys are missing.
@@ -256,6 +276,9 @@ CONFIG_DEFAULTS: MaverickConfig = {
         "pr_target": "main",
         "promotion_chain": ["main"],
         "branch_prefixes": dict(_DEFAULT_BRANCH_PREFIXES),
+    },
+    "hooks": {
+        "worktree_post_create": "",
     },
 }
 
@@ -547,6 +570,29 @@ def write_integration_status(
     raw: dict[str, Any] = _load_json(target) if target.exists() else {}
     raw["integration"] = dict(status)
     target.write_text(json.dumps(raw, indent=2) + "\n")
+
+
+def _default_hooks() -> HooksConfig:
+    """Return a fresh HooksConfig with every hook unset."""
+    return dict(CONFIG_DEFAULTS["hooks"])  # type: ignore[return-value]
+
+
+def read_hooks_config(path: Path | None = None) -> HooksConfig:
+    """Read the hooks block from the project config.
+
+    Returns the defaults (all hooks empty) if the file does not exist or has
+    no hooks block. Missing individual hooks are filled with their default.
+    Unknown hook names are dropped.
+    """
+    target = path or project_config_path()
+    raw = _load_json(target)
+    block = raw.get("hooks") if isinstance(raw, dict) else None
+    hooks = _default_hooks()
+    if isinstance(block, dict):
+        for key in hooks:
+            if key in block and isinstance(block[key], str):
+                hooks[key] = block[key]  # type: ignore[literal-required]
+    return hooks
 
 
 def set_integration_flag(key: str, value: bool, path: Path | None = None) -> None:

--- a/src/maverick/skills/mav-git-workflow/body.md.j2
+++ b/src/maverick/skills/mav-git-workflow/body.md.j2
@@ -63,6 +63,41 @@ Leaving stale worktrees inflates disk usage and confuses future
 if a PR was ejected and the human may want to inspect the in-flight
 state — note the path in the eject comment.
 
+### Repo-specific post-create setup
+
+A freshly created worktree shares the main checkout's `.git`, but **not**
+its dependency installs, generated files, or untracked secrets. Many repos
+need to materialise those before the first build can run inside the new
+worktree (e.g. `pnpm install`, `pip install -e .`, symlinking `.env`).
+
+If `.maverick/config.json` declares `hooks.worktree_post_create`, the CLI
+runs that script after `git worktree add` succeeds. The hook receives:
+
+- `$1` — absolute worktree path
+- `MAVERICK_WORKTREE_PATH` — same as `$1`
+- `MAVERICK_BRANCH` — newly created branch name
+- `MAVERICK_BASE_BRANCH` — branch the new branch was forked from
+- `MAVERICK_REPO_ROOT` — main checkout's absolute path
+
+A non-zero exit, missing script, or non-executable script causes
+`maverick worktree create` to exit non-zero with a clear error. The
+worktree is **left on disk** so an engineer can inspect what the hook
+produced — clean up with `maverick worktree destroy` once diagnosed.
+
+Example wiring (`.maverick/config.json`):
+
+```json
+{
+  "hooks": {
+    "worktree_post_create": "scripts/worktree-setup.sh"
+  }
+}
+```
+
+The hook is optional. Repos that don't declare one see exactly today's
+behaviour. The Maverick CLI stays language-agnostic — the hook can be
+any executable.
+
 ### Stacked branches
 
 If a story depends on a sibling story whose PR is still open, stack per

--- a/src/maverick/worktree.py
+++ b/src/maverick/worktree.py
@@ -7,9 +7,12 @@ at the repo root so they are easy to find and clean up.
 
 from __future__ import annotations
 
+import os
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+
+from . import config
 
 WORKTREE_ROOT = Path(".maverick/worktrees")
 
@@ -64,7 +67,53 @@ def create(branch: str, base: str | None = None) -> Worktree:
     path.parent.mkdir(parents=True, exist_ok=True)
     _git("worktree", "add", "-b", branch, str(path), f"origin/{base}", cwd=root)
     head = _git("rev-parse", "HEAD", cwd=path).strip()
+    _run_post_create_hook(root, path, branch, base)
     return Worktree(path=path, branch=branch, head=head)
+
+
+def _run_post_create_hook(
+    root: Path, worktree_path: Path, branch: str, base: str
+) -> None:
+    """Run the project's ``hooks.worktree_post_create`` script, if configured.
+
+    The hook receives ``worktree_path`` as ``$1`` plus the env vars
+    ``MAVERICK_WORKTREE_PATH``, ``MAVERICK_BRANCH``, ``MAVERICK_BASE_BRANCH``,
+    and ``MAVERICK_REPO_ROOT``. Any non-zero exit, missing script, or
+    non-executable script raises ``RuntimeError`` so the CLI fails clearly;
+    the worktree is left on disk for inspection.
+    """
+    hooks = config.read_hooks_config(root / ".maverick" / "config.json")
+    hook_rel = hooks.get("worktree_post_create", "")
+    if not hook_rel:
+        return
+    hook_abs = (root / hook_rel).resolve()
+    if not hook_abs.is_file():
+        raise RuntimeError(
+            f"worktree_post_create hook not found at {hook_abs}. "
+            f"Worktree left at {worktree_path} for inspection."
+        )
+    if not os.access(hook_abs, os.X_OK):
+        raise RuntimeError(
+            f"worktree_post_create hook is not executable: {hook_abs}. "
+            f"Worktree left at {worktree_path} for inspection."
+        )
+    env = {
+        **os.environ,
+        "MAVERICK_WORKTREE_PATH": str(worktree_path),
+        "MAVERICK_BRANCH": branch,
+        "MAVERICK_BASE_BRANCH": base,
+        "MAVERICK_REPO_ROOT": str(root),
+    }
+    result = subprocess.run(
+        [str(hook_abs), str(worktree_path)],
+        cwd=root,
+        env=env,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"worktree_post_create hook failed (exit {result.returncode}): "
+            f"{hook_abs}. Worktree left at {worktree_path} for inspection."
+        )
 
 
 def destroy(path: Path, force: bool = True) -> None:

--- a/tests/unit/test_worktree_hook.py
+++ b/tests/unit/test_worktree_hook.py
@@ -1,0 +1,87 @@
+"""Tests for the worktree_post_create hook surface in maverick.worktree."""
+
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+from maverick import worktree
+
+
+def _write_config(root: Path, hook_rel: str) -> None:
+    cfg_path = root / ".maverick" / "config.json"
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(json.dumps({"hooks": {"worktree_post_create": hook_rel}}))
+
+
+def _write_hook(
+    root: Path, name: str, body: str, executable: bool = True
+) -> Path:
+    """Write *body* to ``<root>/<name>`` and return the path."""
+    p = root / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body)
+    if executable:
+        p.chmod(p.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return p
+
+
+class TestRunPostCreateHook:
+    def test_no_hook_configured_is_a_noop(self, tmp_path: Path):
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        worktree._run_post_create_hook(tmp_path, wt, "feat/x", "main")
+
+    def test_hook_receives_path_arg_and_env(self, tmp_path: Path):
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        _write_hook(
+            tmp_path,
+            "scripts/hook.sh",
+            "#!/bin/sh\n"
+            "set -e\n"
+            'echo "$1" > "$1/.hook-arg"\n'
+            'env | grep ^MAVERICK_ | sort > "$1/.hook-env"\n',
+        )
+        _write_config(tmp_path, "scripts/hook.sh")
+
+        worktree._run_post_create_hook(tmp_path, wt, "feat/x", "develop")
+
+        assert (wt / ".hook-arg").read_text().strip() == str(wt)
+        env_lines = (wt / ".hook-env").read_text().splitlines()
+        assert f"MAVERICK_WORKTREE_PATH={wt}" in env_lines
+        assert "MAVERICK_BRANCH=feat/x" in env_lines
+        assert "MAVERICK_BASE_BRANCH=develop" in env_lines
+        assert f"MAVERICK_REPO_ROOT={tmp_path}" in env_lines
+
+    def test_missing_hook_file_raises(self, tmp_path: Path):
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        _write_config(tmp_path, "scripts/does-not-exist.sh")
+        with pytest.raises(RuntimeError, match="not found"):
+            worktree._run_post_create_hook(tmp_path, wt, "b", "main")
+        # worktree directory is intentionally left in place
+        assert wt.exists()
+
+    def test_non_executable_hook_raises(self, tmp_path: Path):
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        _write_hook(
+            tmp_path, "scripts/hook.sh", "#!/bin/sh\nexit 0\n", executable=False
+        )
+        _write_config(tmp_path, "scripts/hook.sh")
+        with pytest.raises(RuntimeError, match="not executable"):
+            worktree._run_post_create_hook(tmp_path, wt, "b", "main")
+        assert wt.exists()
+
+    def test_non_zero_exit_raises_with_exit_code(self, tmp_path: Path):
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        _write_hook(tmp_path, "scripts/hook.sh", "#!/bin/sh\nexit 7\n")
+        _write_config(tmp_path, "scripts/hook.sh")
+        with pytest.raises(RuntimeError, match=r"exit 7"):
+            worktree._run_post_create_hook(tmp_path, wt, "b", "main")
+        assert wt.exists()


### PR DESCRIPTION
## Summary

Adds an optional `hooks.worktree_post_create` field to `.maverick/config.json`. After `maverick worktree create` finishes the `git worktree add`, the CLI runs the configured script with:

- `$1` — worktree absolute path
- `MAVERICK_WORKTREE_PATH`, `MAVERICK_BRANCH`, `MAVERICK_BASE_BRANCH`, `MAVERICK_REPO_ROOT` env vars

Non-zero exit, missing script, or non-executable script → `RuntimeError`, with the worktree left on disk for inspection.

The field is optional and empty by default — repos that don't declare a hook see exactly today's behaviour. The CLI stays language-agnostic; hooks can be any executable. Useful for repos that need to materialise per-worktree state (e.g. `pnpm install`, symlinks to untracked secrets) before the first build runs in the new worktree.

## Motivation

A specific consuming project, `fairywren.io`, needs the worktree to symlink `.dev.vars`, `package.json`, `pnpm-lock.yaml`, and `node_modules` from the main checkout. Without it, the first pre-commit hook in the worktree fails (`tsc: command not found`) and triggers a ~15s `pnpm install`. With this hook surface and the consumer-side script, worktree create wall-clock drops from ~20s to ~4s.

The mechanism is intentionally generic — fairywren.io's needs are repo-specific (pnpm, `.dev.vars`), but the same surface lets any project hook in their own setup.

## Files

- `src/maverick/config.py` — new `HooksConfig` TypedDict, wired into `MaverickConfig` + `CONFIG_DEFAULTS`. New `read_hooks_config()` helper mirroring `read_integration_status()`.
- `src/maverick/worktree.py` — `create()` invokes `_run_post_create_hook()` after `git worktree add`. Hard-fails on missing file, non-executable, or non-zero exit.
- `src/maverick/skills/mav-git-workflow/body.md.j2` — adds "Repo-specific post-create setup" subsection documenting the contract. Build output regenerated via `make build`.
- `tests/unit/test_worktree_hook.py` — 5 cases covering the contract.
- `CHANGELOG.md` — entry under `[Unreleased]`.

## Test plan

- [x] `pytest tests/unit -q` — 469 passed, no regressions.
- [x] `make lint typecheck` — clean.
- [x] `make build` — skills/agents/hooks regenerated; only the mav-git-workflow SKILL.md output changes (matches the source template edit).
- [x] End-to-end smoke in a consuming repo (fairywren.io): `time maverick worktree create … --base develop` runs the configured hook, fails appropriately when the script is non-executable, leaves the worktree on disk on failure.

## Versioning

This is an additive backward-compatible change — no consumer using the existing CLI sees any behaviour change without opting in via config. Suggested release: `minor` from `3.1.2-dev` → `3.2.0`.

Per `CLAUDE.md`, the release flow is to merge this PR then run `./scripts/release.sh minor` from main.