### PR TITLE
fix: source Phase 5 commits from timeline events instead of git log (#91)

### DIFF
--- a/skills/do-issue-solo/SKILL.md
+++ b/skills/do-issue-solo/SKILL.md
@@ -182,8 +182,17 @@ This phase has changed. **Push after every task, not at the end.** See
      `git push -u origin <branch>`.
    - If on a stacked branch, run the retarget check per
      `mav-stacked-prs` **before every push**.
-6. Update the tasks comment (or close the sub-issue).
-7. Heartbeat: `uv run maverick coord heartbeat <repo> ` if it
+6. **Log the commit** to the timing report so Phase 5 sub-rows match
+   what the agent actually pushed (#91 — `git log` previously over-counted
+   on Gitflow-style repos):
+   ```bash
+   SHA=$(git rev-parse HEAD)
+   SUBJECT=$(git log -1 --pretty=%s)
+   uv run maverick report log commit --issue  \
+       --sha "$SHA" --subject "$SUBJECT"
+   ```
+7. Update the tasks comment (or close the sub-issue).
+8. Heartbeat: `uv run maverick coord heartbeat <repo> ` if it
    is time for a refresh.
 
 After the last task, run the full verification suite once more.
@@ -272,7 +281,14 @@ PR body as a follow-up note rather than being silently rewritten.
      sees them.
    - If no changes were required: post `Docs review: no changes required.`
 7. Commit any doc changes with a `docs:` conventional commit and push
-   per the push-per-task rule.
+   per the push-per-task rule. If a commit was made, log it so the
+   docs phase row carries its own sub-task (#91):
+   ```bash
+   SHA=$(git rev-parse HEAD)
+   SUBJECT=$(git log -1 --pretty=%s)
+   uv run maverick report log commit --issue  \
+       --sha "$SHA" --subject "$SUBJECT"
+   ```
 8. The PR cannot proceed to Phase 7 until this phase has produced
    either committed doc changes or the auditable no-op record.
 9. **Checkpoint**: `uv run maverick task-progress set <repo>  docs`.

--- a/src/maverick/report_cli.py
+++ b/src/maverick/report_cli.py
@@ -209,11 +209,41 @@ def _fmt_duration(seconds: float) -> str:
 
 
 def _fmt_time(ts: str) -> str:
-    """Render an ISO timestamp as HH:MM:SS (UTC)."""
+    """Render an ISO timestamp as YYYY-MM-DD HH:MM:SS (UTC).
+
+    Including the date makes cross-day rows obvious instead of looking
+    like time going backwards (#91).
+    """
     try:
-        return _parse_ts(ts).strftime("%H:%M:%S")
+        return _parse_ts(ts).strftime("%Y-%m-%d %H:%M:%S")
     except (ValueError, TypeError):
         return ts
+
+
+def _commit_rows(
+    events: Sequence[dict[str, Any]],
+) -> list[tuple[str, str, str]]:
+    """Extract commit events from the timeline as (sha, ts, subject) tuples.
+
+    Phase attribution is intentionally not done here — `render` matches
+    each commit's ts against the phase intervals from `_phase_intervals`.
+    Doing it that way is correct under the do-issue-solo convention that
+    a `phase-checkpoint` marks the **end** of its phase: a commit at
+    time `t` belongs to the phase whose [start_ts, end_ts] contains `t`,
+    i.e. the phase the agent was working on when the commit landed —
+    not the previous phase that just finished.
+    """
+    out: list[tuple[str, str, str]] = []
+    for e in events:
+        if e.get("type") == "commit":
+            out.append(
+                (
+                    str(e.get("sha", "")),
+                    str(e.get("ts", "")),
+                    str(e.get("subject", "")),
+                )
+            )
+    return out
 
 
 def _pair_intervals(
@@ -322,7 +352,6 @@ def render(
     - `claim_created_at` — ISO timestamp from the maverick-claim marker.
       Anchors the first phase's start.
     """
-    commits = list(commits or [])
     if not events:
         return f"# Issue #{issue} — time breakdown\n\nNo timeline events recorded.\n"
 
@@ -331,6 +360,25 @@ def render(
     skills = _pair_intervals(events, "skill-start", "skill-end", "name")
     phases = _phase_intervals(events, claim_created_at)
 
+    # Prefer event-sourced commits (deterministic, in-issue scope, per-phase
+    # attribution). Fall back to git-log commits for older timelines that
+    # pre-date #91. In both cases the renderer matches each commit's ts
+    # against phase intervals — no hardcoded "implement" assumption.
+    event_commits = _commit_rows(events)
+    if event_commits:
+        commit_rows = event_commits
+        commits_from_events = True
+    else:
+        commit_rows = [
+            (
+                str(c.get("sha") or ""),
+                str(c.get("committed_at") or ""),
+                str(c.get("subject") or ""),
+            )
+            for c in (commits or [])
+        ]
+        commits_from_events = False
+
     first_ts = claim_created_at or events[0]["ts"]
     last_ts = events[-1]["ts"]
     total = _seconds_between(first_ts, last_ts)
@@ -338,11 +386,16 @@ def render(
     out: list[str] = []
     out.append(f"# Issue #{issue} — time breakdown")
     out.append("")
+    commit_source = (
+        "commit events in the timeline JSONL"
+        if commits_from_events
+        else "git-log fallback (legacy timeline)"
+    )
     out.append(
         f"Wall-clock: **{_fmt_duration(total)}** from "
         f"{first_ts} to {last_ts}. All timestamps below are UTC. "
         "Phase boundaries come from `maverick task-progress` checkpoints; "
-        "sub-task rows in the implement phase come from commit times; "
+        f"commit sub-rows come from {commit_source}; "
         "PR open/merge timestamps come from `gh pr view`."
     )
     out.append("")
@@ -351,26 +404,34 @@ def render(
     out.append("| Phase | Activity | Start | End | Duration |")
     out.append("|---|---|---|---|---|")
 
-    implement_seen = False
+    emitted_commit_indices: set[int] = set()
     for phase, s, e in phases:
         label = PHASE_LABELS.get(phase, phase)
         facts = _facts_for_phase(phase, events, subagents, questions, skills)
         activity = f"PLACEHOLDER — {facts}" if facts else "PLACEHOLDER"
         dur = _fmt_duration(_seconds_between(s, e))
         out.append(f"| {label} | {activity} | {_fmt_time(s)} | {_fmt_time(e)} | {dur} |")
-        if phase == "implement" and commits and not implement_seen:
-            implement_seen = True
+        # Match each commit to the phase interval whose [start_ts, end_ts]
+        # contains its ts. Each commit emits at most once — when a phase
+        # repeats (e.g. implement → review → implement during recovery),
+        # commits land under the first matching occurrence.
+        phase_commits = [
+            (i, sha, ts, subj)
+            for i, (sha, ts, subj) in enumerate(commit_rows)
+            if i not in emitted_commit_indices and ts and s <= ts <= e
+        ]
+        if phase_commits:
             prev_ts = s
-            for c in commits:
-                sub = (c.get("subject") or "").replace("|", "\\|")
-                sha = (c.get("sha") or "")[:7]
-                c_ts = c.get("committed_at") or ""
+            for i, sha, c_ts, subject in phase_commits:
+                sub = subject.replace("|", "\\|")
+                short_sha = sha[:7]
                 dur_c = _fmt_duration(_seconds_between(prev_ts, c_ts)) if c_ts else "—"
                 out.append(
-                    f"| ↳ commit | `{sha}` — {sub} | "
+                    f"| ↳ commit | `{short_sha}` — {sub} | "
                     f"{_fmt_time(prev_ts)} | {_fmt_time(c_ts)} | {dur_c} |"
                 )
                 prev_ts = c_ts
+                emitted_commit_indices.add(i)
 
     out.append("")
     out.append("## Where the time actually went")
@@ -383,16 +444,16 @@ def render(
     question_total = sum(_seconds_between(s, e) for _, s, e, _ in questions)
 
     impl_total = 0.0
-    if commits and phases:
-        for phase, s, _e in phases:
-            if phase == "implement":
-                prev_ts = s
-                for c in commits:
-                    c_ts = c.get("committed_at") or ""
-                    if c_ts:
-                        impl_total += _seconds_between(prev_ts, c_ts)
-                        prev_ts = c_ts
-                break
+    if commit_rows and phases:
+        for phase, s, e in phases:
+            if phase != "implement":
+                continue
+            prev_ts = s
+            for _sha, c_ts, _subj in commit_rows:
+                if c_ts and s <= c_ts <= e:
+                    impl_total += _seconds_between(prev_ts, c_ts)
+                    prev_ts = c_ts
+            break
 
     coord_total = total - subagent_total - skill_total - question_total - impl_total
     if coord_total < 0:
@@ -519,6 +580,8 @@ def _report_log(args: argparse.Namespace) -> int:
         event["phase"] = args.phase
     if args.sha:
         event["sha"] = args.sha
+    if args.subject:
+        event["subject"] = args.subject
     if args.task:
         event["task"] = args.task
     for raw in args.meta or []:
@@ -545,9 +608,16 @@ def _report_generate(args: argparse.Namespace) -> int:
         print(f"no timeline data for issue {issue} at {tpath}", file=sys.stderr)
         return 2
 
-    branch = args.branch
-    base = args.base or "origin/main"
-    commits = _fetch_commits(branch, base)
+    # New runs emit `commit` events into the timeline (#91), so the
+    # git-log fallback is only consulted when no commit events were
+    # recorded (e.g. older runs that pre-date the change).
+    has_commit_events = any(e.get("type") == "commit" for e in events)
+    if has_commit_events:
+        commits: list[dict[str, Any]] = []
+    else:
+        branch = args.branch
+        base = args.base or "origin/main"
+        commits = _fetch_commits(branch, base)
     pr = _fetch_pr(args.repo, issue) if args.repo else None
     claim_ts = _fetch_claim_created_at(args.repo, issue) if args.repo else None
 
@@ -596,6 +666,7 @@ def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
     p.add_argument("--topic", help="Question topic (question-*)")
     p.add_argument("--phase", help="Phase name (phase-checkpoint)")
     p.add_argument("--sha", help="Commit SHA (commit)")
+    p.add_argument("--subject", help="Commit subject line (commit)")
     p.add_argument("--task", help="Task label (subagent-* / commit)")
     p.add_argument(
         "--meta",

--- a/src/maverick/skills/do-issue-solo/body.md.j2
+++ b/src/maverick/skills/do-issue-solo/body.md.j2
@@ -175,8 +175,17 @@ This phase has changed. **Push after every task, not at the end.** See
      `git push -u origin <branch>`.
    - If on a stacked branch, run the retarget check per
      `{{ SKILLS.MAV_STACKED_PRS }}` **before every push**.
-6. Update the tasks comment (or close the sub-issue).
-7. Heartbeat: `uv run maverick coord heartbeat <repo> {{ ARGUMENTS }}` if it
+6. **Log the commit** to the timing report so Phase 5 sub-rows match
+   what the agent actually pushed (#91 — `git log` previously over-counted
+   on Gitflow-style repos):
+   ```bash
+   SHA=$(git rev-parse HEAD)
+   SUBJECT=$(git log -1 --pretty=%s)
+   uv run maverick report log commit --issue {{ ARGUMENTS }} \
+       --sha "$SHA" --subject "$SUBJECT"
+   ```
+7. Update the tasks comment (or close the sub-issue).
+8. Heartbeat: `uv run maverick coord heartbeat <repo> {{ ARGUMENTS }}` if it
    is time for a refresh.
 
 After the last task, run the full verification suite once more.
@@ -265,7 +274,14 @@ PR body as a follow-up note rather than being silently rewritten.
      sees them.
    - If no changes were required: post `Docs review: no changes required.`
 7. Commit any doc changes with a `docs:` conventional commit and push
-   per the push-per-task rule.
+   per the push-per-task rule. If a commit was made, log it so the
+   docs phase row carries its own sub-task (#91):
+   ```bash
+   SHA=$(git rev-parse HEAD)
+   SUBJECT=$(git log -1 --pretty=%s)
+   uv run maverick report log commit --issue {{ ARGUMENTS }} \
+       --sha "$SHA" --subject "$SUBJECT"
+   ```
 8. The PR cannot proceed to Phase 7 until this phase has produced
    either committed doc changes or the auditable no-op record.
 9. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} docs`.

--- a/tests/unit/test_report_cli.py
+++ b/tests/unit/test_report_cli.py
@@ -238,7 +238,9 @@ class TestFormatters:
         assert report_cli._fmt_duration(secs) == expected
 
     def test_fmt_time(self):
-        assert report_cli._fmt_time("2026-01-01T08:17:35Z") == "08:17:35"
+        # #91: include the date so cross-day rows are obvious instead of
+        # looking like time running backwards.
+        assert report_cli._fmt_time("2026-01-01T08:17:35Z") == "2026-01-01 08:17:35"
 
     def test_fmt_time_invalid_passes_through(self):
         assert report_cli._fmt_time("garbage") == "garbage"
@@ -308,3 +310,145 @@ class TestRender:
         ]
         md = report_cli.render(issue=1, events=events, commits=commits)
         assert "a\\|b" in md
+
+
+class TestCommitEvents:
+    """Event-sourced commit rows replace `git log <base>..<branch>` (#91).
+
+    `_fetch_commits` had a hardcoded `origin/main` base that over-counted
+    on Gitflow-style repos. Reading commits from the JSONL timeline gives
+    us deterministic, in-issue-scoped rows that travel with the timeline.
+    """
+
+    def test_commit_events_render_under_implement_phase(self):
+        events = [
+            {"ts": "2026-01-01T00:00:00Z", "type": "phase-checkpoint", "phase": "branch"},
+            {"ts": "2026-01-01T00:03:00Z", "type": "commit", "sha": "abc1234567",
+             "subject": "feat: add helper"},
+            {"ts": "2026-01-01T00:07:00Z", "type": "commit", "sha": "def4567890",
+             "subject": "test: cover helper"},
+            {"ts": "2026-01-01T00:10:00Z", "type": "phase-checkpoint", "phase": "implement"},
+        ]
+        md = report_cli.render(
+            issue=99,
+            events=events,
+            claim_created_at="2026-01-01T00:00:00Z",
+        )
+        assert "↳ commit" in md
+        assert "abc1234" in md
+        assert "feat: add helper" in md
+        assert "def4567" in md
+        # Preamble reflects the event-driven source.
+        assert "commit events in the timeline JSONL" in md
+
+    def test_event_commits_route_to_their_owning_phase(self):
+        """A Phase 6 `docs:` commit should land under the docs row, not implement."""
+        events = [
+            {"ts": "2026-01-01T00:00:00Z", "type": "phase-checkpoint", "phase": "branch"},
+            {"ts": "2026-01-01T00:05:00Z", "type": "commit", "sha": "aaa1111",
+             "subject": "feat: thing"},
+            {"ts": "2026-01-01T00:10:00Z", "type": "phase-checkpoint", "phase": "implement"},
+            {"ts": "2026-01-01T00:12:00Z", "type": "commit", "sha": "bbb2222",
+             "subject": "docs: explain the thing"},
+            {"ts": "2026-01-01T00:15:00Z", "type": "phase-checkpoint", "phase": "docs"},
+        ]
+        md = report_cli.render(
+            issue=42,
+            events=events,
+            claim_created_at="2026-01-01T00:00:00Z",
+        )
+        lines = md.splitlines()
+        impl_idx = next(i for i, ln in enumerate(lines) if "Phase 5 — execute tasks" in ln)
+        docs_idx = next(i for i, ln in enumerate(lines) if "Phase 6 — documentation review" in ln)
+        # The implement-phase commit appears between its phase row and the next phase row.
+        impl_window = "\n".join(lines[impl_idx:docs_idx])
+        docs_window = "\n".join(lines[docs_idx:])
+        assert "aaa1111" in impl_window
+        assert "aaa1111" not in docs_window
+        assert "bbb2222" in docs_window
+        assert "bbb2222" not in impl_window
+
+    def test_empty_commit_events_falls_back_to_git_log_commits(self):
+        """Legacy timelines with no commit events still render via the `commits` arg."""
+        events = [
+            {"ts": "2026-01-01T00:00:00Z", "type": "phase-checkpoint", "phase": "branch"},
+            {"ts": "2026-01-01T00:10:00Z", "type": "phase-checkpoint", "phase": "implement"},
+        ]
+        commits = [
+            {"sha": "legacy01", "committed_at": "2026-01-01T00:03:00Z",
+             "subject": "feat: legacy"},
+        ]
+        md = report_cli.render(
+            issue=7,
+            events=events,
+            commits=commits,
+            claim_created_at="2026-01-01T00:00:00Z",
+        )
+        assert "legacy0" in md
+        assert "feat: legacy" in md
+        assert "git-log fallback (legacy timeline)" in md
+
+    def test_commit_events_take_priority_over_legacy_commits_arg(self):
+        """When both are present, event-sourced commits win."""
+        events = [
+            {"ts": "2026-01-01T00:00:00Z", "type": "phase-checkpoint", "phase": "branch"},
+            {"ts": "2026-01-01T00:03:00Z", "type": "commit", "sha": "newev01",
+             "subject": "feat: new path"},
+            {"ts": "2026-01-01T00:10:00Z", "type": "phase-checkpoint", "phase": "implement"},
+        ]
+        commits = [
+            {"sha": "legacy01", "committed_at": "2026-01-01T00:03:00Z",
+             "subject": "feat: legacy"},
+        ]
+        md = report_cli.render(
+            issue=7,
+            events=events,
+            commits=commits,
+            claim_created_at="2026-01-01T00:00:00Z",
+        )
+        assert "newev01" in md
+        assert "legacy01" not in md
+
+    def test_log_commit_subcommand_writes_event(self, tmp_path: Path, monkeypatch):
+        """The `report log commit --sha --subject` form round-trips through the JSONL."""
+        monkeypatch.setattr(report_cli, "_main_repo_root", lambda cwd=None: tmp_path)
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers(dest="cmd", required=True)
+        report_cli.build_subparsers(sub)
+        args = parser.parse_args([
+            "report", "log", "commit",
+            "--issue", "55",
+            "--sha", "abc1234",
+            "--subject", "feat: log the commit",
+        ])
+        rc = args._handler(args)
+        assert rc == 0
+        events = report_cli.load_timeline(report_cli.timeline_path(55, repo_root=tmp_path))
+        commit_events = [e for e in events if e["type"] == "commit"]
+        assert len(commit_events) == 1
+        assert commit_events[0]["sha"] == "abc1234"
+        assert commit_events[0]["subject"] == "feat: log the commit"
+
+
+class TestCommitRowsHelper:
+    def test_extracts_commit_events_in_order(self):
+        events = [
+            {"ts": "2026-01-01T00:00:00Z", "type": "phase-checkpoint", "phase": "branch"},
+            {"ts": "2026-01-01T00:01:00Z", "type": "commit", "sha": "111",
+             "subject": "feat: a"},
+            {"ts": "2026-01-01T00:02:00Z", "type": "phase-checkpoint", "phase": "implement"},
+            {"ts": "2026-01-01T00:03:00Z", "type": "commit", "sha": "222",
+             "subject": "feat: b"},
+        ]
+        rows = report_cli._commit_rows(events)
+        assert rows == [
+            ("111", "2026-01-01T00:01:00Z", "feat: a"),
+            ("222", "2026-01-01T00:03:00Z", "feat: b"),
+        ]
+
+    def test_ignores_non_commit_events(self):
+        events = [
+            {"ts": "2026-01-01T00:00:00Z", "type": "phase-checkpoint", "phase": "branch"},
+            {"ts": "2026-01-01T00:01:00Z", "type": "subagent-start", "name": "x"},
+        ]
+        assert report_cli._commit_rows(events) == []


### PR DESCRIPTION
## Summary

- Replace `_fetch_commits` (hardcoded `origin/main..<branch>`) with `commit` events appended to the existing JSONL timeline by do-issue-solo Phase 5 / Phase 6. On Gitflow-style repos the old range pulled in every unmerged `develop` commit (43 stale rows on a real 2-commit fix).
- `render` prefers event-sourced commits and falls back to the legacy `commits` arg so older timelines still render. Phase attribution now ts-range-matches against `_phase_intervals`, so docs commits land under Phase 6 and implement commits under Phase 5.
- `_fmt_time` renders `YYYY-MM-DD HH:MM:SS` so cross-day rows are obvious instead of looking like time running backwards.
- `report log` accepts `--subject` for commit events.

Closes #91

## Test plan

- [x] `uv run pytest tests/unit/ -q` — all 511 tests pass, including six new tests covering: commit events rendering under implement, cross-phase routing (Phase 6 docs commit lands under docs row), legacy fallback when no commit events present, event commits taking priority over the legacy arg, the `log commit` CLI subcommand round-trip, and `_commit_rows` helper behavior.
- [x] `uv run ruff check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] `make build` — `skills/do-issue-solo/SKILL.md` regenerates from the updated template

🤖 Generated with [Claude Code](https://claude.com/claude-code)