### PR TITLE
feat(do-issue-solo): generate timing/activity report on completion (#83)

### DIFF
--- a/skills/do-issue-solo/SKILL.md
+++ b/skills/do-issue-solo/SKILL.md
@@ -107,29 +107,40 @@ implementation.
 
 1. Initialise the issue state file per the
    mav-github-issue-workflow skill.
-2. Dispatch the **agent-issue-analyst** agent with:
+2. Log subagent start: `uv run maverick report log subagent-start --issue  --name agent-issue-analyst`.
+3. Dispatch the **agent-issue-analyst** agent with:
    - Issue number: ``
    - Mode: `solo`
-3. When the agent returns, verify:
+4. Log subagent end: `uv run maverick report log subagent-end --issue  --name agent-issue-analyst`.
+5. When the agent returns, verify:
    - `.claude/issue-state.json` has `phase` set to `design`
    - `.claude/issue-state.json` has `comments.design` set to a comment ID
-4. If the agent flagged ambiguities it could not resolve, ask the user.
+6. If the agent flagged ambiguities it could not resolve:
+   - Log question start: `uv run maverick report log question-start --issue  --topic ambiguity-resolution`.
+   - Ask the user.
+   - Log question end: `uv run maverick report log question-end --issue  --topic ambiguity-resolution`.
+
    Otherwise continue.
-5. **Checkpoint**: `uv run maverick task-progress set <repo>  design`.
+7. **Checkpoint**: `uv run maverick task-progress set <repo>  design`.
 
 ## Phase 3: Create Tasks (subagent)
 
 Run Phase 3 as a subagent.
 
-1. Dispatch the **agent-github-issue-planner** agent with:
+1. Log subagent start: `uv run maverick report log subagent-start --issue  --name agent-github-issue-planner`.
+2. Dispatch the **agent-github-issue-planner** agent with:
    - Issue number: ``
    - Design comment ID from `.claude/issue-state.json`
-2. When the agent returns, verify:
+3. Log subagent end: `uv run maverick report log subagent-end --issue  --name agent-github-issue-planner`.
+4. When the agent returns, verify:
    - `.claude/issue-state.json` has `phase` set to `tasks`
    - If < 5 tasks: `.claude/issue-state.json` has `comments.tasks` set to a comment ID
    - If >= 5 tasks: `.claude/issue-state.json` has `has_sub_issues` set to `true`
-3. If the agent flagged scope concerns, ask the user.
-4. **Checkpoint**: `uv run maverick task-progress set <repo>  tasks`.
+5. If the agent flagged scope concerns:
+   - Log question start: `uv run maverick report log question-start --issue  --topic scope-concerns`.
+   - Ask the user.
+   - Log question end: `uv run maverick report log question-end --issue  --topic scope-concerns`.
+6. **Checkpoint**: `uv run maverick task-progress set <repo>  tasks`.
 
 ## Phase 4: Create Worktree + Branch
 
@@ -232,7 +243,8 @@ PR body as a follow-up note rather than being silently rewritten.
    fi
    ```
 
-3. Dispatch **agent-tech-docs-writer** with:
+3. Log subagent start: `uv run maverick report log subagent-start --issue  --name agent-tech-docs-writer`.
+4. Dispatch **agent-tech-docs-writer** with:
    - **Mode:** `update` (per `do-docs`)
    - **Diff:** `/tmp/diff.patch`
    - **Candidate docs:** the contents of `/tmp/doc-shortlist.txt`. If
@@ -251,18 +263,19 @@ PR body as a follow-up note rather than being silently rewritten.
        human reviewer.
      - Returning "no doc changes required" is a valid outcome and must
        be reported explicitly (not silently inferred).
-4. **Record the outcome** in the PR body or as a one-line PR comment so
+5. Log subagent end: `uv run maverick report log subagent-end --issue  --name agent-tech-docs-writer`.
+6. **Record the outcome** in the PR body or as a one-line PR comment so
    the gate is auditable:
    - If docs were updated or created: list the files changed.
    - If the agent flagged out-of-shortlist docs: append a
      `Docs follow-up: <paths>` line to the PR body so the reviewer
      sees them.
    - If no changes were required: post `Docs review: no changes required.`
-5. Commit any doc changes with a `docs:` conventional commit and push
+7. Commit any doc changes with a `docs:` conventional commit and push
    per the push-per-task rule.
-6. The PR cannot proceed to Phase 7 until this phase has produced
+8. The PR cannot proceed to Phase 7 until this phase has produced
    either committed doc changes or the auditable no-op record.
-7. **Checkpoint**: `uv run maverick task-progress set <repo>  docs`.
+9. **Checkpoint**: `uv run maverick task-progress set <repo>  docs`.
 
 ## Phase 7: Pre-push Cybersecurity Review (mandatory)
 
@@ -272,14 +285,16 @@ changes (callers, importers, dependents) must be reviewed by
 `do-cybersecurity-review` before the PR can be opened.
 
 1. Compute the full diff: `git diff origin/<base>...HEAD`.
-2. Dispatch the **do-cybersecurity-review** skill with:
+2. Log skill start: `uv run maverick report log skill-start --issue  --name do-cybersecurity-review`.
+3. Dispatch the **do-cybersecurity-review** skill with:
    - **Mode:** `update`
    - **Diff:** the output of step 1, passed via stdin or as a file path
    - **Instructions:** review the changed code AND the impact set
      (callers, importers, dependents — bounded to one or two hops).
      Return the structured outcome (verdict + findings) defined in the
      skill's Update Mode contract.
-3. **Act on the verdict:**
+4. Log skill end: `uv run maverick report log skill-end --issue  --name do-cybersecurity-review`.
+5. **Act on the verdict:**
    - **BLOCKING** — halt. Surface the findings to the user verbatim.
      Do not open the PR. The user resolves the BLOCKING items by
      returning to Phase 5 (implement, test, commit, push). Re-run
@@ -290,7 +305,7 @@ changes (callers, importers, dependents) must be reviewed by
      visible to the human reviewer and to agent-code-reviewer.
    - **PASS** — record `Security review: no concerns.` in the PR body
      draft so the gate is auditable.
-4. The PR cannot proceed to Phase 8 until this phase has returned a
+6. The PR cannot proceed to Phase 8 until this phase has returned a
    non-BLOCKING verdict and the outcome has been folded into the PR
    body draft.
 
@@ -344,14 +359,16 @@ The local **agent-code-reviewer** subagent's verdict is the
 review gate the auto-merge path trusts. This is a binary verdict against
 the open PR, not a local-diff advisory loop.
 
-1. Dispatch **agent-code-reviewer** with:
+1. Log subagent start: `uv run maverick report log subagent-start --issue  --name agent-code-reviewer`.
+2. Dispatch **agent-code-reviewer** with:
    - The PR URL
    - The issue body, design comment, and tasks list (so it has the spec)
-2. The agent returns exactly one of two verdicts:
+3. Log subagent end: `uv run maverick report log subagent-end --issue  --name agent-code-reviewer`.
+4. The agent returns exactly one of two verdicts:
    - **PASS** — proceed to Phase 10 (merge).
    - **FAIL** — proceed to Phase 11 (eject). Do not attempt to auto-fix.
-3. Update phase to `review` in the state file.
-4. **Checkpoint**: `uv run maverick task-progress set <repo>  review`.
+5. Update phase to `review` in the state file.
+6. **Checkpoint**: `uv run maverick task-progress set <repo>  review`.
 
 There is no fix-and-re-review loop. If the reviewer FAILs the PR, the
 next step is eject-to-human, not iterate.
@@ -411,6 +428,21 @@ next step is eject-to-human, not iterate.
     - Local state file
     - Destroy the worktree: `uv run maverick worktree destroy <worktree-path>`.
 11. **Checkpoint**: `uv run maverick task-progress set <repo>  complete`.
+12. **Generate the timing report** (#83). The report is written to the
+    **main repo's** `.maverick/reports/` (resolved via `git rev-parse
+    --git-common-dir`), not the destroyed worktree's:
+    ```bash
+    uv run maverick report generate <repo>  --branch <branch>
+    ```
+13. **Fill in the per-phase narratives.** Read
+    `.maverick/reports/do-issue-solo-.md`. For each phase
+    row whose Activity cell starts with `PLACEHOLDER`, replace the
+    `PLACEHOLDER` prefix with a single sentence summarising what
+    actually happened in that phase (from your session memory — e.g.
+    "Issue analyst summarised the bug and proposed three rollout
+    options."). Keep the structured facts that follow the `—` and
+    leave timestamps, durations, sub-task rows, and the summary table
+    untouched. Write the file back.
 
 ## Phase 11: Eject (on FAIL)
 
@@ -434,8 +466,19 @@ next step is eject-to-human, not iterate.
    - Trigger block propagation per `mav-block-propagation`:
      apply `blocked-by:#` to every transitive descendant.
    - Cancel any in-flight subagent work for stories now in the blocked set.
-5. Release the claim: `uv run maverick coord release <repo>  --reason ejected`.
-6. Do **not** destroy the worktree — the human may want to inspect it.
+5. **Checkpoint the eject** (#83): `uv run maverick task-progress set <repo>  ejected`.
+6. **Generate the timing report** for the run so the human reviewer
+   can see how time was spent leading up to the eject:
+   ```bash
+   uv run maverick report generate <repo>  --branch <branch>
+   ```
+7. **Fill in the per-phase narratives.** Same as the PASS path: read
+   `.maverick/reports/do-issue-solo-.md` and replace each
+   `PLACEHOLDER` prefix with a one-sentence narrative from session
+   memory. Write the file back. Generate the report **before**
+   releasing the claim so it lands even if release errors.
+8. Release the claim: `uv run maverick coord release <repo>  --reason ejected`.
+9. Do **not** destroy the worktree — the human may want to inspect it.
    Log the worktree path so the user can find it.
 
 ## Rules

--- a/src/maverick/cli.py
+++ b/src/maverick/cli.py
@@ -206,6 +206,11 @@ def main():
 
     _build_coord(subparsers)
 
+    # do-issue-solo timing reports (#83)
+    from maverick.report_cli import build_subparsers as _build_report
+
+    _build_report(subparsers)
+
     args = parser.parse_args()
 
     if args.command == "init":
@@ -275,6 +280,7 @@ def main():
         "task-progress",
         "issue",
         "git-workflow",
+        "report",
     ):
         import sys as _sys
 

--- a/src/maverick/coord_cli.py
+++ b/src/maverick/coord_cli.py
@@ -260,6 +260,22 @@ def _task_progress_set(args: argparse.Namespace) -> int:
         payload,
         preamble="<!-- maverick task-progress -->",
     )
