### PR TITLE
perf(docs-review): pre-filter doc shortlist before dispatching docs-writer

### DIFF
--- a/skills/do-issue-guided/SKILL.md
+++ b/skills/do-issue-guided/SKILL.md
@@ -122,20 +122,72 @@ This phase **always runs** before push. The agent decides whether any
 docs work is needed; the workflow does not skip the analysis based on
 its own heuristic.
 
-1. Compute the full diff: `git diff $(uv run maverick git-workflow story-base)...HEAD`.
-2. Dispatch the **agent-tech-docs-writer** agent with:
+The agent is dispatched with a **pre-filtered shortlist** of docs the
+diff plausibly touches, not the open-ended "audit every doc" brief.
+On prior issues the unbounded brief ate ~6 min of wall clock on a
+15-file diff. The agent still reports any out-of-shortlist docs it
+believes are impacted; those surface as a follow-up note for you to
+review.
+
+1. Compute the diff and changed paths:
+
+   ```bash
+   BASE=$(uv run maverick git-workflow story-base)
+   git diff "origin/${BASE}...HEAD" > /tmp/diff.patch
+   git diff --name-only "origin/${BASE}...HEAD" > /tmp/changed-paths.txt
+   ```
+
+2. **Build the candidate doc shortlist.** Derive search terms from the
+   diff (basenames + top-level directories from changed paths, plus
+   identifier-like tokens introduced or removed in added/removed lines).
+   Grep every `docs/` tree in the repo. An empty shortlist is valid.
+
+   ```bash
+   {
+     cut -d/ -f1 /tmp/changed-paths.txt
+     sed 's|.*/||; s|\.[^.]*$||' /tmp/changed-paths.txt
+     grep -E '^[+-][^+-]' /tmp/diff.patch \
+       | grep -Eo '\b(function|def|class|interface|type|const|export)[[:space:]]+[A-Za-z_][A-Za-z0-9_]+' \
+       | awk '{print $NF}'
+   } | awk 'length($0) >= 3' | sort -u > /tmp/doc-terms.txt
+
+   mapfile -t DOC_ROOTS < <(find . -type d -name docs \
+     -not -path '*/node_modules/*' -not -path '*/.git/*' -not -path '*/.venv/*')
+
+   : > /tmp/doc-shortlist.txt
+   if [[ ${#DOC_ROOTS[@]} -gt 0 && -s /tmp/doc-terms.txt ]]; then
+     while IFS= read -r term; do
+       grep -rlF -- "$term" "${DOC_ROOTS[@]}" 2>/dev/null || true
+     done < /tmp/doc-terms.txt \
+       | grep -E '\.(md|mdx)$' \
+       | sort -u > /tmp/doc-shortlist.txt
+   fi
+   ```
+
+3. Dispatch the **agent-tech-docs-writer** agent with:
    - **Mode:** `update` (per `do-docs`)
-   - **Diff:** the output of step 1
-   - **Instructions:** review every changed file. Update existing
-     `docs/` content that is now stale, and create new documents for
-     any new component, subsystem, or architectural change with no
-     existing coverage. Return "no doc changes required" explicitly if
-     neither applies — do not skip silently.
-3. **Checkpoint — Review docs outcome with the user:** show what was
-   updated or created (or the explicit no-op decision) and confirm
-   before pushing. If updates are inaccurate or out of scope, push back
-   and ask the agent to revise.
-4. Commit any doc changes with a `docs:` conventional commit.
+   - **Diff:** `/tmp/diff.patch`
+   - **Candidate docs:** the contents of `/tmp/doc-shortlist.txt`. If
+     the file is empty, pass the literal string
+     `<empty — scan only for gaps requiring new coverage>`.
+   - **Instructions:**
+     - Read each candidate doc. Update only sections rendered stale by
+       the diff; do **not** refactor unrelated content.
+     - If the diff introduces a component, subsystem, or architectural
+       change with no coverage anywhere in `docs/`, create the new
+       document.
+     - If you find a doc **outside the candidate list** that you
+       believe is impacted, **list its path in your return payload —
+       do not edit it.** One-pass dispatch: no widen-and-retry; the
+       caller surfaces these as a follow-up note for the user.
+     - Returning "no doc changes required" is a valid outcome and must
+       be reported explicitly.
+4. **Checkpoint — Review docs outcome with the user:** show what was
+   updated or created (or the explicit no-op decision), surface any
+   out-of-shortlist docs the agent flagged, and confirm before pushing.
+   If updates are inaccurate or out of scope, push back and ask the
+   agent to revise.
+5. Commit any doc changes with a `docs:` conventional commit.
 
 ## Phase 8: Pre-push Cybersecurity Review (mandatory)
 

