### PR TITLE
fix(ci): prevent and detect non-tag commits on stable

### DIFF
--- a/.github/workflows/guard-stable.yml
+++ b/.github/workflows/guard-stable.yml
@@ -1,0 +1,70 @@
+name: Guard Stable
+
+# Hard-block PRs targeting `stable`. `stable` is CI-managed and is only
+# ever advanced by `release-finalize.yml` via a REST PATCH on the ref —
+# there is no legitimate PR-into-stable flow. Any PR opened against
+# `stable` is the failure mode that caused the 3.1.2-dev drift (see
+# PRs #71 and #73), so we fail the check, leave a breadcrumb on the PR,
+# and close it.
+#
+# The ruleset on `stable` makes this check required, so the merge button
+# is disabled even before the workflow finishes.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+    branches: [stable]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  block:
+    # Pinned name so the required-status-check context in the
+    # 'Protect Stable' ruleset stays stable across refactors.
+    name: guard-stable
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail, comment, and close
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "::error::PRs into 'stable' are not permitted."
+          echo "::error::PR #${PR_NUMBER} targets stable; closing."
+
+          BODY=$(cat <<'EOF'
+          ## This PR will not be merged
+
+          The `stable` branch is **CI-managed** and is only ever advanced by
+          `release-finalize.yml` via a REST `PATCH` on the ref — there is no
+          legitimate PR-into-`stable` flow.
+
+          A PR targeting `stable` is the exact failure mode that caused the
+          3.1.2-dev drift (see PRs #71 and #73): the merge advances `stable`
+          to a non-release-tag commit, and `/plugin update` immediately
+          starts delivering an in-development version to every end user.
+
+          ### What you probably meant to do
+
+          - **Releasing a new version?** Run `./scripts/release.sh <patch|minor|major>`.
+            That opens a PR targeting `main`. Squash-merging it triggers
+            `release-finalize.yml`, which tags the commit and force-FFs
+            `stable` to the tag.
+          - **Landing a regular change?** Re-open this PR with `--base main`.
+
+          This PR is being closed automatically. If you believe this is in
+          error, open an issue.
+          EOF
+          )
+
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BODY" \
+            || echo "::warning::failed to comment on PR; closing anyway"
+
+          gh pr close "$PR_NUMBER" --repo "$REPO" \
+            || echo "::warning::failed to close PR"
+
+          exit 1

--- a/.github/workflows/verify-stable.yml
+++ b/.github/workflows/verify-stable.yml
@@ -44,13 +44,24 @@ jobs:
           echo "::error::stable@${STABLE_SHA} is not a v* release-tag commit."
           echo "::error::stable must only ever be fast-forwarded to a v* tag via release-finalize.yml."
 
-          # Leave a tracking issue so the failure is visible outside the
-          # Actions tab. release-finalize.yml documents the recovery
-          # command (force-update via gh api PATCH).
+          # Ensure the tracking label exists before we try to attach it.
+          # `gh issue create -l <missing>` aborts before creating the issue,
+          # which is how the 3.1.2-dev drift went unnoticed: the label
+          # didn't exist, the gh call errored, set -e short-circuited the
+          # script, and no issue was ever filed.
+          gh label create stable-drift \
+            --repo "$REPO" \
+            --color "B60205" \
+            --description "stable branch advanced to a non-release-tag commit; /plugin update breaks for end users" \
+            2>/dev/null || true
+
+          # `|| true` so a transient issue-creation failure can't swallow
+          # the explicit `exit 1` below — the build must always fail when
+          # stable is off-tag, even if we couldn't file the breadcrumb.
           gh issue create \
             --repo "$REPO" \
             --title "stable branch is not a release-tag commit (${STABLE_SHA:0:7})" \
-            --label "release,bug" \
+            --label "stable-drift,bug" \
             --body "stable@${STABLE_SHA} is not at a v* release tag.
 
           This means /plugin update is delivering an in-development version
@@ -58,6 +69,7 @@ jobs:
 
           Recovery: force-update stable to the latest v* tag commit. The
           exact gh-api command is documented in .github/workflows/release-finalize.yml
-          (the Fast-forward stable branch step's error remediation block)."
+          (the Fast-forward stable branch step's error remediation block)." \
+            || echo "::warning::failed to create tracking issue; failing the build anyway"
 
           exit 1


### PR DESCRIPTION
## Summary

Two related CI fixes for the failure mode that delivered `3.1.2-dev` to end users via `/plugin update` (PRs #71 and #73 merged `main` into `stable` and went un-noticed).

- **`verify-stable.yml`**: the workflow detected the drift correctly but `gh issue create` referenced a nonexistent `release` label and aborted with `could not add label`. With `set -e`, the script exited before filing the tracking issue. Fix: idempotently create a `stable-drift` label, use `stable-drift,bug`, and wrap `gh issue create` with `|| echo ::warning::` so a label/network failure can never again swallow the explicit `exit 1`.
- **`guard-stable.yml`** (new): hard-blocks PRs targeting `stable`. Fails the check, comments with remediation guidance, and auto-closes the PR. Wired into the `Protect Stable` ruleset as a required status check (alongside the new `non_fast_forward` rule and the existing `deletion` rule), so the merge button is disabled even before the workflow finishes.

`stable` is CI-managed and only ever advanced by `release-finalize.yml` via REST `PATCH refs/heads/stable`. There is no legitimate PR-into-`stable` flow — so it's safe for `guard-stable` to fail unconditionally.

## Related side-effects already applied

- The `Protect Stable` ruleset has already been updated to add `non_fast_forward` and require the `guard-stable` check (admin/integration bypass actors unchanged).
- `stable` was force-rolled-back from `80e0289` to `89517ea` (the `v3.1.1` release commit) to unbreak `/plugin update` for end users.

## Test plan

- [ ] Squash-merge this PR
- [ ] Open a throw-away PR targeting `stable` and confirm `guard-stable` (a) fails the required check, (b) comments with the remediation message, (c) auto-closes the PR
- [ ] Next release: confirm `release-finalize.yml`'s REST `PATCH` still successfully advances `stable` to the new tag commit despite the new ruleset rules
- [ ] If `stable` ever drifts off-tag again, confirm a `stable-drift` issue is filed (use the verify-stable job in the Actions tab to manually trigger via a test push if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)