+    # Best-effort timeline append for the `maverick report generate`
+    # path (#83). Local history; never fails the durable marker write.
+    try:
+        from maverick import report_cli
+
+        report_cli.append_event(
+            args.issue,
+            {
+                "type": "phase-checkpoint",
+                "phase": args.phase,
+                "ts": payload["updated_at"],
+                "instance_id": payload["instance_id"],
+            },
+        )
+    except Exception as e:  # noqa: BLE001 — best-effort
+        print(f"warning: timeline append failed: {e}", file=sys.stderr)
     _json_print(payload)
     return 0
 

--- a/src/maverick/gh_state.py
+++ b/src/maverick/gh_state.py
@@ -54,6 +54,7 @@ TASK_PROGRESS_PHASES = (
     "review",
     "merged",
     "complete",
+    "ejected",
 )
 
 

--- a/src/maverick/report_cli.py
+++ b/src/maverick/report_cli.py
@@ -1,0 +1,650 @@
+"""CLI sub-commands for do-issue-solo timing reports (#83).
+
+Exposes a small command surface that the do-issue-solo skill body uses to
+record timeline events during a run, plus a `generate` command that
+renders the final markdown report.
+
+Design notes:
+
+- The rolling `maverick-task-progress` GitHub marker only carries the
+  latest phase, so per-phase timestamps are not recoverable from
+  GitHub. We capture phase boundaries (and other events) to a local
+  JSONL file under `<main-repo>/.maverick/reports/`. The file is
+  durable across worktree destruction because we resolve the **main**
+  repo root via `git rev-parse --git-common-dir`.
+- `append_event` is best-effort. A logging failure must never break a
+  do-issue-solo run, so we swallow exceptions and warn on stderr.
+- `render` is a pure function: it takes already-loaded data (events +
+  git log + PR metadata + claim time) and returns a markdown string.
+  The CLI command wires up I/O; tests exercise `render` directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Event type values accepted by `maverick report log`. Unknown types
+# parse and round-trip but are warned about and ignored at render time.
+KNOWN_EVENT_TYPES: frozenset[str] = frozenset(
+    {
+        "phase-checkpoint",
+        "subagent-start",
+        "subagent-end",
+        "skill-start",
+        "skill-end",
+        "question-start",
+        "question-end",
+        "commit",
+        "resume",
+    }
+)
+
+# Display labels for the report. Order mirrors do-issue-solo phases.
+PHASE_LABELS: dict[str, str] = {
+    "claimed": "Phase 0 — coordination",
+    "design": "Phase 1-2 — understand + design",
+    "tasks": "Phase 3 — create tasks",
+    "branch": "Phase 4 — worktree + branch",
+    "implement": "Phase 5 — execute tasks",
+    "docs": "Phase 6 — documentation review",
+    "security": "Phase 7 — cybersecurity review",
+    "pr_open": "Phase 8 — open PR",
+    "ci_green": "Phase 8 — CI green",
+    "review": "Phase 9 — code review",
+    "merged": "Phase 10 — merged",
+    "complete": "Phase 10 — complete",
+    "ejected": "Phase 11 — ejected",
+}
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+
+def _main_repo_root(cwd: Path | None = None) -> Path:
+    """Resolve the main repo root, even when called from inside a worktree.
+
+    `git rev-parse --git-common-dir` returns the **shared** `.git`
+    directory for the main checkout (whereas `--git-dir` points at the
+    worktree's `.git` file). The parent of the common dir is the main
+    repo root. Falls back to ``cwd`` (or ``Path.cwd()``) when not in a
+    git repo — keeps unit tests trivial.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=cwd,
+        )
+        common_dir = Path(out.stdout.strip())
+        if not common_dir.is_absolute():
+            base = cwd or Path.cwd()
+            common_dir = (base / common_dir).resolve()
+        return common_dir.parent
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return cwd or Path.cwd()
+
+
+def timeline_path(issue: int, repo_root: Path | None = None) -> Path:
+    """Resolve the JSONL path for an issue's timeline."""
+    root = repo_root or _main_repo_root()
+    return root / ".maverick" / "reports" / f".do-issue-solo-{issue}.timeline.jsonl"
+
+
+def report_path(issue: int, repo_root: Path | None = None) -> Path:
+    """Resolve the rendered-report path for an issue."""
+    root = repo_root or _main_repo_root()
+    return root / ".maverick" / "reports" / f"do-issue-solo-{issue}.md"
+
+
+# ---------------------------------------------------------------------------
+# JSONL writer
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def append_event(
+    issue: int,
+    event: dict[str, Any],
+    repo_root: Path | None = None,
+) -> bool:
+    """Append a single event to the issue's timeline JSONL.
+
+    Returns True on success, False if the write failed for any reason.
+    Never raises — logging must never break a do-issue-solo run.
+    """
+    try:
+        path = timeline_path(issue, repo_root=repo_root)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        record = dict(event)
+        record.setdefault("ts", _now_iso())
+        record.setdefault("issue", issue)
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, sort_keys=True) + "\n")
+        return True
+    except Exception as e:  # noqa: BLE001 — best-effort; warn-not-raise
+        print(f"warning: report log append failed: {e}", file=sys.stderr)
+        return False
+
+
+def _validate_event(d: Any) -> bool:
+    """Defensive validator. Returns False for malformed records (skipped
+    at render time with a stderr warning)."""
+    if not isinstance(d, dict):
+        return False
+    ts = d.get("ts")
+    if not isinstance(ts, str) or not ts.endswith("Z"):
+        return False
+    if not isinstance(d.get("type"), str):
+        return False
+    return True
+
+
+def load_timeline(path: Path) -> list[dict[str, Any]]:
+    """Load and validate a JSONL timeline. Skips malformed lines."""
+    if not path.exists():
+        return []
+    events: list[dict[str, Any]] = []
+    for i, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            d = json.loads(raw)
+        except json.JSONDecodeError:
+            print(
+                f"warning: skipping malformed JSON at {path}:{i}",
+                file=sys.stderr,
+            )
+            continue
+        if not _validate_event(d):
+            print(
+                f"warning: skipping invalid event at {path}:{i}: {raw[:80]}",
+                file=sys.stderr,
+            )
+            continue
+        events.append(d)
+    events.sort(key=lambda e: e["ts"])
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def _parse_ts(s: str) -> datetime:
+    return datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
+def _fmt_duration(seconds: float) -> str:
+    """Human-readable duration. <1s shows '<1s'; otherwise compact form."""
+    if seconds is None:
+        return "—"
+    secs = int(round(seconds))
+    if secs < 1:
+        return "<1s"
+    if secs < 60:
+        return f"{secs}s"
+    minutes, secs = divmod(secs, 60)
+    if minutes < 60:
+        if secs == 0:
+            return f"{minutes}m"
+        return f"{minutes}m {secs}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h {minutes}m"
+
+
+def _fmt_time(ts: str) -> str:
+    """Render an ISO timestamp as HH:MM:SS (UTC)."""
+    try:
+        return _parse_ts(ts).strftime("%H:%M:%S")
+    except (ValueError, TypeError):
+        return ts
+
+
+def _pair_intervals(
+    events: Sequence[dict[str, Any]],
+    start_type: str,
+    end_type: str,
+    key_field: str,
+) -> list[tuple[str, str, str, str]]:
+    """Pair start/end events by `key_field`. Returns
+    [(key, start_ts, end_ts, owning_phase), ...]. Unmatched starts get
+    end=start (zero duration); unmatched ends are ignored.
+    """
+    open_intervals: dict[str, tuple[str, str]] = {}
+    out: list[tuple[str, str, str, str]] = []
+    current_phase = ""
+    for e in events:
+        if e["type"] == "phase-checkpoint":
+            current_phase = e.get("phase", "")
+            continue
+        if e["type"] == start_type:
+            key = str(e.get(key_field, ""))
+            open_intervals[key] = (e["ts"], current_phase)
+        elif e["type"] == end_type:
+            key = str(e.get(key_field, ""))
+            opened = open_intervals.pop(key, None)
+            if opened is None:
+                continue
+            start_ts, phase = opened
+            out.append((key, start_ts, e["ts"], phase))
+    for key, (start_ts, phase) in open_intervals.items():
+        out.append((key, start_ts, start_ts, phase))
+    return out
+
+
+def _phase_intervals(
+    events: Sequence[dict[str, Any]],
+    claim_created_at: str | None,
+) -> list[tuple[str, str, str]]:
+    """Build [(phase, start_ts, end_ts), ...] from phase-checkpoint events.
+
+    Each checkpoint marks the **end** of its phase. The first phase's
+    start is `claim_created_at` (if available) or the first event's
+    timestamp.
+    """
+    cps = [e for e in events if e["type"] == "phase-checkpoint"]
+    if not cps:
+        return []
+    intervals: list[tuple[str, str, str]] = []
+    prev_end = claim_created_at
+    if not prev_end and events:
+        prev_end = events[0]["ts"]
+    for cp in cps:
+        phase = cp.get("phase", "")
+        start_ts = prev_end or cp["ts"]
+        end_ts = cp["ts"]
+        intervals.append((phase, start_ts, end_ts))
+        prev_end = end_ts
+    return intervals
+
+
+def _seconds_between(start: str, end: str) -> float:
+    try:
+        return (_parse_ts(end) - _parse_ts(start)).total_seconds()
+    except (ValueError, TypeError):
+        return 0.0
+
+
+def _facts_for_phase(
+    phase: str,
+    events: Sequence[dict[str, Any]],
+    subagents: Sequence[tuple[str, str, str, str]],
+    questions: Sequence[tuple[str, str, str, str]],
+    skills: Sequence[tuple[str, str, str, str]],
+) -> str:
+    """Build the auto-generated facts portion of a phase's Activity cell."""
+    pieces: list[str] = []
+    for name, s, e, p in subagents:
+        if p == phase:
+            pieces.append(f"{name} ({_fmt_duration(_seconds_between(s, e))})")
+    for name, s, e, p in skills:
+        if p == phase:
+            pieces.append(f"{name} ({_fmt_duration(_seconds_between(s, e))})")
+    for topic, s, e, p in questions:
+        if p == phase:
+            pieces.append(f"question: {topic} ({_fmt_duration(_seconds_between(s, e))})")
+    return " + ".join(pieces) if pieces else ""
+
+
+def render(
+    issue: int,
+    events: Sequence[dict[str, Any]],
+    commits: Sequence[dict[str, Any]] | None = None,
+    pr: dict[str, Any] | None = None,
+    claim_created_at: str | None = None,
+) -> str:
+    """Render the timing report to markdown.
+
+    Pure function — all inputs are passed; no I/O. The CLI command
+    `maverick report generate` fetches `commits`/`pr`/`claim_created_at`
+    and calls this.
+
+    - `events` — chronological timeline events (already validated/sorted).
+    - `commits` — list of {sha, committed_at, subject} for Phase 5
+      sub-rows. May be empty if branch info is unavailable.
+    - `pr` — {created_at, merged_at, number} from `gh pr view`. May be None.
+    - `claim_created_at` — ISO timestamp from the maverick-claim marker.
+      Anchors the first phase's start.
+    """
+    commits = list(commits or [])
+    if not events:
+        return f"# Issue #{issue} — time breakdown\n\nNo timeline events recorded.\n"
+
+    subagents = _pair_intervals(events, "subagent-start", "subagent-end", "name")
+    questions = _pair_intervals(events, "question-start", "question-end", "topic")
+    skills = _pair_intervals(events, "skill-start", "skill-end", "name")
+    phases = _phase_intervals(events, claim_created_at)
+
+    first_ts = claim_created_at or events[0]["ts"]
+    last_ts = events[-1]["ts"]
+    total = _seconds_between(first_ts, last_ts)
+
+    out: list[str] = []
+    out.append(f"# Issue #{issue} — time breakdown")
+    out.append("")
+    out.append(
+        f"Wall-clock: **{_fmt_duration(total)}** from "
+        f"{first_ts} to {last_ts}. All timestamps below are UTC. "
+        "Phase boundaries come from `maverick task-progress` checkpoints; "
+        "sub-task rows in the implement phase come from commit times; "
+        "PR open/merge timestamps come from `gh pr view`."
+    )
+    out.append("")
+    out.append("## Phases")
+    out.append("")
+    out.append("| Phase | Activity | Start | End | Duration |")
+    out.append("|---|---|---|---|---|")
+
+    implement_seen = False
+    for phase, s, e in phases:
+        label = PHASE_LABELS.get(phase, phase)
+        facts = _facts_for_phase(phase, events, subagents, questions, skills)
+        activity = f"PLACEHOLDER — {facts}" if facts else "PLACEHOLDER"
+        dur = _fmt_duration(_seconds_between(s, e))
+        out.append(f"| {label} | {activity} | {_fmt_time(s)} | {_fmt_time(e)} | {dur} |")
+        if phase == "implement" and commits and not implement_seen:
+            implement_seen = True
+            prev_ts = s
+            for c in commits:
+                sub = (c.get("subject") or "").replace("|", "\\|")
+                sha = (c.get("sha") or "")[:7]
+                c_ts = c.get("committed_at") or ""
+                dur_c = _fmt_duration(_seconds_between(prev_ts, c_ts)) if c_ts else "—"
+                out.append(
+                    f"| ↳ commit | `{sha}` — {sub} | "
+                    f"{_fmt_time(prev_ts)} | {_fmt_time(c_ts)} | {dur_c} |"
+                )
+                prev_ts = c_ts
+
+    out.append("")
+    out.append("## Where the time actually went")
+    out.append("")
+    out.append("| Slice | Wall-clock |")
+    out.append("|---|---|")
+
+    subagent_total = sum(_seconds_between(s, e) for _, s, e, _ in subagents)
+    skill_total = sum(_seconds_between(s, e) for _, s, e, _ in skills)
+    question_total = sum(_seconds_between(s, e) for _, s, e, _ in questions)
+
+    impl_total = 0.0
+    if commits and phases:
+        for phase, s, _e in phases:
+            if phase == "implement":
+                prev_ts = s
+                for c in commits:
+                    c_ts = c.get("committed_at") or ""
+                    if c_ts:
+                        impl_total += _seconds_between(prev_ts, c_ts)
+                        prev_ts = c_ts
+                break
+
+    coord_total = total - subagent_total - skill_total - question_total - impl_total
+    if coord_total < 0:
+        coord_total = 0.0
+
+    out.append(f"| Subagent compute | {_fmt_duration(subagent_total)} |")
+    out.append(f"| Skill dispatches (do-cybersecurity-review etc.) | {_fmt_duration(skill_total)} |")
+    out.append(f"| Implementation (commit-to-commit inside Phase 5) | {_fmt_duration(impl_total)} |")
+    out.append(f"| User decision points | {_fmt_duration(question_total)} |")
+    out.append(f"| Coordination / CLI / checkpoint overhead | {_fmt_duration(coord_total)} |")
+
+    if pr:
+        out.append("")
+        out.append("## PR")
+        out.append("")
+        pr_num = pr.get("number")
+        out.append(f"- PR #{pr_num}: opened {pr.get('created_at') or '?'} → merged {pr.get('merged_at') or '?'}")
+
+    out.append("")
+    out.append(
+        "_Activity cells marked `PLACEHOLDER` are intended to be replaced "
+        "with a one-sentence narrative of what happened in that phase. "
+        "Re-run `maverick report generate` to regenerate from the timeline._"
+    )
+    out.append("")
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# External data helpers (network/shell — not exercised in unit tests)
+# ---------------------------------------------------------------------------
+
+
+def _fetch_commits(branch: str | None, base: str | None) -> list[dict[str, Any]]:
+    """Resolve commit log via `git log`. Returns [] on failure or when
+    `branch`/`base` cannot be resolved."""
+    if not branch:
+        return []
+    base = base or "origin/main"
+    try:
+        out = subprocess.run(
+            ["git", "log", f"{base}..{branch}", "--reverse", "--pretty=%H|%cI|%s"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        print(f"warning: git log failed for {base}..{branch}: {e}", file=sys.stderr)
+        return []
+    commits: list[dict[str, Any]] = []
+    for line in out.stdout.splitlines():
+        parts = line.split("|", 2)
+        if len(parts) != 3:
+            continue
+        sha, c_ts, subject = parts
+        commits.append({"sha": sha, "committed_at": c_ts, "subject": subject})
+    return commits
+
+
+def _fetch_pr(repo: str, issue: int) -> dict[str, Any] | None:
+    """Look up the PR for an issue via `gh pr list --search '<issue-ref>'`."""
+    try:
+        out = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "all",
+                "--search",
+                f"#{issue} in:body",
+                "--json",
+                "number,createdAt,mergedAt,state",
+                "--limit",
+                "5",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        data = json.loads(out.stdout)
+    except (subprocess.CalledProcessError, FileNotFoundError, json.JSONDecodeError) as e:
+        print(f"warning: gh pr lookup failed: {e}", file=sys.stderr)
+        return None
+    if not data:
+        return None
+    # Prefer the most-recently-merged one; otherwise first.
+    merged = [p for p in data if p.get("mergedAt")]
+    chosen = merged[0] if merged else data[0]
+    return {
+        "number": chosen.get("number"),
+        "created_at": chosen.get("createdAt"),
+        "merged_at": chosen.get("mergedAt"),
+    }
+
+
+def _fetch_claim_created_at(repo: str, issue: int) -> str | None:
+    """Read the claim marker's claimed_at field via `maverick gh-state read`."""
+    try:
+        from maverick import gh_state
+
+        m = gh_state.latest_marker(repo, issue, "maverick-claim")
+        if m and isinstance(m.payload, dict):
+            return m.payload.get("claimed_at")
+    except Exception as e:  # noqa: BLE001 — best-effort enrichment
+        print(f"warning: claim marker lookup failed: {e}", file=sys.stderr)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# CLI handlers
+# ---------------------------------------------------------------------------
+
+
+def _report_log(args: argparse.Namespace) -> int:
+    event: dict[str, Any] = {"type": args.event_type}
+    if args.name:
+        event["name"] = args.name
+    if args.topic:
+        event["topic"] = args.topic
+    if args.phase:
+        event["phase"] = args.phase
+    if args.sha:
+        event["sha"] = args.sha
+    if args.task:
+        event["task"] = args.task
+    for raw in args.meta or []:
+        if "=" not in raw:
+            print(f"warning: ignoring --meta without '=': {raw}", file=sys.stderr)
+            continue
+        k, v = raw.split("=", 1)
+        event[k] = v
+    if args.event_type not in KNOWN_EVENT_TYPES:
+        print(
+            f"warning: unknown event type '{args.event_type}' (logging anyway)",
+            file=sys.stderr,
+        )
+    append_event(args.issue, event)
+    return 0
+
+
+def _report_generate(args: argparse.Namespace) -> int:
+    issue = args.issue
+    repo_root = _main_repo_root()
+    tpath = timeline_path(issue, repo_root=repo_root)
+    events = load_timeline(tpath)
+    if not events:
+        print(f"no timeline data for issue {issue} at {tpath}", file=sys.stderr)
+        return 2
+
+    branch = args.branch
+    base = args.base or "origin/main"
+    commits = _fetch_commits(branch, base)
+    pr = _fetch_pr(args.repo, issue) if args.repo else None
+    claim_ts = _fetch_claim_created_at(args.repo, issue) if args.repo else None
+
+    md = render(
+        issue=issue,
+        events=events,
+        commits=commits,
+        pr=pr,
+        claim_created_at=claim_ts,
+    )
+
+    out_path = Path(args.out) if args.out else report_path(issue, repo_root=repo_root)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(md, encoding="utf-8")
+    print(str(out_path))
+    return 0
+
+
+def _report_path(args: argparse.Namespace) -> int:
+    print(str(timeline_path(args.issue)))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Subparser wiring
+# ---------------------------------------------------------------------------
+
+
+def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
+    r = subparsers.add_parser(
+        "report",
+        help="do-issue-solo timing reports (log events / render markdown)",
+    )
+    r_sub = r.add_subparsers(dest="report_cmd", required=True)
+
+    p = r_sub.add_parser(
+        "log",
+        help="Append a timeline event for an issue (used by do-issue-solo)",
+    )
+    p.add_argument(
+        "event_type",
+        help="Event type, e.g. subagent-start, subagent-end, question-start",
+    )
+    p.add_argument("--issue", type=int, required=True, help="GitHub issue number")
+    p.add_argument("--name", help="Agent or skill name (subagent-* / skill-*)")
+    p.add_argument("--topic", help="Question topic (question-*)")
+    p.add_argument("--phase", help="Phase name (phase-checkpoint)")
+    p.add_argument("--sha", help="Commit SHA (commit)")
+    p.add_argument("--task", help="Task label (subagent-* / commit)")
+    p.add_argument(
+        "--meta",
+        action="append",
+        help="Extra key=value pair; may be repeated",
+    )
+    p.set_defaults(_handler=_report_log)
+
+    p = r_sub.add_parser(
+        "generate",
+        help="Render the timing-report markdown to .maverick/reports/",
+    )
+    p.add_argument("repo", help="owner/repo (used to look up PR + claim metadata)")
+    p.add_argument("issue", type=int)
+    p.add_argument(
+        "--branch",
+        help="Feature branch (defaults to current branch via `git rev-parse`)",
+    )
+    p.add_argument(
+        "--base",
+        help="Base branch for git-log range (default: origin/main)",
+    )
+    p.add_argument("--out", help="Override output path (default: .maverick/reports/...)")
+    p.set_defaults(_handler=_report_generate)
+
+    p = r_sub.add_parser(
+        "path",
+        help="Print the resolved timeline JSONL path for an issue",
+    )
+    p.add_argument("issue", type=int)
+    p.set_defaults(_handler=_report_path)
+
+
+def dispatch(args: argparse.Namespace) -> int:
+    handler = getattr(args, "_handler", None)
+    if handler is None:
+        print("no handler wired", file=sys.stderr)
+        return 1
+    return int(handler(args) or 0)
+
+
+__all__ = [
+    "KNOWN_EVENT_TYPES",
+    "PHASE_LABELS",
+    "append_event",
+    "build_subparsers",
+    "dispatch",
+    "load_timeline",
+    "render",
+    "report_path",
+    "timeline_path",
+]

--- a/src/maverick/skills/do-issue-solo/body.md.j2
+++ b/src/maverick/skills/do-issue-solo/body.md.j2
@@ -100,29 +100,40 @@ implementation.
 
 1. Initialise the issue state file per the
    {{ SKILLS.MAV_GITHUB_ISSUE_WORKFLOW }} skill.
-2. Dispatch the **{{ AGENTS.AGENT_ISSUE_ANALYST }}** agent with:
+2. Log subagent start: `uv run maverick report log subagent-start --issue {{ ARGUMENTS }} --name {{ AGENTS.AGENT_ISSUE_ANALYST }}`.
+3. Dispatch the **{{ AGENTS.AGENT_ISSUE_ANALYST }}** agent with:
    - Issue number: `{{ ARGUMENTS }}`
    - Mode: `solo`
-3. When the agent returns, verify:
+4. Log subagent end: `uv run maverick report log subagent-end --issue {{ ARGUMENTS }} --name {{ AGENTS.AGENT_ISSUE_ANALYST }}`.
+5. When the agent returns, verify:
    - `.claude/issue-state.json` has `phase` set to `design`
    - `.claude/issue-state.json` has `comments.design` set to a comment ID
-4. If the agent flagged ambiguities it could not resolve, ask the user.
+6. If the agent flagged ambiguities it could not resolve:
+   - Log question start: `uv run maverick report log question-start --issue {{ ARGUMENTS }} --topic ambiguity-resolution`.
+   - Ask the user.
+   - Log question end: `uv run maverick report log question-end --issue {{ ARGUMENTS }} --topic ambiguity-resolution`.
+
    Otherwise continue.
-5. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} design`.
+7. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} design`.
 
 ## Phase 3: Create Tasks (subagent)
 
 Run Phase 3 as a subagent.
 
-1. Dispatch the **{{ AGENTS.AGENT_GITHUB_ISSUE_PLANNER }}** agent with:
+1. Log subagent start: `uv run maverick report log subagent-start --issue {{ ARGUMENTS }} --name {{ AGENTS.AGENT_GITHUB_ISSUE_PLANNER }}`.
+2. Dispatch the **{{ AGENTS.AGENT_GITHUB_ISSUE_PLANNER }}** agent with:
    - Issue number: `{{ ARGUMENTS }}`
    - Design comment ID from `.claude/issue-state.json`
-2. When the agent returns, verify:
+3. Log subagent end: `uv run maverick report log subagent-end --issue {{ ARGUMENTS }} --name {{ AGENTS.AGENT_GITHUB_ISSUE_PLANNER }}`.
+4. When the agent returns, verify:
    - `.claude/issue-state.json` has `phase` set to `tasks`
    - If < 5 tasks: `.claude/issue-state.json` has `comments.tasks` set to a comment ID
    - If >= 5 tasks: `.claude/issue-state.json` has `has_sub_issues` set to `true`
-3. If the agent flagged scope concerns, ask the user.
-4. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} tasks`.
+5. If the agent flagged scope concerns:
+   - Log question start: `uv run maverick report log question-start --issue {{ ARGUMENTS }} --topic scope-concerns`.
+   - Ask the user.
+   - Log question end: `uv run maverick report log question-end --issue {{ ARGUMENTS }} --topic scope-concerns`.
+6. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} tasks`.
 
 ## Phase 4: Create Worktree + Branch
 