--- a/skills/do-issue-solo/SKILL.md
+++ b/skills/do-issue-solo/SKILL.md
@@ -185,29 +185,84 @@ verification discipline, failure handling, and crash recovery.
 ## Phase 6: Documentation Review (mandatory)
 
 This phase **always runs** before the PR is opened. There is no skip
-path — the heuristic-gated version of this phase used to let stale docs
-ship when Claude's affected-or-not call was wrong. The agent decides
-whether work is needed; the workflow decides whether the agent runs.
+path — the heuristic-gated version used to let stale docs ship when
+Claude's affected-or-not call was wrong. The agent decides whether
+work is needed; the workflow decides whether the agent runs.
 
-1. Compute the full diff: `git diff origin/<base>...HEAD`.
-2. Dispatch **agent-tech-docs-writer** with:
+The agent is dispatched with a **pre-filtered shortlist** of docs the
+diff plausibly touches, not the open-ended "audit every doc" brief
+that made this phase the longest single subagent cost on prior issues
+(observed: ~6 min on a 15-file diff). The agent still reports any
+out-of-shortlist docs it believes are impacted — those surface in the
+PR body as a follow-up note rather than being silently rewritten.
+
+1. Compute the diff and changed paths:
+
+   ```bash
+   BASE=$(uv run maverick git-workflow story-base)
+   git diff "origin/${BASE}...HEAD" > /tmp/diff.patch
+   git diff --name-only "origin/${BASE}...HEAD" > /tmp/changed-paths.txt
+   ```
+
+2. **Build the candidate doc shortlist.** Derive search terms from the
+   diff (basenames + top-level directories from changed paths, plus
+   identifier-like tokens introduced or removed in added/removed lines).
+   Grep every `docs/` tree in the repo. The shortlist may legitimately
+   be empty — that is a valid input to step 3.
+
+   ```bash
+   {
+     cut -d/ -f1 /tmp/changed-paths.txt
+     sed 's|.*/||; s|\.[^.]*$||' /tmp/changed-paths.txt
+     grep -E '^[+-][^+-]' /tmp/diff.patch \
+       | grep -Eo '\b(function|def|class|interface|type|const|export)[[:space:]]+[A-Za-z_][A-Za-z0-9_]+' \
+       | awk '{print $NF}'
+   } | awk 'length($0) >= 3' | sort -u > /tmp/doc-terms.txt
+
+   mapfile -t DOC_ROOTS < <(find . -type d -name docs \
+     -not -path '*/node_modules/*' -not -path '*/.git/*' -not -path '*/.venv/*')
+
+   : > /tmp/doc-shortlist.txt
+   if [[ ${#DOC_ROOTS[@]} -gt 0 && -s /tmp/doc-terms.txt ]]; then
+     while IFS= read -r term; do
+       grep -rlF -- "$term" "${DOC_ROOTS[@]}" 2>/dev/null || true
+     done < /tmp/doc-terms.txt \
+       | grep -E '\.(md|mdx)$' \
+       | sort -u > /tmp/doc-shortlist.txt
+   fi
+   ```
+
+3. Dispatch **agent-tech-docs-writer** with:
    - **Mode:** `update` (per `do-docs`)
-   - **Diff:** the output of step 1
-   - **Instructions:** review every changed file. Decide for each whether
-     existing `docs/` content is now stale, or whether a new document is
-     needed for a new component, subsystem, or architectural change with
-     no existing coverage. Update or create accordingly. Returning
-     "no doc changes required" is a valid outcome and must be reported
-     explicitly (not silently inferred).
-3. **Record the outcome** in the PR body or as a one-line PR comment so
+   - **Diff:** `/tmp/diff.patch`
+   - **Candidate docs:** the contents of `/tmp/doc-shortlist.txt`. If
+     the file is empty, pass the literal string
+     `<empty — scan only for gaps requiring new coverage>`.
+   - **Instructions:**
+     - Read each candidate doc. Update only sections rendered stale by
+       the diff; do **not** refactor unrelated content.
+     - If the diff introduces a component, subsystem, or architectural
+       change with no coverage anywhere in `docs/`, create the new
+       document.
+     - If you find a doc **outside the candidate list** that you
+       believe is impacted, **list its path in your return payload —
+       do not edit it.** One-pass dispatch: no widen-and-retry; the
+       caller folds these into a follow-up note on the PR for the
+       human reviewer.
+     - Returning "no doc changes required" is a valid outcome and must
+       be reported explicitly (not silently inferred).
+4. **Record the outcome** in the PR body or as a one-line PR comment so
    the gate is auditable:
    - If docs were updated or created: list the files changed.
+   - If the agent flagged out-of-shortlist docs: append a
+     `Docs follow-up: <paths>` line to the PR body so the reviewer
+     sees them.
    - If no changes were required: post `Docs review: no changes required.`
-4. Commit any doc changes with a `docs:` conventional commit and push
+5. Commit any doc changes with a `docs:` conventional commit and push
    per the push-per-task rule.
-5. The PR cannot proceed to Phase 7 until this phase has produced
+6. The PR cannot proceed to Phase 7 until this phase has produced
    either committed doc changes or the auditable no-op record.
-6. **Checkpoint**: `uv run maverick task-progress set <repo>  docs`.
+7. **Checkpoint**: `uv run maverick task-progress set <repo>  docs`.
 
 ## Phase 7: Pre-push Cybersecurity Review (mandatory)
 

--- a/src/maverick/skills/do-issue-guided/body.md.j2
+++ b/src/maverick/skills/do-issue-guided/body.md.j2
@@ -115,20 +115,72 @@ This phase **always runs** before push. The agent decides whether any
 docs work is needed; the workflow does not skip the analysis based on
 its own heuristic.
 
-1. Compute the full diff: `git diff $(uv run maverick git-workflow story-base)...HEAD`.
-2. Dispatch the **{{ AGENTS.AGENT_TECH_DOCS_WRITER }}** agent with:
+The agent is dispatched with a **pre-filtered shortlist** of docs the
+diff plausibly touches, not the open-ended "audit every doc" brief.
+On prior issues the unbounded brief ate ~6 min of wall clock on a
+15-file diff. The agent still reports any out-of-shortlist docs it
+believes are impacted; those surface as a follow-up note for you to
+review.
+
+1. Compute the diff and changed paths:
+{% raw %}
+   ```bash
+   BASE=$(uv run maverick git-workflow story-base)
+   git diff "origin/${BASE}...HEAD" > /tmp/diff.patch
+   git diff --name-only "origin/${BASE}...HEAD" > /tmp/changed-paths.txt
+   ```
+{% endraw %}
+2. **Build the candidate doc shortlist.** Derive search terms from the
+   diff (basenames + top-level directories from changed paths, plus
+   identifier-like tokens introduced or removed in added/removed lines).
+   Grep every `docs/` tree in the repo. An empty shortlist is valid.
+{% raw %}
+   ```bash
+   {
+     cut -d/ -f1 /tmp/changed-paths.txt
+     sed 's|.*/||; s|\.[^.]*$||' /tmp/changed-paths.txt
+     grep -E '^[+-][^+-]' /tmp/diff.patch \
+       | grep -Eo '\b(function|def|class|interface|type|const|export)[[:space:]]+[A-Za-z_][A-Za-z0-9_]+' \
+       | awk '{print $NF}'
+   } | awk 'length($0) >= 3' | sort -u > /tmp/doc-terms.txt
+
+   mapfile -t DOC_ROOTS < <(find . -type d -name docs \
+     -not -path '*/node_modules/*' -not -path '*/.git/*' -not -path '*/.venv/*')
+
+   : > /tmp/doc-shortlist.txt
+   if [[ ${#DOC_ROOTS[@]} -gt 0 && -s /tmp/doc-terms.txt ]]; then
+     while IFS= read -r term; do
+       grep -rlF -- "$term" "${DOC_ROOTS[@]}" 2>/dev/null || true
+     done < /tmp/doc-terms.txt \
+       | grep -E '\.(md|mdx)$' \
+       | sort -u > /tmp/doc-shortlist.txt
+   fi
+   ```
+{% endraw %}
+3. Dispatch the **{{ AGENTS.AGENT_TECH_DOCS_WRITER }}** agent with:
    - **Mode:** `update` (per `{{ SKILLS.DO_DOCS }}`)