@@ -225,7 +236,8 @@ PR body as a follow-up note rather than being silently rewritten.
    fi
    ```
 {% endraw %}
-3. Dispatch **{{ AGENTS.AGENT_TECH_DOCS_WRITER }}** with:
+3. Log subagent start: `uv run maverick report log subagent-start --issue {{ ARGUMENTS }} --name {{ AGENTS.AGENT_TECH_DOCS_WRITER }}`.
+4. Dispatch **{{ AGENTS.AGENT_TECH_DOCS_WRITER }}** with:
    - **Mode:** `update` (per `{{ SKILLS.DO_DOCS }}`)
    - **Diff:** `/tmp/diff.patch`
    - **Candidate docs:** the contents of `/tmp/doc-shortlist.txt`. If
@@ -244,18 +256,19 @@ PR body as a follow-up note rather than being silently rewritten.
        human reviewer.
      - Returning "no doc changes required" is a valid outcome and must
        be reported explicitly (not silently inferred).
-4. **Record the outcome** in the PR body or as a one-line PR comment so
+5. Log subagent end: `uv run maverick report log subagent-end --issue {{ ARGUMENTS }} --name {{ AGENTS.AGENT_TECH_DOCS_WRITER }}`.
+6. **Record the outcome** in the PR body or as a one-line PR comment so
    the gate is auditable:
    - If docs were updated or created: list the files changed.
    - If the agent flagged out-of-shortlist docs: append a
      `Docs follow-up: <paths>` line to the PR body so the reviewer
      sees them.
    - If no changes were required: post `Docs review: no changes required.`
-5. Commit any doc changes with a `docs:` conventional commit and push
+7. Commit any doc changes with a `docs:` conventional commit and push
    per the push-per-task rule.
-6. The PR cannot proceed to Phase 7 until this phase has produced
+8. The PR cannot proceed to Phase 7 until this phase has produced
    either committed doc changes or the auditable no-op record.
-7. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} docs`.
+9. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} docs`.
 
 ## Phase 7: Pre-push Cybersecurity Review (mandatory)
 
@@ -265,14 +278,16 @@ changes (callers, importers, dependents) must be reviewed by
 `{{ SKILLS.DO_CYBERSECURITY_REVIEW }}` before the PR can be opened.
 
 1. Compute the full diff: `git diff origin/<base>...HEAD`.
-2. Dispatch the **{{ SKILLS.DO_CYBERSECURITY_REVIEW }}** skill with:
+2. Log skill start: `uv run maverick report log skill-start --issue {{ ARGUMENTS }} --name {{ SKILLS.DO_CYBERSECURITY_REVIEW }}`.
+3. Dispatch the **{{ SKILLS.DO_CYBERSECURITY_REVIEW }}** skill with:
    - **Mode:** `update`
    - **Diff:** the output of step 1, passed via stdin or as a file path
    - **Instructions:** review the changed code AND the impact set
      (callers, importers, dependents — bounded to one or two hops).
      Return the structured outcome (verdict + findings) defined in the
      skill's Update Mode contract.
-3. **Act on the verdict:**
+4. Log skill end: `uv run maverick report log skill-end --issue {{ ARGUMENTS }} --name {{ SKILLS.DO_CYBERSECURITY_REVIEW }}`.
+5. **Act on the verdict:**
    - **BLOCKING** — halt. Surface the findings to the user verbatim.
      Do not open the PR. The user resolves the BLOCKING items by
      returning to Phase 5 (implement, test, commit, push). Re-run
@@ -283,7 +298,7 @@ changes (callers, importers, dependents) must be reviewed by
      visible to the human reviewer and to {{ AGENTS.AGENT_CODE_REVIEWER }}.
    - **PASS** — record `Security review: no concerns.` in the PR body
      draft so the gate is auditable.
-4. The PR cannot proceed to Phase 8 until this phase has returned a
+6. The PR cannot proceed to Phase 8 until this phase has returned a
    non-BLOCKING verdict and the outcome has been folded into the PR
    body draft.
 
@@ -337,14 +352,16 @@ The local **{{ AGENTS.AGENT_CODE_REVIEWER }}** subagent's verdict is the
 review gate the auto-merge path trusts. This is a binary verdict against
 the open PR, not a local-diff advisory loop.
 
-1. Dispatch **{{ AGENTS.AGENT_CODE_REVIEWER }}** with:
+1. Log subagent start: `uv run maverick report log subagent-start --issue {{ ARGUMENTS }} --name {{ AGENTS.AGENT_CODE_REVIEWER }}`.
+2. Dispatch **{{ AGENTS.AGENT_CODE_REVIEWER }}** with:
    - The PR URL
    - The issue body, design comment, and tasks list (so it has the spec)
-2. The agent returns exactly one of two verdicts:
+3. Log subagent end: `uv run maverick report log subagent-end --issue {{ ARGUMENTS }} --name {{ AGENTS.AGENT_CODE_REVIEWER }}`.
+4. The agent returns exactly one of two verdicts:
    - **PASS** — proceed to Phase 10 (merge).
    - **FAIL** — proceed to Phase 11 (eject). Do not attempt to auto-fix.
-3. Update phase to `review` in the state file.
-4. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} review`.
+5. Update phase to `review` in the state file.
+6. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} review`.
 
 There is no fix-and-re-review loop. If the reviewer FAILs the PR, the
 next step is eject-to-human, not iterate.
@@ -404,6 +421,21 @@ next step is eject-to-human, not iterate.
     - Local state file
     - Destroy the worktree: `uv run maverick worktree destroy <worktree-path>`.
 11. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} complete`.
+12. **Generate the timing report** (#83). The report is written to the
+    **main repo's** `.maverick/reports/` (resolved via `git rev-parse
+    --git-common-dir`), not the destroyed worktree's:
+    ```bash
+    uv run maverick report generate <repo> {{ ARGUMENTS }} --branch <branch>
+    ```
+13. **Fill in the per-phase narratives.** Read
+    `.maverick/reports/do-issue-solo-{{ ARGUMENTS }}.md`. For each phase
+    row whose Activity cell starts with `PLACEHOLDER`, replace the
+    `PLACEHOLDER` prefix with a single sentence summarising what
+    actually happened in that phase (from your session memory — e.g.
+    "Issue analyst summarised the bug and proposed three rollout
+    options."). Keep the structured facts that follow the `—` and
+    leave timestamps, durations, sub-task rows, and the summary table
+    untouched. Write the file back.
 
 ## Phase 11: Eject (on FAIL)
 
@@ -427,8 +459,19 @@ next step is eject-to-human, not iterate.
    - Trigger block propagation per `{{ SKILLS.MAV_BLOCK_PROPAGATION }}`:
      apply `blocked-by:#{{ ARGUMENTS }}` to every transitive descendant.
    - Cancel any in-flight subagent work for stories now in the blocked set.
-5. Release the claim: `uv run maverick coord release <repo> {{ ARGUMENTS }} --reason ejected`.
-6. Do **not** destroy the worktree — the human may want to inspect it.
+5. **Checkpoint the eject** (#83): `uv run maverick task-progress set <repo> {{ ARGUMENTS }} ejected`.
+6. **Generate the timing report** for the run so the human reviewer
+   can see how time was spent leading up to the eject:
+   ```bash
+   uv run maverick report generate <repo> {{ ARGUMENTS }} --branch <branch>
+   ```
+7. **Fill in the per-phase narratives.** Same as the PASS path: read
+   `.maverick/reports/do-issue-solo-{{ ARGUMENTS }}.md` and replace each
+   `PLACEHOLDER` prefix with a one-sentence narrative from session
+   memory. Write the file back. Generate the report **before**
+   releasing the claim so it lands even if release errors.
+8. Release the claim: `uv run maverick coord release <repo> {{ ARGUMENTS }} --reason ejected`.
+9. Do **not** destroy the worktree — the human may want to inspect it.
    Log the worktree path so the user can find it.
 
 ## Rules

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -416,7 +416,7 @@ class TestTaskProgressCli:
     ):
         import argparse
 
-        from maverick import coord_cli, gh_state
+        from maverick import coord_cli, gh_state, report_cli
 
         monkeypatch.setattr(
             coordinator, "_instance_id_path", lambda: tmp_path / "instance_id"
@@ -434,6 +434,16 @@ class TestTaskProgressCli:
             return 1
 
         monkeypatch.setattr(gh_state, "upsert_marker", fake_upsert)
+        # Redirect the timeline append (#83) to tmp_path so the test
+        # doesn't litter the working tree's .maverick/reports/.
+        timeline_events: list[dict] = []
+
+        def fake_append(issue, event, repo_root=None):
+            timeline_events.append({"issue": issue, **event})
+            return True
+
+        monkeypatch.setattr(report_cli, "append_event", fake_append)
+
         args = argparse.Namespace(repo="me/r", issue=42, phase="review")
 
         rc = coord_cli._task_progress_set(args)
@@ -446,6 +456,13 @@ class TestTaskProgressCli:
         assert captured["payload"]["instance_id"] == "i-abc"
         assert captured["payload"]["updated_at"].endswith("Z")
         assert "task-progress" in captured["preamble"]
+        # #83: task-progress set must also append a phase-checkpoint
+        # event to the local timeline JSONL so the report generator
+        # can reconstruct per-phase timestamps.
+        assert len(timeline_events) == 1
+        assert timeline_events[0]["type"] == "phase-checkpoint"
+        assert timeline_events[0]["phase"] == "review"
+        assert timeline_events[0]["issue"] == 42
 
     def test_read_returns_latest_marker_payload(self, monkeypatch):
         import argparse

--- a/tests/unit/test_gh_state.py
+++ b/tests/unit/test_gh_state.py
@@ -97,6 +97,9 @@ class TestTaskProgressMarker:
         # The CLI's `task-progress set <phase>` validates against this list,
         # and the do-issue-solo skill's resume table assumes this ordering.
         assert TASK_PROGRESS_PHASES[0] == "claimed"
-        assert TASK_PROGRESS_PHASES[-1] == "complete"
+        # `complete` and `ejected` are both terminal phases (PASS and FAIL
+        # paths). Either may be the final value depending on how the run
+        # ended.
+        assert {"complete", "ejected"}.issubset(TASK_PROGRESS_PHASES)
         # Each phase must be unique.
         assert len(TASK_PROGRESS_PHASES) == len(set(TASK_PROGRESS_PHASES))

--- a/tests/unit/test_report_cli.py
+++ b/tests/unit/test_report_cli.py
@@ -1,0 +1,310 @@
+"""Unit tests for the `maverick report` CLI surface (#83)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from maverick import report_cli
+
+
+def _parse(*argv: str) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    report_cli.build_subparsers(sub)
+    return parser.parse_args(list(argv))
+
+
+# ---------------------------------------------------------------------------
+# argparse wiring
+# ---------------------------------------------------------------------------
+
+
+class TestArgparseWiring:
+    def test_log_subcommand_parses(self):
+        args = _parse(
+            "report", "log", "subagent-start",
+            "--issue", "123", "--name", "agent-issue-analyst",
+        )
+        assert args._handler is report_cli._report_log
+        assert args.issue == 123
+        assert args.event_type == "subagent-start"
+        assert args.name == "agent-issue-analyst"
+
+    def test_generate_subcommand_parses(self):
+        args = _parse(
+            "report", "generate", "owner/repo", "42",
+            "--branch", "feat/42-foo",
+        )
+        assert args._handler is report_cli._report_generate
+        assert args.repo == "owner/repo"
+        assert args.issue == 42
+        assert args.branch == "feat/42-foo"
+
+    def test_path_subcommand_parses(self):
+        args = _parse("report", "path", "42")
+        assert args._handler is report_cli._report_path
+        assert args.issue == 42
+
+
+# ---------------------------------------------------------------------------
+# append_event
+# ---------------------------------------------------------------------------
+
+
+class TestAppendEvent:
+    def test_round_trip_writes_jsonl(self, tmp_path: Path):
+        ok = report_cli.append_event(
+            42,
+            {"type": "phase-checkpoint", "phase": "design"},
+            repo_root=tmp_path,
+        )
+        assert ok is True
+        path = report_cli.timeline_path(42, repo_root=tmp_path)
+        assert path.exists()
+        line = path.read_text().strip()
+        record = json.loads(line)
+        assert record["type"] == "phase-checkpoint"
+        assert record["phase"] == "design"
+        assert record["issue"] == 42
+        assert record["ts"].endswith("Z")
+
+    def test_creates_parent_directories(self, tmp_path: Path):
+        report_cli.append_event(
+            7,
+            {"type": "subagent-start", "name": "agent-x"},
+            repo_root=tmp_path,
+        )
+        path = report_cli.timeline_path(7, repo_root=tmp_path)
+        assert path.parent.exists()
+
+    def test_appends_not_overwrites(self, tmp_path: Path):
+        for phase in ("claimed", "design", "tasks"):
+            report_cli.append_event(
+                1,
+                {"type": "phase-checkpoint", "phase": phase, "ts": f"2026-01-01T00:00:0{['claimed','design','tasks'].index(phase)}Z"},
+                repo_root=tmp_path,
+            )
+        path = report_cli.timeline_path(1, repo_root=tmp_path)
+        lines = [ln for ln in path.read_text().splitlines() if ln.strip()]
+        assert len(lines) == 3
+
+    def test_failure_returns_false_does_not_raise(self, tmp_path: Path, monkeypatch):
+        # Force mkdir to raise — append_event must swallow the error.
+        from pathlib import Path as P
+
+        def boom(self, *a, **kw):
+            raise PermissionError("nope")
+
+        monkeypatch.setattr(P, "mkdir", boom)
+        ok = report_cli.append_event(
+            1, {"type": "phase-checkpoint", "phase": "design"}, repo_root=tmp_path
+        )
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# Validation + loading
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    @pytest.mark.parametrize(
+        "evt",
+        [
+            {"ts": "2026-01-01T00:00:00Z", "type": "phase-checkpoint", "phase": "design"},
+            {"ts": "2026-01-01T00:00:00Z", "type": "subagent-start", "name": "x"},
+        ],
+    )
+    def test_valid(self, evt):
+        assert report_cli._validate_event(evt)
+
+    @pytest.mark.parametrize(
+        "evt",
+        [
+            None,
+            "not a dict",
+            {"type": "phase-checkpoint"},  # missing ts
+            {"ts": "not-iso", "type": "phase-checkpoint"},  # ts not Z-suffixed
+            {"ts": "2026-01-01T00:00:00Z"},  # missing type
+            {"ts": "2026-01-01T00:00:00Z", "type": 42},  # type not str
+        ],
+    )
+    def test_invalid(self, evt):
+        assert not report_cli._validate_event(evt)
+
+    def test_load_skips_malformed_lines(self, tmp_path: Path, capsys):
+        path = tmp_path / "t.jsonl"
+        path.write_text(
+            "\n".join(
+                [
+                    json.dumps({"ts": "2026-01-01T00:00:01Z", "type": "phase-checkpoint", "phase": "design"}),
+                    "{not json",
+                    json.dumps({"type": "phase-checkpoint"}),  # invalid
+                    json.dumps({"ts": "2026-01-01T00:00:02Z", "type": "phase-checkpoint", "phase": "tasks"}),
+                    "",
+                ]
+            )
+        )
+        events = report_cli.load_timeline(path)
+        assert len(events) == 2
+        assert [e["phase"] for e in events] == ["design", "tasks"]
+        captured = capsys.readouterr()
+        assert "warning" in captured.err
+
+    def test_load_sorts_by_ts(self, tmp_path: Path):
+        path = tmp_path / "t.jsonl"
+        path.write_text(
+            "\n".join(
+                json.dumps(e)
+                for e in [
+                    {"ts": "2026-01-01T00:00:02Z", "type": "phase-checkpoint", "phase": "tasks"},
+                    {"ts": "2026-01-01T00:00:01Z", "type": "phase-checkpoint", "phase": "design"},
+                ]
+            )
+        )
+        events = report_cli.load_timeline(path)
+        assert [e["phase"] for e in events] == ["design", "tasks"]
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+class TestPairIntervals:
+    def test_pairs_subagents_with_phase_attribution(self):
+        events = [
+            {"ts": "2026-01-01T00:00:01Z", "type": "phase-checkpoint", "phase": "claimed"},
+            {"ts": "2026-01-01T00:00:02Z", "type": "subagent-start", "name": "agent-x"},
+            {"ts": "2026-01-01T00:00:05Z", "type": "subagent-end", "name": "agent-x"},
+            {"ts": "2026-01-01T00:00:06Z", "type": "phase-checkpoint", "phase": "design"},
+        ]
+        pairs = report_cli._pair_intervals(events, "subagent-start", "subagent-end", "name")
+        assert pairs == [
+            ("agent-x", "2026-01-01T00:00:02Z", "2026-01-01T00:00:05Z", "claimed"),
+        ]
+
+    def test_unmatched_start_gets_zero_duration(self):
+        events = [
+            {"ts": "2026-01-01T00:00:01Z", "type": "phase-checkpoint", "phase": "design"},
+            {"ts": "2026-01-01T00:00:02Z", "type": "subagent-start", "name": "agent-x"},
+        ]
+        pairs = report_cli._pair_intervals(events, "subagent-start", "subagent-end", "name")
+        assert len(pairs) == 1
+        assert pairs[0][1] == pairs[0][2]
+
+
+class TestPhaseIntervals:
+    def test_anchors_first_phase_to_claim_time(self):
+        events = [
+            {"ts": "2026-01-01T00:01:00Z", "type": "phase-checkpoint", "phase": "claimed"},
+            {"ts": "2026-01-01T00:05:00Z", "type": "phase-checkpoint", "phase": "design"},
+        ]
+        intervals = report_cli._phase_intervals(events, "2026-01-01T00:00:00Z")
+        assert intervals == [
+            ("claimed", "2026-01-01T00:00:00Z", "2026-01-01T00:01:00Z"),
+            ("design", "2026-01-01T00:01:00Z", "2026-01-01T00:05:00Z"),
+        ]
+
+    def test_no_claim_falls_back_to_first_event(self):
+        events = [
+            {"ts": "2026-01-01T00:01:00Z", "type": "phase-checkpoint", "phase": "claimed"},
+        ]
+        intervals = report_cli._phase_intervals(events, None)
+        assert intervals[0][1] == "2026-01-01T00:01:00Z"
+
+    def test_empty_returns_empty(self):
+        assert report_cli._phase_intervals([], None) == []
+
+
+class TestFormatters:
+    @pytest.mark.parametrize(
+        "secs,expected",
+        [
+            (0, "<1s"),
+            (1, "1s"),
+            (59, "59s"),
+            (60, "1m"),
+            (90, "1m 30s"),
+            (3600, "1h 0m"),
+            (3700, "1h 1m"),
+        ],
+    )
+    def test_fmt_duration(self, secs, expected):
+        assert report_cli._fmt_duration(secs) == expected
+
+    def test_fmt_time(self):
+        assert report_cli._fmt_time("2026-01-01T08:17:35Z") == "08:17:35"
+
+    def test_fmt_time_invalid_passes_through(self):
+        assert report_cli._fmt_time("garbage") == "garbage"
+
+
+class TestRender:
+    def test_empty_events_returns_stub(self):
+        md = report_cli.render(issue=42, events=[])
+        assert "Issue #42" in md
+        assert "No timeline events" in md
+
+    def test_minimal_run_renders_table_and_summary(self):
+        events = [
+            {"ts": "2026-01-01T00:00:30Z", "type": "phase-checkpoint", "phase": "claimed"},
+            {"ts": "2026-01-01T00:00:31Z", "type": "subagent-start", "name": "agent-issue-analyst"},
+            {"ts": "2026-01-01T00:04:04Z", "type": "subagent-end", "name": "agent-issue-analyst"},
+            {"ts": "2026-01-01T00:05:00Z", "type": "phase-checkpoint", "phase": "design"},
+            {"ts": "2026-01-01T00:06:00Z", "type": "phase-checkpoint", "phase": "complete"},
+        ]
+        md = report_cli.render(
+            issue=42,
+            events=events,
+            claim_created_at="2026-01-01T00:00:00Z",
+        )
+        # Header
+        assert "# Issue #42 — time breakdown" in md
+        assert "Wall-clock:" in md
+        # Phase rows
+        assert "Phase 0 — coordination" in md
+        assert "Phase 1-2 — understand + design" in md
+        assert "Phase 10 — complete" in md
+        # PLACEHOLDER prefix
+        assert "PLACEHOLDER" in md
+        # Subagent fact rendered into the design row
+        assert "agent-issue-analyst" in md
+        # Summary table
+        assert "Subagent compute" in md
+        assert "Coordination" in md
+
+    def test_implement_phase_renders_commit_subrows(self):
+        events = [
+            {"ts": "2026-01-01T00:00:00Z", "type": "phase-checkpoint", "phase": "branch"},
+            {"ts": "2026-01-01T00:10:00Z", "type": "phase-checkpoint", "phase": "implement"},
+        ]
+        commits = [
+            {"sha": "abc1234567", "committed_at": "2026-01-01T00:03:00Z", "subject": "feat: add helper"},
+            {"sha": "def4567890", "committed_at": "2026-01-01T00:07:00Z", "subject": "test: cover helper"},
+        ]
+        md = report_cli.render(
+            issue=99,
+            events=events,
+            commits=commits,
+            claim_created_at="2026-01-01T00:00:00Z",
+        )
+        assert "↳ commit" in md
+        assert "abc1234" in md
+        assert "feat: add helper" in md
+        assert "def4567" in md
+
+    def test_pipe_in_commit_subject_is_escaped(self):
+        events = [
+            {"ts": "2026-01-01T00:00:00Z", "type": "phase-checkpoint", "phase": "branch"},
+            {"ts": "2026-01-01T00:10:00Z", "type": "phase-checkpoint", "phase": "implement"},
+        ]
+        commits = [
+            {"sha": "abc1234", "committed_at": "2026-01-01T00:01:00Z", "subject": "feat: a|b helper"},
+        ]
+        md = report_cli.render(issue=1, events=events, commits=commits)
+        assert "a\\|b" in md


### PR DESCRIPTION
## Summary

- New `maverick report log|generate|path` CLI surface (`src/maverick/report_cli.py`) for capturing do-issue-solo timeline events to `.maverick/reports/.do-issue-solo-<N>.timeline.jsonl` and rendering a markdown report to `.maverick/reports/do-issue-solo-<N>.md` at the end of a run.
- `maverick task-progress set` now also appends a `phase-checkpoint` event to the local timeline (best-effort — the durable GitHub marker write still succeeds even if the local append fails).
- `do-issue-solo` skill body wraps each subagent/skill dispatch and user-question pause with `report log` calls so the report can attribute time to subagent compute, user decision points, and coordination overhead.
- Phase 10 (PASS) and Phase 11 (eject) each gain steps to generate the report and instruct Claude to replace each `PLACEHOLDER` Activity cell with a one-sentence narrative drawn from session memory.
- Adds `ejected` as a terminal `TASK_PROGRESS_PHASES` value so Phase 11's end has a timeline anchor.
- Timeline JSONL and rendered report live in the **main repo's** `.maverick/reports/` (resolved via `git rev-parse --git-common-dir`) so artefacts survive worktree destruction at Phase 10 step 10.

## Test plan

- [x] Unit tests cover argparse wiring, append_event round-trip, validation, malformed-line skipping, interval pairing, phase-interval reconstruction, duration/time formatters, and the renderer (with commit sub-rows and pipe-escaping). 35 new tests.
- [x] Updated `test_coordinator.py::test_set_writes_marker_with_phase_and_instance_id` to mock `report_cli.append_event` and assert the new phase-checkpoint event is emitted alongside the marker write.
- [x] Full suite: 504 unit tests pass (`uv run pytest tests/unit`).
- [x] `make lint` clean; `make typecheck` clean.
- [x] `make build` regenerates `skills/do-issue-solo/SKILL.md` with the new `report log` bullets visible.
- [x] Manual smoke test in `/tmp/maverick-report-smoke`: `report log` → JSONL appended; `report generate` → markdown rendered with expected phase rows and summary table.
- [ ] End-to-end happy-path verification against a real do-issue-solo run will land naturally the next time the workflow is invoked against an issue in this or a downstream repo.

Closes #83