-   - **Diff:** the output of step 1
-   - **Instructions:** review every changed file. Update existing
-     `docs/` content that is now stale, and create new documents for
-     any new component, subsystem, or architectural change with no
-     existing coverage. Return "no doc changes required" explicitly if
-     neither applies — do not skip silently.
-3. **Checkpoint — Review docs outcome with the user:** show what was
-   updated or created (or the explicit no-op decision) and confirm
-   before pushing. If updates are inaccurate or out of scope, push back
-   and ask the agent to revise.
-4. Commit any doc changes with a `docs:` conventional commit.
+   - **Diff:** `/tmp/diff.patch`
+   - **Candidate docs:** the contents of `/tmp/doc-shortlist.txt`. If
+     the file is empty, pass the literal string
+     `<empty — scan only for gaps requiring new coverage>`.
+   - **Instructions:**
+     - Read each candidate doc. Update only sections rendered stale by
+       the diff; do **not** refactor unrelated content.
+     - If the diff introduces a component, subsystem, or architectural
+       change with no coverage anywhere in `docs/`, create the new
+       document.
+     - If you find a doc **outside the candidate list** that you
+       believe is impacted, **list its path in your return payload —
+       do not edit it.** One-pass dispatch: no widen-and-retry; the
+       caller surfaces these as a follow-up note for the user.
+     - Returning "no doc changes required" is a valid outcome and must
+       be reported explicitly.
+4. **Checkpoint — Review docs outcome with the user:** show what was
+   updated or created (or the explicit no-op decision), surface any
+   out-of-shortlist docs the agent flagged, and confirm before pushing.
+   If updates are inaccurate or out of scope, push back and ask the
+   agent to revise.
+5. Commit any doc changes with a `docs:` conventional commit.
 
 ## Phase 8: Pre-push Cybersecurity Review (mandatory)
 

--- a/src/maverick/skills/do-issue-solo/body.md.j2
+++ b/src/maverick/skills/do-issue-solo/body.md.j2
@@ -178,29 +178,84 @@ verification discipline, failure handling, and crash recovery.
 ## Phase 6: Documentation Review (mandatory)
 
 This phase **always runs** before the PR is opened. There is no skip
-path — the heuristic-gated version of this phase used to let stale docs
-ship when Claude's affected-or-not call was wrong. The agent decides
-whether work is needed; the workflow decides whether the agent runs.
+path — the heuristic-gated version used to let stale docs ship when
+Claude's affected-or-not call was wrong. The agent decides whether
+work is needed; the workflow decides whether the agent runs.
 
-1. Compute the full diff: `git diff origin/<base>...HEAD`.
-2. Dispatch **{{ AGENTS.AGENT_TECH_DOCS_WRITER }}** with:
+The agent is dispatched with a **pre-filtered shortlist** of docs the
+diff plausibly touches, not the open-ended "audit every doc" brief
+that made this phase the longest single subagent cost on prior issues
+(observed: ~6 min on a 15-file diff). The agent still reports any
+out-of-shortlist docs it believes are impacted — those surface in the
+PR body as a follow-up note rather than being silently rewritten.
+
+1. Compute the diff and changed paths:
+{% raw %}
+   ```bash
+   BASE=$(uv run maverick git-workflow story-base)
+   git diff "origin/${BASE}...HEAD" > /tmp/diff.patch
+   git diff --name-only "origin/${BASE}...HEAD" > /tmp/changed-paths.txt
+   ```
+{% endraw %}
+2. **Build the candidate doc shortlist.** Derive search terms from the
+   diff (basenames + top-level directories from changed paths, plus
+   identifier-like tokens introduced or removed in added/removed lines).
+   Grep every `docs/` tree in the repo. The shortlist may legitimately
+   be empty — that is a valid input to step 3.
+{% raw %}
+   ```bash
+   {
+     cut -d/ -f1 /tmp/changed-paths.txt
+     sed 's|.*/||; s|\.[^.]*$||' /tmp/changed-paths.txt
+     grep -E '^[+-][^+-]' /tmp/diff.patch \
+       | grep -Eo '\b(function|def|class|interface|type|const|export)[[:space:]]+[A-Za-z_][A-Za-z0-9_]+' \
+       | awk '{print $NF}'
+   } | awk 'length($0) >= 3' | sort -u > /tmp/doc-terms.txt
+
+   mapfile -t DOC_ROOTS < <(find . -type d -name docs \
+     -not -path '*/node_modules/*' -not -path '*/.git/*' -not -path '*/.venv/*')
+
+   : > /tmp/doc-shortlist.txt
+   if [[ ${#DOC_ROOTS[@]} -gt 0 && -s /tmp/doc-terms.txt ]]; then
+     while IFS= read -r term; do
+       grep -rlF -- "$term" "${DOC_ROOTS[@]}" 2>/dev/null || true
+     done < /tmp/doc-terms.txt \
+       | grep -E '\.(md|mdx)$' \
+       | sort -u > /tmp/doc-shortlist.txt
+   fi
+   ```
+{% endraw %}
+3. Dispatch **{{ AGENTS.AGENT_TECH_DOCS_WRITER }}** with:
    - **Mode:** `update` (per `{{ SKILLS.DO_DOCS }}`)
-   - **Diff:** the output of step 1
-   - **Instructions:** review every changed file. Decide for each whether
-     existing `docs/` content is now stale, or whether a new document is
-     needed for a new component, subsystem, or architectural change with
-     no existing coverage. Update or create accordingly. Returning
-     "no doc changes required" is a valid outcome and must be reported
-     explicitly (not silently inferred).
-3. **Record the outcome** in the PR body or as a one-line PR comment so
+   - **Diff:** `/tmp/diff.patch`
+   - **Candidate docs:** the contents of `/tmp/doc-shortlist.txt`. If
+     the file is empty, pass the literal string
+     `<empty — scan only for gaps requiring new coverage>`.
+   - **Instructions:**
+     - Read each candidate doc. Update only sections rendered stale by
+       the diff; do **not** refactor unrelated content.
+     - If the diff introduces a component, subsystem, or architectural
+       change with no coverage anywhere in `docs/`, create the new
+       document.
+     - If you find a doc **outside the candidate list** that you
+       believe is impacted, **list its path in your return payload —
+       do not edit it.** One-pass dispatch: no widen-and-retry; the
+       caller folds these into a follow-up note on the PR for the
+       human reviewer.
+     - Returning "no doc changes required" is a valid outcome and must
+       be reported explicitly (not silently inferred).
+4. **Record the outcome** in the PR body or as a one-line PR comment so
    the gate is auditable:
    - If docs were updated or created: list the files changed.
+   - If the agent flagged out-of-shortlist docs: append a
+     `Docs follow-up: <paths>` line to the PR body so the reviewer
+     sees them.
    - If no changes were required: post `Docs review: no changes required.`
-4. Commit any doc changes with a `docs:` conventional commit and push
+5. Commit any doc changes with a `docs:` conventional commit and push
    per the push-per-task rule.
-5. The PR cannot proceed to Phase 7 until this phase has produced
+6. The PR cannot proceed to Phase 7 until this phase has produced
    either committed doc changes or the auditable no-op record.
-6. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} docs`.
+7. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} docs`.
 
 ## Phase 7: Pre-push Cybersecurity Review (mandatory)
 


### PR DESCRIPTION
## Summary

Phase 6 of `do-issue-solo` and Phase 7 of `do-issue-guided` previously dispatched `agent-tech-docs-writer` with the full diff and an open-ended "review every changed file… update or create accordingly" brief. The unbounded scope forced the agent to read all of `docs/` to decide what was stale — on a 15-file diff this cost ~6 min of wall clock (observed in `fairywren.io#296`, the time-breakdown report at `/Users/davidcheal/projects/fairywren.io/issue-296-time-breakdown.md` flagged the docs-writer as one of the two heavy hitters that accounted for nearly half the run).

Both phases now compute a **candidate doc shortlist** before dispatch:

1. Derive search terms from the diff (changed-path basenames + top directories + identifier-like tokens on +/- lines).
2. Grep every `docs/` tree (root and any `<pkg>/docs/`) for those terms.
3. Hand the agent the shortlist + diff and constrain it to update only stale sections of those docs. Out-of-shortlist docs the agent believes are impacted are **flagged in the return payload, not edited** — the caller surfaces them as a follow-up note in the PR body (solo) or at the checkpoint (guided).

One-pass dispatch — no widen-and-retry. Accuracy is preserved via the orphan-flag mechanism without paying a second agent run. New-coverage gaps are still handled: an empty shortlist is a valid input and the agent explicitly scans for components/subsystems with no existing coverage.

## Trade-offs

- **Pro**: ~3-5 min savings expected on issues with non-trivial diffs that touch documented surfaces. Most of the cost was the agent re-reading whole docs to detect staleness; bounded scope removes that.
- **Con**: shortlist heuristic could miss a relevant doc (e.g., a cross-cutting overview that doesn't contain any of the derived search terms). Mitigated by the orphan-flag pathway — the agent can still report docs it thinks are impacted, just without editing them in this pass.

## Test plan

- [ ] Squash-merge this PR
- [ ] On the next `do-issue-solo` run, observe the new shortlist step output (`/tmp/doc-terms.txt`, `/tmp/doc-shortlist.txt`) and the agent's response. Confirm wall-clock for Phase 6 drops materially vs. prior runs on similar-sized diffs.
- [ ] Confirm that if the agent flags any out-of-shortlist docs, the follow-up line appears in the PR body.
- [ ] If false negatives become a pattern, revisit and consider widen-and-retry (one extra dispatch) or extract the shortlist computation into a `maverick doc-shortlist` CLI helper for easier iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)