### PR TITLE
feat: workflow report schema v1 + per-project LLM defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ maverick.egg-info/
 prototyping/
 node_modules/
 .ruff_cache/
+temp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Workflow report schema (BREAKING).** The do-issue-solo timing report has been refactored to a concrete v1 JSON schema. The JSONL timeline is now the authoritative record; the rendered Markdown is a pure function of it. Each row carries `schema_version`, `action`, `start_ts`, `end_ts`, `instance_id`, `issue`, `maverick_version`, `maverick_skill`, `maverick_agent`, `phase`, and `outcome`. Phase and outcome are closed enums; unknown values are rejected at write time. Intervals (`agent-dispatch`, `skill-dispatch`, `question`) are opened with `maverick report begin` and closed with `maverick report end`; the CLI assigns all wall-clock timestamps via the begin/end pair, persisted via a transient sidecar.
+
+- **Workflow report Markdown format.** The rendered report is now titled `# Maverick workflow report`, opens with an Issue/PR/Skill/Outcome/Maverick metadata block, has a `## Total Time` section in raw seconds, a `## Phases` table with one row per `(phase, action)` (commit sub-rows still nested), and an `## Analysis` section combining the time-allocation slice table and a list of `note` rows emitted during the run. The preamble paragraph, trailing PR note, and `PLACEHOLDER` re-render instructions have been removed.
+
+- **No backwards compatibility.** Pre-schema JSONL files (from before this change) will not render with the new code — `maverick report verify` flags them as schema violations. There is no migrator; older runs are audit-only.
+
+### Added
+
+- **`maverick report run-start <skill>`** — emit a `run-start` row at workflow entry so subsequent rows inherit `maverick_skill`.
+- **`maverick report begin / end`** — open / close interval rows (agent-dispatch, skill-dispatch, question), pairing via a transient sidecar in `.maverick/reports/`.
+- **`maverick report note --text`** — write narrative directly to the JSONL during the run; the renderer surfaces these in the Analysis section.
+- **`maverick report verify <issue>`** — lint a timeline JSONL against the v1 schema and surface dangling open intervals.
+
 ## [3.3.1] - 2026-05-18
 
 ## [3.3.0] - 2026-05-16

--- a/docs/skills/maverick-skills.md
+++ b/docs/skills/maverick-skills.md
@@ -8,6 +8,11 @@ This page lists every skill shipped with the Maverick plugin, generated from the
 Scan a project for missing best-practice areas and implement the top recommendation for each gap. Currently covers linting and unit testing. Installs tools, writes configs, and adds CI steps.
 
 
+## do-code
+
+Implement a focused code change. Use this skill as the wrapper for any implementation work so the Maverick workflow report captures what was done and so the agent applies the project's coding standards before editing. Intended to be invoked once per task from inside a do-issue-* or do-epic phase, not standalone.
+
+
 ## do-cybersecurity-review
 
 Run a security audit of the project's existing codebase and write a findings report to docs/security-audit.md. Covers secrets exposure, dependency vulnerabilities, authentication and authorisation patterns, input validation, transport security, and common OWASP risks. Run as part of do-init or on demand.
@@ -61,6 +66,11 @@ Scan a project for missing best-practice areas and recommend 1-3 technology opti
 ## do-tech-docs
 
 Technical documentation standards — document structure, writing style, file organisation, mermaid diagrams, and validation. Referenced by do-docs and tech-docs-writer.
+
+
+## do-test
+
+Write or update tests for a code change. Operates in two modes: `unit` (module-scoped, fast, deterministic) and `integration` (crosses module / service / database boundaries). Intended to be invoked once per testable change from inside a do-issue-* or do-epic phase. Mode is required.
 
 
 ## do-upskill

--- a/skills/do-code/SKILL.md
+++ b/skills/do-code/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: do-code
+description: Implement a focused code change. Use this skill as the wrapper for any implementation work so the Maverick workflow report captures what was done and so the agent applies the project's coding standards before editing. Intended to be invoked once per task from inside a do-issue-* or do-epic phase, not standalone.
+argument-hint: brief description of the task (one line)
+user-invocable: true
+disable-model-invocation: false
+---
+
+**Depends on:** mav-bp-error-handling, mav-bp-logging, mav-bp-application-security, mav-local-verification, mav-scope-boundaries, mav-systematic-debugging
+
+# Implement a Code Change
+
+Wraps implementation work in a Maverick skill so the workflow report
+records what was done and the agent applies the project's coding
+standards before editing. Invoke this skill **once per task** from
+inside `do-issue-solo` / `do-issue-guided` /
+`do-epic` Phase 5. The argument is a one-line task
+description that gets logged in the report.
+
+This skill is a thin wrapper. The actual edits are made by the
+orchestrating Claude Code session using its built-in tools (Read, Edit,
+Write, Bash, Grep). The skill's job is to pin standards and scope, not
+to perform the edits in a subagent.
+
+## Preflight (mandatory)
+
+Run this **first**. If it exits non-zero, halt and report the stderr
+output to the user verbatim. Do not proceed.
+
+```bash
+uv run maverick preflight do-code
+```
+
+The check verifies the project is initialised and `uv` is on PATH.
+
+## Standards to apply
+
+Before editing, read and follow:
+
+- `mav-scope-boundaries` — implement only what ``
+  asks for. No unrelated cleanup, no opportunistic refactors, no
+  abstractions for hypothetical future requirements. Three similar
+  lines is better than a premature abstraction.
+- `mav-bp-error-handling` — error handling at system
+  boundaries only (user input, external APIs). Don't catch what
+  framework guarantees rule out. No defensive code for scenarios that
+  can't happen.
+- `mav-bp-logging` — log levels, structured fields, and
+  the project's logging conventions.
+- `mav-bp-application-security` — input validation, secret
+  handling, authn/authz patterns. If the change touches any of these,
+  surface the design choice in your verification.
+
+Also read **any project-level skills** at `docs/maverick/skills/` —
+topic-specific guidance for this codebase that supplements the
+maverick-wide best practices.
+
+## Implementation loop
+
+1. **Read before writing.** Open the files you're about to change.
+   Grep for existing patterns nearby — the goal is for the edit to
+   look like it was written by whoever wrote the surrounding code.
+2. **Make the change.** Smallest diff that satisfies the task. If you
+   notice an unrelated bug or a tempting refactor, **do not fix it**
+   in this skill — write it down for a follow-up.
+3. **Verify** per `mav-local-verification` (lint,
+   typecheck, tests). Run the project's verification commands.
+4. **If verification fails**, diagnose per
+   `mav-systematic-debugging` and fix. Do not paper over
+   a failing test or silence a lint warning. Do not commit red.
+5. **Return** when (a) the task is done and (b) verification is green.
+
+## Rules
+
+- **Default to no comments.** Identifiers carry the WHAT. Only add a
+  comment when the WHY is non-obvious (hidden constraint, subtle
+  invariant, workaround for a specific bug). No "removed X" /
+  "added Y" / "used by Z" comments — those rot.
+- **No half-finished implementations.** If the task can't be completed
+  cleanly, halt and report rather than leaving partial state.
+- **No unauthorised destructive actions.** Don't `git push --force`,
+  `git reset --hard`, `rm -rf`, drop tables, or delete data. If the
+  task description doesn't explicitly authorise a destructive step,
+  treat it as out of scope and ask.
+- **Tests are part of the change.** If the change is testable, write
+  or update tests in the same task (or wrap that work in
+  `do-test` as a sibling call before the commit).
+- **Stay inside the task envelope.** When `` is
+  ambiguous, ask for clarification rather than guess.
+
+<!-- maverick-plugin-version: 3.3.2-dev -->

--- a/skills/do-issue-solo/SKILL.md
+++ b/skills/do-issue-solo/SKILL.md
@@ -112,11 +112,11 @@ implementation.
 
 1. Initialise the issue state file per the
    mav-github-issue-workflow skill.
-2. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue  --phase design --agent agent-issue-analyst`.
+2. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue  --phase design --agent agent-issue-analyst --skill-name mav-create-solution-design`.
 3. Dispatch the **agent-issue-analyst** agent with:
    - Issue number: ``
    - Mode: `solo`
-4. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue  --phase design --agent agent-issue-analyst --outcome success`.
+4. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue  --phase design --agent agent-issue-analyst --skill-name mav-create-solution-design --outcome success`.
    (Use `--outcome failure` if the agent returned an error rather than a design.)
 5. When the agent returns, verify:
    - `.claude/issue-state.json` has `phase` set to `design`
@@ -133,11 +133,11 @@ implementation.
 
 Run Phase 3 as a subagent.
 
-1. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue  --phase tasks --agent agent-github-issue-planner`.
+1. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue  --phase tasks --agent agent-github-issue-planner --skill-name mav-create-tasks`.
 2. Dispatch the **agent-github-issue-planner** agent with:
    - Issue number: ``
    - Design comment ID from `.claude/issue-state.json`
-3. Close it: `uv run maverick report end agent-dispatch --issue  --phase tasks --agent agent-github-issue-planner --outcome success`.
+3. Close it: `uv run maverick report end agent-dispatch --issue  --phase tasks --agent agent-github-issue-planner --skill-name mav-create-tasks --outcome success`.
 4. When the agent returns, verify:
    - `.claude/issue-state.json` has `phase` set to `tasks`
    - If < 5 tasks: `.claude/issue-state.json` has `comments.tasks` set to a comment ID
@@ -257,7 +257,7 @@ PR body as a follow-up note rather than being silently rewritten.
    fi
    ```
 
-3. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue  --phase docs --agent agent-tech-docs-writer`.
+3. Open the agent-dispatch interval. The agent operates under `do-docs` — pass it as `--skill-name` so the Maverick Skill column in the report names the inner skill: `uv run maverick report begin agent-dispatch --issue  --phase docs --agent agent-tech-docs-writer --skill-name do-docs`.
 4. Dispatch **agent-tech-docs-writer** with:
    - **Mode:** `update` (per `do-docs`)
    - **Diff:** `/tmp/diff.patch`
@@ -277,7 +277,7 @@ PR body as a follow-up note rather than being silently rewritten.
        human reviewer.
      - Returning "no doc changes required" is a valid outcome and must
        be reported explicitly (not silently inferred).
-5. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue  --phase docs --agent agent-tech-docs-writer --outcome success`.
+5. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue  --phase docs --agent agent-tech-docs-writer --skill-name do-docs --outcome success`.
 6. **Record the outcome** in the PR body or as a one-line PR comment so
    the gate is auditable:
    - If docs were updated or created: list the files changed.
@@ -380,11 +380,11 @@ The local **agent-code-reviewer** subagent's verdict is the
 review gate the auto-merge path trusts. This is a binary verdict against
 the open PR, not a local-diff advisory loop.
 
-1. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue  --phase review --agent agent-code-reviewer`.
+1. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue  --phase review --agent agent-code-reviewer --skill-name mav-bp-code-review`.
 2. Dispatch **agent-code-reviewer** with:
    - The PR URL
    - The issue body, design comment, and tasks list (so it has the spec)
-3. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue  --phase review --agent agent-code-reviewer --outcome <success|failure>` (use `failure` on FAIL verdict).
+3. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue  --phase review --agent agent-code-reviewer --skill-name mav-bp-code-review --outcome <success|failure>` (use `failure` on FAIL verdict).
 4. The agent returns exactly one of two verdicts:
    - **PASS** — proceed to Phase 10 (merge).
    - **FAIL** — proceed to Phase 11 (eject). Do not attempt to auto-fix.

--- a/skills/do-issue-solo/SKILL.md
+++ b/skills/do-issue-solo/SKILL.md
@@ -59,7 +59,12 @@ This phase is new in the workflow overhaul. Before any other phase.
 2. Claim the issue: `uv run maverick coord claim <repo> `.
    The command exits non-zero if the claim is rejected — treat that as
    abort.
-3. Start a heartbeat loop that refreshes the lease every
+3. **Start the workflow report** (writes a `run-start` row that later
+   `report` calls inherit `maverick_skill` from):
+   ```bash
+   uv run maverick report run-start do-issue-solo --issue  --phase claimed
+   ```
+4. Start a heartbeat loop that refreshes the lease every
    `HEARTBEAT_INTERVAL_MINUTES` minutes for as long as you hold the
    claim. The CLI provides a self-terminating foreground loop — run it
    in the background and let it exit on its own when `coord release`
@@ -69,9 +74,9 @@ This phase is new in the workflow overhaul. Before any other phase.
    ```
    If two consecutive heartbeats fail, the loop exits non-zero — treat
    that as claim-lost and abort (do not push further work).
-4. Register a release handler that fires on every exit path (success,
+5. Register a release handler that fires on every exit path (success,
    eject, abort): `uv run maverick coord release <repo>  --reason <reason>`.
-5. Cold-start hydrate per `mav-durability-on-gh`. The
+6. Cold-start hydrate per `mav-durability-on-gh`. The
    skill is fully resumable — a fresh agent re-entering after a crash,
    stop, or context-exhaustion must skip phases that already completed
    rather than re-running them against an in-flight or merged PR (#41).
@@ -107,18 +112,19 @@ implementation.
 
 1. Initialise the issue state file per the
    mav-github-issue-workflow skill.
-2. Log subagent start: `uv run maverick report log subagent-start --issue  --name agent-issue-analyst`.
+2. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue  --phase design --agent agent-issue-analyst`.
 3. Dispatch the **agent-issue-analyst** agent with:
    - Issue number: ``
    - Mode: `solo`
-4. Log subagent end: `uv run maverick report log subagent-end --issue  --name agent-issue-analyst`.
+4. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue  --phase design --agent agent-issue-analyst --outcome success`.
+   (Use `--outcome failure` if the agent returned an error rather than a design.)
 5. When the agent returns, verify:
    - `.claude/issue-state.json` has `phase` set to `design`
    - `.claude/issue-state.json` has `comments.design` set to a comment ID
 6. If the agent flagged ambiguities it could not resolve:
-   - Log question start: `uv run maverick report log question-start --issue  --topic ambiguity-resolution`.
+   - Open the question interval: `uv run maverick report begin question --issue  --phase design --topic ambiguity-resolution`.
    - Ask the user.
-   - Log question end: `uv run maverick report log question-end --issue  --topic ambiguity-resolution`.
+   - Close it: `uv run maverick report end question --issue  --phase design --topic ambiguity-resolution --outcome success`.
 
    Otherwise continue.
 7. **Checkpoint**: `uv run maverick task-progress set <repo>  design`.
@@ -127,19 +133,19 @@ implementation.
 
 Run Phase 3 as a subagent.
 
-1. Log subagent start: `uv run maverick report log subagent-start --issue  --name agent-github-issue-planner`.
+1. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue  --phase tasks --agent agent-github-issue-planner`.
 2. Dispatch the **agent-github-issue-planner** agent with:
    - Issue number: ``
    - Design comment ID from `.claude/issue-state.json`
-3. Log subagent end: `uv run maverick report log subagent-end --issue  --name agent-github-issue-planner`.
+3. Close it: `uv run maverick report end agent-dispatch --issue  --phase tasks --agent agent-github-issue-planner --outcome success`.
 4. When the agent returns, verify:
    - `.claude/issue-state.json` has `phase` set to `tasks`
    - If < 5 tasks: `.claude/issue-state.json` has `comments.tasks` set to a comment ID
    - If >= 5 tasks: `.claude/issue-state.json` has `has_sub_issues` set to `true`
 5. If the agent flagged scope concerns:
-   - Log question start: `uv run maverick report log question-start --issue  --topic scope-concerns`.
+   - Open the question interval: `uv run maverick report begin question --issue  --phase tasks --topic scope-concerns`.
    - Ask the user.
-   - Log question end: `uv run maverick report log question-end --issue  --topic scope-concerns`.
+   - Close it: `uv run maverick report end question --issue  --phase tasks --topic scope-concerns --outcome success`.
 6. **Checkpoint**: `uv run maverick task-progress set <repo>  tasks`.
 
 ## Phase 4: Create Worktree + Branch
@@ -182,8 +188,16 @@ This phase has changed. **Push after every task, not at the end.** See
      `git push -u origin <branch>`.
    - If on a stacked branch, run the retarget check per
      `mav-stacked-prs` **before every push**.
-6. Update the tasks comment (or close the sub-issue).
-7. Heartbeat: `uv run maverick coord heartbeat <repo> ` if it
+6. **Log the commit** to the workflow report. SHA and subject come from
+   git; the timestamp is wall-clock at the moment of this CLI call:
+   ```bash
+   SHA=$(git rev-parse HEAD)
+   SUBJECT=$(git log -1 --pretty=%s)
+   uv run maverick report commit --issue  \
+       --phase implement --sha "$SHA" --subject "$SUBJECT"
+   ```
+7. Update the tasks comment (or close the sub-issue).
+8. Heartbeat: `uv run maverick coord heartbeat <repo> ` if it
    is time for a refresh.
 
 After the last task, run the full verification suite once more.
@@ -243,7 +257,7 @@ PR body as a follow-up note rather than being silently rewritten.
    fi
    ```
 
-3. Log subagent start: `uv run maverick report log subagent-start --issue  --name agent-tech-docs-writer`.
+3. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue  --phase docs --agent agent-tech-docs-writer`.
 4. Dispatch **agent-tech-docs-writer** with:
    - **Mode:** `update` (per `do-docs`)
    - **Diff:** `/tmp/diff.patch`
@@ -263,7 +277,7 @@ PR body as a follow-up note rather than being silently rewritten.
        human reviewer.
      - Returning "no doc changes required" is a valid outcome and must
        be reported explicitly (not silently inferred).
-5. Log subagent end: `uv run maverick report log subagent-end --issue  --name agent-tech-docs-writer`.
+5. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue  --phase docs --agent agent-tech-docs-writer --outcome success`.
 6. **Record the outcome** in the PR body or as a one-line PR comment so
    the gate is auditable:
    - If docs were updated or created: list the files changed.
@@ -272,7 +286,14 @@ PR body as a follow-up note rather than being silently rewritten.
      sees them.
    - If no changes were required: post `Docs review: no changes required.`
 7. Commit any doc changes with a `docs:` conventional commit and push
-   per the push-per-task rule.
+   per the push-per-task rule. If a commit was made, log it so the
+   docs phase row gets its own sub-row in the report:
+   ```bash
+   SHA=$(git rev-parse HEAD)
+   SUBJECT=$(git log -1 --pretty=%s)
+   uv run maverick report commit --issue  \
+       --phase docs --sha "$SHA" --subject "$SUBJECT"
+   ```
 8. The PR cannot proceed to Phase 7 until this phase has produced
    either committed doc changes or the auditable no-op record.
 9. **Checkpoint**: `uv run maverick task-progress set <repo>  docs`.
@@ -285,7 +306,7 @@ changes (callers, importers, dependents) must be reviewed by
 `do-cybersecurity-review` before the PR can be opened.
 
 1. Compute the full diff: `git diff origin/<base>...HEAD`.
-2. Log skill start: `uv run maverick report log skill-start --issue  --name do-cybersecurity-review`.
+2. Open the skill-dispatch interval: `uv run maverick report begin skill-dispatch --issue  --phase security --skill-name do-cybersecurity-review`.
 3. Dispatch the **do-cybersecurity-review** skill with:
    - **Mode:** `update`
    - **Diff:** the output of step 1, passed via stdin or as a file path
@@ -293,7 +314,7 @@ changes (callers, importers, dependents) must be reviewed by
      (callers, importers, dependents — bounded to one or two hops).
      Return the structured outcome (verdict + findings) defined in the
      skill's Update Mode contract.
-4. Log skill end: `uv run maverick report log skill-end --issue  --name do-cybersecurity-review`.
+4. Close the skill-dispatch interval: `uv run maverick report end skill-dispatch --issue  --phase security --skill-name do-cybersecurity-review --outcome <success|failure|blocked>` (use `blocked` if the verdict was BLOCKING).
 5. **Act on the verdict:**
    - **BLOCKING** — halt. Surface the findings to the user verbatim.
      Do not open the PR. The user resolves the BLOCKING items by
@@ -359,11 +380,11 @@ The local **agent-code-reviewer** subagent's verdict is the
 review gate the auto-merge path trusts. This is a binary verdict against
 the open PR, not a local-diff advisory loop.
 
-1. Log subagent start: `uv run maverick report log subagent-start --issue  --name agent-code-reviewer`.
+1. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue  --phase review --agent agent-code-reviewer`.
 2. Dispatch **agent-code-reviewer** with:
    - The PR URL
    - The issue body, design comment, and tasks list (so it has the spec)
-3. Log subagent end: `uv run maverick report log subagent-end --issue  --name agent-code-reviewer`.
+3. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue  --phase review --agent agent-code-reviewer --outcome <success|failure>` (use `failure` on FAIL verdict).
 4. The agent returns exactly one of two verdicts:
    - **PASS** — proceed to Phase 10 (merge).
    - **FAIL** — proceed to Phase 11 (eject). Do not attempt to auto-fix.
@@ -428,21 +449,23 @@ next step is eject-to-human, not iterate.
     - Local state file
     - Destroy the worktree: `uv run maverick worktree destroy <worktree-path>`.
 11. **Checkpoint**: `uv run maverick task-progress set <repo>  complete`.
-12. **Generate the timing report** (#83). The report is written to the
-    **main repo's** `.maverick/reports/` (resolved via `git rev-parse
-    --git-common-dir`), not the destroyed worktree's:
+12. **Emit per-phase narrative notes** so the report's Analysis section
+    has context for what happened. The JSONL is the authoritative
+    record; the report is a pure render of it, so notes must land in
+    the JSONL — do not edit the rendered Markdown by hand:
     ```bash
-    uv run maverick report generate <repo>  --branch <branch>
+    uv run maverick report note --issue  --phase design \
+        --text "<one-sentence summary of what the analyst returned>"
+    uv run maverick report note --issue  --phase implement \
+        --text "<one-sentence summary of what landed in Phase 5>"
+    # ... one `report note` per phase that produced work worth narrating
     ```
-13. **Fill in the per-phase narratives.** Read
-    `.maverick/reports/do-issue-solo-.md`. For each phase
-    row whose Activity cell starts with `PLACEHOLDER`, replace the
-    `PLACEHOLDER` prefix with a single sentence summarising what
-    actually happened in that phase (from your session memory — e.g.
-    "Issue analyst summarised the bug and proposed three rollout
-    options."). Keep the structured facts that follow the `—` and
-    leave timestamps, durations, sub-task rows, and the summary table
-    untouched. Write the file back.
+13. **Generate the workflow report**. Written to the **main repo's**
+    `.maverick/reports/` (resolved via `git rev-parse --git-common-dir`),
+    not the destroyed worktree's. Re-runs are deterministic:
+    ```bash
+    uv run maverick report generate <repo> 
+    ```
 
 ## Phase 11: Eject (on FAIL)
 
@@ -467,16 +490,18 @@ next step is eject-to-human, not iterate.
      apply `blocked-by:#` to every transitive descendant.
    - Cancel any in-flight subagent work for stories now in the blocked set.
 5. **Checkpoint the eject** (#83): `uv run maverick task-progress set <repo>  ejected`.
-6. **Generate the timing report** for the run so the human reviewer
-   can see how time was spent leading up to the eject:
+6. **Emit per-phase narrative notes** so the eject report has context
+   for the human reviewer:
    ```bash
-   uv run maverick report generate <repo>  --branch <branch>
+   uv run maverick report note --issue  --phase review \
+       --text "<one-sentence summary of what the reviewer flagged>"
+   # ... one `report note` per phase that produced work worth narrating
    ```
-7. **Fill in the per-phase narratives.** Same as the PASS path: read
-   `.maverick/reports/do-issue-solo-.md` and replace each
-   `PLACEHOLDER` prefix with a one-sentence narrative from session
-   memory. Write the file back. Generate the report **before**
-   releasing the claim so it lands even if release errors.
+7. **Generate the workflow report**. Do this **before** releasing the
+   claim so the report lands even if release errors:
+   ```bash
+   uv run maverick report generate <repo> 
+   ```
 8. Release the claim: `uv run maverick coord release <repo>  --reason ejected`.
 9. Do **not** destroy the worktree — the human may want to inspect it.
    Log the worktree path so the user can find it.

--- a/skills/do-test/SKILL.md
+++ b/skills/do-test/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: do-test
+description: Write or update tests for a code change. Operates in two modes: `unit` (module-scoped, fast, deterministic) and `integration` (crosses module / service / database boundaries). Intended to be invoked once per testable change from inside a do-issue-* or do-epic phase. Mode is required.
+argument-hint: mode: unit or integration
+user-invocable: true
+disable-model-invocation: false
+---
+
+**Depends on:** mav-bp-unit-testing, mav-bp-integration-testing, mav-local-verification, mav-scope-boundaries
+
+# Write or Update Tests
+
+Wraps test-writing work in a Maverick skill so the workflow report
+records what was tested and the agent applies the project's testing
+standards before writing tests. Invoke this skill **once per testable
+change** from inside `do-issue-solo` /
+`do-issue-guided` / `do-epic` Phase 5 —
+typically as a sibling call to `do-code`, before the
+commit for that task.
+
+This skill is a thin wrapper. The actual test files are written by the
+orchestrating Claude Code session using its built-in tools (Read, Edit,
+Write, Bash). The skill's job is to pin the right standards for the
+mode and keep scope tight.
+
+## Preflight (mandatory)
+
+Run this **first**. If it exits non-zero, halt and report the stderr
+output to the user verbatim. Do not proceed.
+
+```bash
+uv run maverick preflight do-test
+```
+
+The check verifies the project is initialised and `uv` is on PATH.
+
+## Mode Selection
+
+`` must specify a mode:
+
+- `unit` — module-scoped, fast, deterministic. No network, no real
+  database, no real filesystem outside the test's own `tmp_path`.
+  Use this for any change that can be exercised through its public
+  surface in-process.
+- `integration` — crosses module / service / database / external API
+  boundaries. Real I/O is allowed (and usually required). Slower;
+  reserved for changes whose behaviour only emerges across that
+  boundary.
+
+If no mode is specified, halt and ask the caller to pick one. Do not
+guess — getting the mode wrong invites flaky tests or fast-but-untrue
+coverage.
+
+## Unit Mode
+
+Apply `mav-bp-unit-testing` for the project's unit-testing
+conventions (test framework, naming, fixture style, assertion
+patterns).
+
+1. **Locate the test file.** Look for an existing test file that
+   corresponds to the production code you just changed. If none
+   exists, follow the project's convention for placement
+   (`tests/unit/test_<module>.py`, `<module>.test.ts`, etc.) — check
+   how nearby modules are tested.
+2. **Identify what changed in observable behaviour.** Write tests
+   against the public surface, not the internals. If the change is
+   purely refactoring with no behaviour change, the existing tests
+   should already cover it — re-running them is the validation.
+3. **Write one test per branch / case.** Cover the happy path,
+   relevant edge cases, and any error paths the change introduced.
+   Don't write a single mega-test that exercises everything.
+4. **Verify** by running the project's unit suite per
+   `mav-local-verification`. The whole suite — not just
+   the new tests — must stay green.
+
+## Integration Mode
+
+Apply `mav-bp-integration-testing` for the project's
+integration-testing conventions (which real services are stood up,
+fixture lifecycle, isolation strategy, slowness budget).
+
+1. **Locate or create the integration test file.** Integration tests
+   typically live separately from unit tests
+   (`tests/integration/`, `e2e/`, `__tests__/integration/`, etc.) and
+   have their own runner config.
+2. **Stand up real dependencies.** Do not mock the boundary the test
+   is supposed to exercise — if a test "covers" the database layer
+   with a mocked database, it's a unit test, not an integration test.
+3. **Test the boundary, not the unit.** Assert observable end-to-end
+   behaviour, not implementation details on either side of the
+   boundary.
+4. **Clean up.** Integration tests must leave no state behind —
+   transactions roll back, fixtures tear down, temporary resources
+   are released. Failure to clean up makes the next test flaky.
+5. **Verify** by running the project's integration suite. Note the
+   wall-clock cost — if a new test pushes a green CI run past the
+   project's slowness budget, refactor it or split it.
+
+## Rules
+
+- **No mocks at the unit's own boundary.** If you're testing `foo()`,
+  don't mock `foo()`'s direct collaborators with such fidelity that
+  the test passes regardless of `foo()`'s behaviour. Mock at one hop
+  out: the network, the database, the clock.
+- **Tests describe behaviour, not implementation.** A test that breaks
+  on internal refactors without a behaviour change is a maintenance
+  cost. Write assertions against return values, side effects, and
+  invariants — not against private call sequences.
+- **No `assert True` placeholders.** If you don't know how to test
+  the change, halt and ask rather than ship an empty test.
+- **Stay inside the task envelope.** Don't refactor adjacent unrelated
+  tests in this skill. Follow `mav-scope-boundaries`.
+- **Tests must be deterministic.** No reliance on system time, random
+  seeds, network availability outside the boundary under test, or
+  ordering between independent tests.
+
+<!-- maverick-plugin-version: 3.3.2-dev -->

--- a/src/maverick/config.py
+++ b/src/maverick/config.py
@@ -172,6 +172,37 @@ _DEFAULT_BRANCH_PREFIXES: dict[str, str] = {
 }
 
 
+class LlmConfig(TypedDict):
+    """Per-project LLM model selection for Maverick workflows.
+
+    Three layers compose at resolution time (see
+    ``report_cli._current_llm``):
+
+    - ``default``: the model used when nothing more specific applies.
+    - ``agents``: per-agent overrides, keyed by agent name (e.g.
+      ``"agent-tech-docs-writer": "claude-sonnet-4-6"``). Applies to
+      rows whose ``maverick_agent`` matches the key.
+    - ``skills``: per-skill overrides, keyed by inner-skill name (e.g.
+      ``"do-test": "claude-sonnet-4-6"``). Applies to ``skill-dispatch``
+      rows whose ``dispatched_skill`` matches, AND to ``agent-dispatch``
+      rows where the agent was invoked under that skill.
+
+    The agent override takes priority over the skill override on
+    ``agent-dispatch`` rows that carry both. Anything not matched falls
+    through to ``default``.
+
+    Maverick ships baseline defaults (see ``CONFIG_DEFAULTS["llm"]``).
+    Repos override by writing an ``llm`` block in
+    ``.maverick/config.json``; the loader deep-merges ``agents`` and
+    ``skills`` so a repo can add or change a single entry without
+    re-stating the whole table.
+    """
+
+    default: str
+    agents: dict[str, str]
+    skills: dict[str, str]
+
+
 class HooksConfig(TypedDict):
     """Repo-specific scripts to run at maverick CLI lifecycle points.
 
@@ -229,6 +260,7 @@ class MaverickConfig(TypedDict):
     issue_lifecycle: IssueLifecycleConfig
     git_workflow: GitWorkflowConfig
     hooks: HooksConfig
+    llm: LlmConfig
 
 
 # Defaults applied when sections or keys are missing.
@@ -279,6 +311,31 @@ CONFIG_DEFAULTS: MaverickConfig = {
     },
     "hooks": {
         "worktree_post_create": "",
+    },
+    "llm": {
+        # Default model for any row not matched by a more specific
+        # rule. Opus is the safe default — reasoning-heavy work expects
+        # it. Repos that want to economise can drop this to Sonnet.
+        "default": "claude-opus-4-7",
+        # Per-agent overrides. Reasoning-heavy agents (issue-analyst,
+        # code-reviewer) fall through to `default` (Opus). Agents that
+        # mostly follow patterns are pinned to Sonnet so they're cheap
+        # by default; override per-repo in .maverick/config.json's
+        # `llm.agents` block.
+        "agents": {
+            "agent-github-issue-planner": "claude-sonnet-4-6",
+            "agent-tech-docs-writer": "claude-sonnet-4-6",
+            "agent-maverick": "claude-sonnet-4-6",
+            "agent-session-reviewer": "claude-sonnet-4-6",
+        },
+        # Per-skill overrides. Reasoning-heavy skills (do-code,
+        # do-cybersecurity-review) fall through to `default` (Opus).
+        # Pattern-following skills are pinned to Sonnet.
+        "skills": {
+            "do-test": "claude-sonnet-4-6",
+            "do-docs": "claude-sonnet-4-6",
+            "do-tech-docs": "claude-sonnet-4-6",
+        },
     },
 }
 
@@ -593,6 +650,50 @@ def read_hooks_config(path: Path | None = None) -> HooksConfig:
             if key in block and isinstance(block[key], str):
                 hooks[key] = block[key]  # type: ignore[literal-required]
     return hooks
+
+
+def _default_llm() -> LlmConfig:
+    """Return a fresh LlmConfig with Maverick's baked-in defaults."""
+    defaults = CONFIG_DEFAULTS["llm"]
+    return {
+        "default": defaults["default"],
+        "agents": dict(defaults["agents"]),
+        "skills": dict(defaults["skills"]),
+    }
+
+
+def read_llm_config(path: Path | None = None) -> LlmConfig:
+    """Read the llm block from the project config, deep-merged over defaults.
+
+    Returns Maverick's baked-in defaults if the file does not exist or has
+    no ``llm`` block. Per-repo overrides:
+
+    - ``default``: if set, replaces the Maverick default.
+    - ``agents``: deep-merged — repo entries override Maverick entries by
+      key, but Maverick entries the repo doesn't mention stay in effect.
+    - ``skills``: same deep-merge semantics.
+
+    To **fully replace** the agents or skills map (e.g. "this repo uses
+    only Opus, no per-agent overrides"), the repo writes an empty dict:
+    ``"agents": {}`` ― deep-merge over an empty user dict still applies
+    Maverick defaults, so use ``{"agent-foo": ""}`` to suppress a single
+    Maverick default, or write ``llm.default`` only and accept that the
+    Maverick per-agent map continues to apply.
+    """
+    target = path or project_config_path()
+    raw = _load_json(target)
+    block = raw.get("llm") if isinstance(raw, dict) else None
+    result = _default_llm()
+    if isinstance(block, dict):
+        if isinstance(block.get("default"), str) and block["default"]:
+            result["default"] = block["default"]
+        for sub in ("agents", "skills"):
+            user_map = block.get(sub)
+            if isinstance(user_map, dict):
+                for k, v in user_map.items():
+                    if isinstance(k, str) and isinstance(v, str):
+                        result[sub][k] = v  # type: ignore[literal-required]
+    return result
 
 
 def set_integration_flag(key: str, value: bool, path: Path | None = None) -> None:

--- a/src/maverick/coord_cli.py
+++ b/src/maverick/coord_cli.py
@@ -261,18 +261,20 @@ def _task_progress_set(args: argparse.Namespace) -> int:
         preamble="<!-- maverick task-progress -->",
     )
     # Best-effort timeline append for the `maverick report generate`
-    # path (#83). Local history; never fails the durable marker write.
+    # path. Local history; never fails the durable marker write.
     try:
         from maverick import report_cli
 
         report_cli.append_event(
-            args.issue,
             {
-                "type": "phase-checkpoint",
-                "phase": args.phase,
-                "ts": payload["updated_at"],
+                "schema_version": report_cli.SCHEMA_VERSION,
+                "action": "phase-boundary",
+                "start_ts": payload["updated_at"],
                 "instance_id": payload["instance_id"],
-            },
+                "issue": args.issue,
+                "maverick_version": report_cli._get_version(),
+                "phase": args.phase,
+            }
         )
     except Exception as e:  # noqa: BLE001 — best-effort
         print(f"warning: timeline append failed: {e}", file=sys.stderr)

--- a/src/maverick/names.py
+++ b/src/maverick/names.py
@@ -5,6 +5,7 @@
 # ---------------------------------------------------------------------------
 
 DO_ADOPT = "do-adopt"
+DO_CODE = "do-code"
 DO_CYBERSECURITY_REVIEW = "do-cybersecurity-review"
 DO_DOCS = "do-docs"
 DO_EPIC = "do-epic"
@@ -16,6 +17,7 @@ DO_MAVERICK_ALIGNMENT = "do-maverick-alignment"
 DO_PULLREQUEST_REVIEW = "do-pullrequest-review"
 DO_RECOMMEND = "do-recommend"
 DO_TECH_DOCS = "do-tech-docs"
+DO_TEST = "do-test"
 DO_UPSKILL = "do-upskill"
 MAV_BP_ACCESSIBILITY = "mav-bp-accessibility"
 MAV_BP_ALERTING = "mav-bp-alerting"
@@ -59,6 +61,7 @@ MAV_SYSTEMATIC_DEBUGGING = "mav-systematic-debugging"
 
 ALL_SKILL_NAMES = {
     DO_ADOPT,
+    DO_CODE,
     DO_CYBERSECURITY_REVIEW,
     DO_DOCS,
     DO_EPIC,
@@ -70,6 +73,7 @@ ALL_SKILL_NAMES = {
     DO_PULLREQUEST_REVIEW,
     DO_RECOMMEND,
     DO_TECH_DOCS,
+    DO_TEST,
     DO_UPSKILL,
     MAV_BP_ACCESSIBILITY,
     MAV_BP_ALERTING,

--- a/src/maverick/preflight.py
+++ b/src/maverick/preflight.py
@@ -101,6 +101,16 @@ PREREQS: dict[str, Prereqs] = {
         tools=("uv",),
         runtime=("cli_version_compatible",),
     ),
+    "do-code": Prereqs(
+        flags=("init",),
+        tools=("uv",),
+        runtime=("cli_version_compatible",),
+    ),
+    "do-test": Prereqs(
+        flags=("init",),
+        tools=("uv",),
+        runtime=("cli_version_compatible",),
+    ),
 }
 
 

--- a/src/maverick/report_cli.py
+++ b/src/maverick/report_cli.py
@@ -68,6 +68,7 @@ import argparse
 import json
 import sys
 from collections.abc import Sequence
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TypedDict
@@ -110,22 +111,54 @@ OUTCOMES: frozenset[str] = frozenset({"success", "failure", "blocked", "skipped"
 
 PHASES: frozenset[str] = frozenset(TASK_PROGRESS_PHASES)
 
-# Display labels for the rendered Phases table.
-PHASE_LABELS: dict[str, str] = {
-    "claimed": "Phase 0 — coordination",
-    "design": "Phase 1-2 — understand + design",
-    "tasks": "Phase 3 — create tasks",
-    "branch": "Phase 4 — worktree + branch",
-    "implement": "Phase 5 — execute tasks",
-    "docs": "Phase 6 — documentation review",
-    "security": "Phase 7 — cybersecurity review",
-    "pr_open": "Phase 8 — open PR",
-    "ci_green": "Phase 8 — CI green",
-    "review": "Phase 9 — code review",
-    "merged": "Phase 10 — merged",
-    "complete": "Phase 10 — complete",
-    "ejected": "Phase 11 — ejected",
+# Display split for the rendered Phases table.
+# `PHASE_NUMBER` is the value of the table's `Phase` column.
+# `PHASE_DESCRIPTOR` becomes the `<action> — <descriptor>` suffix in the
+# Maverick Action column. Splitting the two lets us repeat the phase
+# number across multiple rows for the same phase (one per action) without
+# duplicating the descriptor on every row.
+PHASE_NUMBER: dict[str, str] = {
+    "claimed": "Phase 0",
+    "design": "Phase 1-2",
+    "tasks": "Phase 3",
+    "branch": "Phase 4",
+    "implement": "Phase 5",
+    "docs": "Phase 6",
+    "security": "Phase 7",
+    "pr_open": "Phase 8",
+    "ci_green": "Phase 8",
+    "review": "Phase 9",
+    "merged": "Phase 10",
+    "complete": "Phase 10",
+    "ejected": "Phase 11",
 }
+
+PHASE_DESCRIPTOR: dict[str, str] = {
+    "claimed": "coordination",
+    "design": "understand + design",
+    "tasks": "create tasks",
+    "branch": "worktree + branch",
+    "implement": "execute tasks",
+    "docs": "documentation review",
+    "security": "cybersecurity review",
+    "pr_open": "open PR",
+    "ci_green": "CI green",
+    "review": "code review",
+    "merged": "merged",
+    "complete": "complete",
+    "ejected": "ejected",
+}
+
+# Kept for backwards compatibility with external callers that imported the
+# combined labels. Internal render code uses the split dicts above.
+PHASE_LABELS: dict[str, str] = {
+    p: f"{PHASE_NUMBER[p]} — {PHASE_DESCRIPTOR[p]}" for p in PHASE_NUMBER
+}
+
+# Last-resort label used when no explicit `--llm`, no `MAVERICK_LLM` env
+# var, and no prior run-start row carries a value. Generic on purpose:
+# we know it's some Claude Code session but not which model.
+FALLBACK_LLM: str = "claude-code"
 
 
 class _RequiredEvent(TypedDict):
@@ -145,11 +178,26 @@ class Event(_RequiredEvent, total=False):
 
     Inherits the required fields from `_RequiredEvent` and adds optional
     payload that is meaningful only for some actions.
+
+    `maverick_skill` is the **outer** /do-* skill driving the whole run
+    (inherited from the `run-start` row on every event).
+    `dispatched_skill` is the **inner** skill this row dispatches —
+    required on `skill-dispatch` rows, optional on `agent-dispatch` rows
+    when the agent is invoked under a named skill (e.g. agent-tech-docs-writer
+    operating under do-docs).
+    `llm` is the model identifier running this row's work. It is
+    populated on every row at write time via the fallback chain in
+    `_current_llm()` and can be overridden per-row with `--llm` so
+    multi-model runs (e.g. Opus orchestrator + Sonnet subagents) render
+    correctly. Optional in the schema so older v1 rows that lack it
+    still load.
     """
 
     end_ts: str | None
     maverick_skill: str | None
     maverick_agent: str | None
+    dispatched_skill: str | None
+    llm: str | None
     outcome: str | None
     notes: str | None
     sha: str | None
@@ -300,6 +348,9 @@ def _validate(event: dict[str, Any]) -> None:
         if not event.get("maverick_skill"):
             raise SchemaError("run-start action requires maverick_skill")
 
+    if action == "skill-dispatch" and not event.get("dispatched_skill"):
+        raise SchemaError("skill-dispatch action requires dispatched_skill")
+
 
 # ---------------------------------------------------------------------------
 # Write path
@@ -412,6 +463,64 @@ def _current_skill(issue: int, repo_root: Path | None = None) -> str | None:
     return None
 
 
+def _current_llm(
+    explicit: str | None = None,
+    issue: int | None = None,
+    repo_root: Path | None = None,
+    agent: str | None = None,
+    skill_name: str | None = None,
+) -> str:
+    """Resolve the LLM identifier for a row being written.
+
+    Resolution chain, in priority order:
+    1. Explicit ``--llm`` on the CLI call.
+    2. ``MAVERICK_LLM`` env var (workflow-wide override).
+    3. Per-agent entry in the project ``llm.agents`` config block.
+    4. Per-skill entry in the project ``llm.skills`` config block.
+    5. Project ``llm.default``.
+    6. Latest ``run-start`` row's ``llm`` for this issue (inherits across
+       CLI invocations even if the orchestrator never opened the project
+       config — useful for one-off runs).
+    7. The ``FALLBACK_LLM`` literal.
+
+    The project config (3-5) is deep-merged over Maverick's built-in
+    defaults at load time, so reasonable values are always present even
+    without an ``llm`` block in ``.maverick/config.json``.
+    """
+    import os as _os
+
+    if explicit:
+        return explicit
+    env_val = _os.environ.get("MAVERICK_LLM")
+    if env_val:
+        return env_val
+
+    try:
+        from maverick.config import read_llm_config
+        llm_cfg = read_llm_config()
+    except Exception:  # noqa: BLE001 — best-effort; fall through on any error
+        llm_cfg = None
+
+    if llm_cfg is not None:
+        if agent and agent in llm_cfg["agents"]:
+            return llm_cfg["agents"][agent]
+        if skill_name and skill_name in llm_cfg["skills"]:
+            return llm_cfg["skills"][skill_name]
+        if llm_cfg["default"]:
+            return llm_cfg["default"]
+
+    if issue is not None:
+        try:
+            events = load_timeline(timeline_path(issue, repo_root=repo_root))
+        except Exception:  # noqa: BLE001 — best-effort fallback lookup
+            events = []
+        for e in reversed(events):
+            run_llm = e.get("llm")
+            if e.get("action") == "run-start" and run_llm:
+                return str(run_llm)
+    return FALLBACK_LLM
+
+
 # ---------------------------------------------------------------------------
 # Renderer
 # ---------------------------------------------------------------------------
@@ -470,11 +579,16 @@ def render(issue: int, events: Sequence[Event], pr: dict[str, Any] | None = None
 
     Pure function. The CLI handler loads `events` and optionally fetches
     `pr` metadata; this function is fully deterministic given its inputs.
+
+    The Phases table emits one row per (phase, action) tuple in wall-clock
+    order within each phase. A `phase-boundary` row appears only when no
+    agent/skill dispatch fired in that phase. Commit rows show only the
+    end timestamp (commits are atomic events).
     """
     if not events:
         return f"# Maverick workflow report\n\nNo timeline events recorded for issue #{issue}.\n"
 
-    skill = _current_skill_from_events(events) or "(unknown)"
+    root_skill = _current_skill_from_events(events) or "(unknown)"
     version = events[-1].get("maverick_version", "?")
     instances: list[str] = []
     seen: set[str] = set()
@@ -501,9 +615,15 @@ def render(issue: int, events: Sequence[Event], pr: dict[str, Any] | None = None
             if merged_at:
                 line += f" (merged {merged_at})"
             out.append(line)
-    out.append(f"- Skill: {skill}")
+    out.append(f"- Skill: {root_skill}")
     out.append(f"- Outcome: {_outcome_label(events)}")
     out.append(f"- Maverick: {version}")
+    llms = _distinct_llms(events)
+    if llms:
+        if len(llms) == 1:
+            out.append(f"- LLM: {llms[0]}")
+        else:
+            out.append(f"- LLMs: {', '.join(llms)}")
     if instances:
         if len(instances) == 1:
             out.append(f"- Instance: {instances[0]}")
@@ -521,32 +641,21 @@ def render(issue: int, events: Sequence[Event], pr: dict[str, Any] | None = None
 
     out.append("## Phases")
     out.append("")
-    out.append("| Phase | Maverick Action | Maverick Agent | Start | End | Duration |")
-    out.append("|---|---|---|---|---|---|")
+    out.append(
+        "| Phase | LLM | Maverick Root Skill | Maverick Sub Agent | "
+        "Maverick Skill | Start | End | Duration | Maverick Action |"
+    )
+    out.append("|---|---|---|---|---|---|---|---|---|")
 
-    intervals_by_phase = _intervals_by_phase(events, phases)
-    commits_by_phase = _commits_by_phase(events, phases)
-
-    for phase, s, e in phases:
-        label = PHASE_LABELS.get(phase, phase)
-        rows_for_phase = intervals_by_phase.get(phase, [])
-        if rows_for_phase:
-            for action, agent, start_ts, end_ts in rows_for_phase:
-                out.append(
-                    f"| {label} | {action} | {agent or '—'} | "
-                    f"{_fmt_ts(start_ts)} | {_fmt_ts(end_ts)} | "
-                    f"{_seconds_between(start_ts, end_ts)} |"
-                )
-        else:
+    for phase, p_start, p_end in phases:
+        rows = _rows_for_phase(events, phase, p_start, p_end)
+        for row in rows:
+            phase_number = PHASE_NUMBER.get(phase, phase)
             out.append(
-                f"| {label} | phase-boundary | — | "
-                f"{_fmt_ts(s)} | {_fmt_ts(e)} | {_seconds_between(s, e)} |"
-            )
-        for sha, ts, subject in commits_by_phase.get(phase, []):
-            short_sha = sha[:7]
-            sub = subject.replace("|", "\\|")
-            out.append(
-                f"| ↳ commit | `{short_sha}` — {sub} | — | — | {_fmt_ts(ts)} | — |"
+                f"| {phase_number} | {row.llm} | {root_skill} | "
+                f"{row.sub_agent} | {row.skill} | "
+                f"{row.start} | {row.end} | {row.duration} | "
+                f"{row.action} |"
             )
 
     out.append("")
@@ -562,9 +671,112 @@ def render(issue: int, events: Sequence[Event], pr: dict[str, Any] | None = None
         for n in notes:
             phase = n.get("phase", "")
             text = n.get("notes", "") or ""
-            out.append(f"- {PHASE_LABELS.get(phase, phase)}: {text}")
+            label = (
+                f"{PHASE_NUMBER[phase]} — {PHASE_DESCRIPTOR[phase]}"
+                if phase in PHASE_NUMBER
+                else phase
+            )
+            out.append(f"- {label}: {text}")
     out.append("")
     return "\n".join(out)
+
+
+@dataclass(frozen=True)
+class _PhaseRow:
+    """One rendered row of the Phases table."""
+
+    llm: str
+    sub_agent: str
+    skill: str
+    start: str
+    end: str
+    duration: str
+    action: str
+    sort_key: str  # the ts to order this row by within the phase
+
+
+def _rows_for_phase(
+    events: Sequence[Event],
+    phase: str,
+    phase_start: str,
+    phase_end: str,
+) -> list[_PhaseRow]:
+    """Build the in-order list of rendered rows for a single phase.
+
+    Rules:
+    - For each interval event with `phase == this phase`, emit a row
+      with both timestamps + duration.
+    - For each commit event with `phase == this phase`, emit a row with
+      only `end_ts` (commits are atomic).
+    - If no **interval dispatch** fired in this phase, also emit a
+      `phase-boundary` row spanning the whole phase. Commits alone
+      don't suppress the boundary row — they describe what landed, not
+      what was being done.
+    - Sort by wall-clock so dispatches, commits, and boundary appear in
+      the order they actually happened.
+    """
+    descriptor = PHASE_DESCRIPTOR.get(phase, phase)
+    rows: list[_PhaseRow] = []
+    has_dispatch = False
+    for e in events:
+        if e.get("phase") != phase:
+            continue
+        action = e.get("action")
+        if action in INTERVAL_ACTIONS:
+            has_dispatch = True
+            start_ts = e["start_ts"]
+            end_ts = e.get("end_ts") or start_ts
+            rows.append(
+                _PhaseRow(
+                    llm=e.get("llm") or FALLBACK_LLM,
+                    sub_agent=e.get("maverick_agent") or "—",
+                    skill=e.get("dispatched_skill") or "—",
+                    start=_fmt_ts(start_ts),
+                    end=_fmt_ts(end_ts),
+                    duration=str(_seconds_between(start_ts, end_ts)),
+                    action=f"{action} — {descriptor}",
+                    sort_key=start_ts,
+                )
+            )
+        elif action == "commit":
+            ts = e["start_ts"]
+            sha = (e.get("sha") or "")[:7]
+            subject = (e.get("subject") or "").replace("|", "\\|")
+            rows.append(
+                _PhaseRow(
+                    llm=e.get("llm") or FALLBACK_LLM,
+                    sub_agent="—",
+                    skill="—",
+                    start="—",
+                    end=_fmt_ts(ts),
+                    duration="—",
+                    action=f"commit {sha} — {subject}",
+                    sort_key=ts,
+                )
+            )
+    if not has_dispatch:
+        # Choose the llm for the synthesized phase-boundary row: prefer
+        # the latest event in this phase that carries an llm; fall back
+        # to FALLBACK_LLM.
+        boundary_llm = FALLBACK_LLM
+        for e in events:
+            row_llm = e.get("llm")
+            if e.get("phase") == phase and row_llm:
+                boundary_llm = str(row_llm)
+        rows.append(
+            _PhaseRow(
+                llm=boundary_llm,
+                sub_agent="—",
+                skill="—",
+                start=_fmt_ts(phase_start),
+                end=_fmt_ts(phase_end),
+                duration=str(_seconds_between(phase_start, phase_end)),
+                action=f"phase-boundary — {descriptor}",
+                sort_key=phase_start,
+            )
+        )
+    rows.sort(key=lambda r: r.sort_key)
+    return rows
 
 
 def _current_skill_from_events(events: Sequence[Event]) -> str | None:
@@ -574,46 +786,29 @@ def _current_skill_from_events(events: Sequence[Event]) -> str | None:
     return None
 
 
-def _intervals_by_phase(
-    events: Sequence[Event],
-    phases: Sequence[tuple[str, str, str]],
-) -> dict[str, list[tuple[str, str | None, str, str]]]:
-    """Bucket interval events by their owning phase (matched on start_ts).
-
-    Returns {phase: [(action, agent, start_ts, end_ts), ...]}.
-    """
-    buckets: dict[str, list[tuple[str, str | None, str, str]]] = {}
+def _distinct_llms(events: Sequence[Event]) -> list[str]:
+    """Distinct llm values in first-seen order. Empty list if none recorded."""
+    seen: set[str] = set()
+    out: list[str] = []
     for e in events:
-        action = e.get("action")
-        if action not in INTERVAL_ACTIONS:
-            continue
-        start_ts = e["start_ts"]
-        end_ts = e.get("end_ts") or start_ts
-        phase = _phase_for_ts(start_ts, phases) or e.get("phase", "")
-        agent = e.get("maverick_agent")
-        buckets.setdefault(phase, []).append((str(action), agent, start_ts, end_ts))
-    return buckets
-
-
-def _commits_by_phase(
-    events: Sequence[Event],
-    phases: Sequence[tuple[str, str, str]],
-) -> dict[str, list[tuple[str, str, str]]]:
-    """Bucket commit events by their owning phase. Returns {phase: [(sha, ts, subject), ...]}."""
-    buckets: dict[str, list[tuple[str, str, str]]] = {}
-    for e in events:
-        if e.get("action") != "commit":
-            continue
-        ts = e["start_ts"]
-        phase = _phase_for_ts(ts, phases) or e.get("phase", "")
-        buckets.setdefault(phase, []).append(
-            (str(e.get("sha", "")), ts, str(e.get("subject", "")))
-        )
-    return buckets
+        llm = e.get("llm")
+        if llm and llm not in seen:
+            seen.add(llm)
+            out.append(llm)
+    return out
 
 
 def _append_analysis_table(out: list[str], events: Sequence[Event], total: int) -> None:
-    """The 'where the time went' summary table, in seconds."""
+    """The 'where the time went' summary table, in seconds.
+
+    The slices are mutually exclusive by construction:
+    - Agent dispatches / Skill dispatches / User decision points are the
+      summed durations of those interval rows.
+    - Implementation = wall-clock inside the implement phase that is NOT
+      covered by any dispatch (so do-code / do-test wrapping moves time
+      from this slice into Skill dispatches rather than double-counting).
+    - Coordination = total minus everything above.
+    """
     agent_total = sum(
         _seconds_between(e["start_ts"], e.get("end_ts") or e["start_ts"])
         for e in events
@@ -629,38 +824,46 @@ def _append_analysis_table(out: list[str], events: Sequence[Event], total: int) 
         for e in events
         if e.get("action") == "question"
     )
-    commit_total = _implementation_seconds(events)
-    coord_total = max(0, total - agent_total - skill_total - question_total - commit_total)
+    impl_total = _unwrapped_implementation_seconds(events)
+    coord_total = max(0, total - agent_total - skill_total - question_total - impl_total)
 
     out.append("| Slice | Seconds |")
     out.append("|---|---|")
     out.append(f"| Agent dispatches | {agent_total} |")
     out.append(f"| Skill dispatches | {skill_total} |")
-    out.append(f"| Implementation (commit-to-commit inside Phase 5) | {commit_total} |")
+    out.append(f"| Implementation (unwrapped, inside Phase 5) | {impl_total} |")
     out.append(f"| User decision points | {question_total} |")
     out.append(f"| Coordination / CLI / checkpoint overhead | {coord_total} |")
 
 
-def _implementation_seconds(events: Sequence[Event]) -> int:
-    """Sum of commit-to-commit deltas inside the implement phase."""
+def _unwrapped_implementation_seconds(events: Sequence[Event]) -> int:
+    """Wall-clock inside the implement phase not covered by a dispatch.
+
+    With do-code / do-test wrapping in Phase 5, most implementation time
+    sits inside skill-dispatch intervals — that work is already counted
+    in `Skill dispatches`. This slice surfaces the *uninstrumented* time
+    inside Phase 5 (e.g. the gap between a `do-code` close and the next
+    `do-code` open, or between the last `do-code` close and the phase's
+    end). Computed as the implement phase's wall-clock minus the sum of
+    dispatch durations that fall inside it.
+    """
     phases = _phase_intervals(events)
     implement = next((p for p in phases if p[0] == "implement"), None)
     if not implement:
         return 0
     _, impl_start, impl_end = implement
-    commits = sorted(
-        (e["start_ts"] for e in events if e.get("action") == "commit"),
-        key=lambda ts: ts,
-    )
-    impl_commits = [ts for ts in commits if impl_start <= ts <= impl_end]
-    if not impl_commits:
-        return 0
-    total = 0
-    prev = impl_start
-    for ts in impl_commits:
-        total += _seconds_between(prev, ts)
-        prev = ts
-    return total
+    impl_total = _seconds_between(impl_start, impl_end)
+    dispatched = 0
+    for e in events:
+        if e.get("action") not in INTERVAL_ACTIONS:
+            continue
+        if e.get("phase") != "implement":
+            continue
+        end_ts = e.get("end_ts")
+        if not end_ts:
+            continue
+        dispatched += _seconds_between(e["start_ts"], end_ts)
+    return max(0, impl_total - dispatched)
 
 
 # ---------------------------------------------------------------------------
@@ -702,8 +905,20 @@ def _fetch_pr(repo: str, issue: int) -> dict[str, Any] | None:
 # ---------------------------------------------------------------------------
 
 
-def _build_base(args: argparse.Namespace, action: str) -> dict[str, Any]:
-    """Shared scaffold for every write — system fields, schema, action."""
+def _build_base(
+    args: argparse.Namespace,
+    action: str,
+    *,
+    agent: str | None = None,
+    skill_name: str | None = None,
+) -> dict[str, Any]:
+    """Shared scaffold for every write — system fields, schema, action.
+
+    ``agent`` and ``skill_name`` give context to the LLM resolver so that
+    per-agent / per-skill config overrides apply. They default to None
+    for atomic events that don't have an agent/skill identity (run-start,
+    phase-boundary, commit, note, resume).
+    """
     base = _system_fields(args.issue)
     base["action"] = action
     base["start_ts"] = _now_iso()
@@ -712,6 +927,12 @@ def _build_base(args: argparse.Namespace, action: str) -> dict[str, Any]:
         skill = _current_skill(args.issue)
     if skill:
         base["maverick_skill"] = skill
+    base["llm"] = _current_llm(
+        explicit=getattr(args, "llm", None),
+        issue=args.issue,
+        agent=agent,
+        skill_name=skill_name,
+    )
     return base
 
 
@@ -765,13 +986,17 @@ def _report_end(args: argparse.Namespace) -> int:
         return 1
     _write_pending(pending_path(args.issue), pending)
 
-    event = _build_base(args, args.action)
+    agent_ctx = args.agent or open_iv.get("agent")
+    inner_skill = args.skill_name or open_iv.get("skill_name")
+    event = _build_base(args, args.action, agent=agent_ctx, skill_name=inner_skill)
     event["start_ts"] = open_iv["start_ts"]
     event["end_ts"] = _now_iso()
     event["phase"] = args.phase or open_iv.get("phase") or ""
     event["outcome"] = args.outcome
-    if args.agent or open_iv.get("agent"):
-        event["maverick_agent"] = args.agent or open_iv.get("agent")
+    if agent_ctx:
+        event["maverick_agent"] = agent_ctx
+    if inner_skill:
+        event["dispatched_skill"] = inner_skill
     if args.notes:
         event["notes"] = args.notes
     append_event(event)
@@ -878,6 +1103,17 @@ def _add_phase(p: argparse.ArgumentParser, required: bool = True) -> None:
     )
 
 
+def _add_llm(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        "--llm",
+        help=(
+            "LLM identifier for this row (e.g. claude-opus-4-7). Optional; "
+            "falls back to MAVERICK_LLM env var, then to the latest run-start's "
+            "llm, then to the literal 'claude-code'."
+        ),
+    )
+
+
 def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
     r = subparsers.add_parser(
         "report",
@@ -890,12 +1126,14 @@ def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
     p.add_argument("skill", help="The /do-* skill driving this run (e.g. do-issue-solo)")
     _add_issue(p)
     _add_phase(p, required=False)
+    _add_llm(p)
     p.set_defaults(_handler=_report_run_start)
 
     # phase
     p = r_sub.add_parser("phase", help="Mark the end of a phase (phase-boundary event)")
     _add_phase(p)
     _add_issue(p)
+    _add_llm(p)
     p.set_defaults(_handler=_report_phase)
 
     # begin
@@ -906,6 +1144,7 @@ def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
     p.add_argument("--agent", help="Agent name (for agent-dispatch)")
     p.add_argument("--skill-name", dest="skill_name", help="Skill name (for skill-dispatch)")
     p.add_argument("--topic", help="Question topic (for question)")
+    _add_llm(p)
     p.set_defaults(_handler=_report_begin)
 
     # end
@@ -918,6 +1157,7 @@ def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
     p.add_argument("--skill-name", dest="skill_name")
     p.add_argument("--topic")
     p.add_argument("--notes")
+    _add_llm(p)
     p.set_defaults(_handler=_report_end)
 
     # commit
@@ -926,12 +1166,14 @@ def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
     _add_phase(p)
     p.add_argument("--sha", required=True)
     p.add_argument("--subject", required=True)
+    _add_llm(p)
     p.set_defaults(_handler=_report_commit)
 
     # note
     p = r_sub.add_parser("note", help="Record narrative for the report's Analysis section")
     _add_issue(p)
     _add_phase(p)
+    _add_llm(p)
     p.add_argument("--text", required=True)
     p.set_defaults(_handler=_report_note)
 
@@ -939,6 +1181,7 @@ def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
     p = r_sub.add_parser("resume", help="Mark a workflow resume after a crash")
     _add_issue(p)
     _add_phase(p)
+    _add_llm(p)
     p.set_defaults(_handler=_report_resume)
 
     # generate

--- a/src/maverick/report_cli.py
+++ b/src/maverick/report_cli.py
@@ -1,52 +1,116 @@
-"""CLI sub-commands for do-issue-solo timing reports (#83).
+"""CLI sub-commands for the Maverick workflow report (schema v1).
 
-Exposes a small command surface that the do-issue-solo skill body uses to
-record timeline events during a run, plus a `generate` command that
-renders the final markdown report.
+The Maverick workflow report records what happened during a `do-*` skill
+run: which phases ran, which agents and skills were dispatched, which
+commits landed, and what notes the agent left. The on-disk
+representation is a JSONL timeline; the rendered Markdown report is a
+pure function of that timeline.
 
-Design notes:
+## Schema (v1)
 
-- The rolling `maverick-task-progress` GitHub marker only carries the
-  latest phase, so per-phase timestamps are not recoverable from
-  GitHub. We capture phase boundaries (and other events) to a local
-  JSONL file under `<main-repo>/.maverick/reports/`. The file is
-  durable across worktree destruction because we resolve the **main**
-  repo root via `git rev-parse --git-common-dir`.
-- `append_event` is best-effort. A logging failure must never break a
-  do-issue-solo run, so we swallow exceptions and warn on stderr.
-- `render` is a pure function: it takes already-loaded data (events +
-  git log + PR metadata + claim time) and returns a markdown string.
-  The CLI command wires up I/O; tests exercise `render` directly.
+Every row in the timeline JSONL is a typed event conforming to
+`Event` below. The schema is closed: unknown `action`/`phase`/`outcome`
+values are rejected at write time. The renderer rejects malformed rows
+at read time (and skips them with a warning).
+
+Each row carries:
+- `schema_version` — bump on any breaking change
+- `action` — the discriminator; one of `ACTIONS`
+- `start_ts` — wall-clock at which the CLI was invoked
+- `end_ts` — wall-clock at interval close (`null` for atomic events
+  and for intervals whose `end` has not yet fired)
+- system fields — `instance_id`, `maverick_version`
+- run fields — `issue`, `maverick_skill` (inherited from the
+  `run-start` row), `maverick_agent`, `phase`
+- outcome — `success | failure | blocked | skipped` (present only on
+  rows whose `end_ts` is set)
+- optional payload — `notes`, `sha`, `subject`
+
+## Intervals are one row per interval
+
+Interval events (`agent-dispatch`, `skill-dispatch`, `question`) cover
+work that has duration. The CLI is called twice — `begin` and `end` —
+but only **one** row is written, by the `end` call. The `begin` call
+records `start_ts` to a transient sidecar (`.do-issue-solo-N.pending.json`)
+in the reports dir; `end` reads it back, writes the final row with both
+timestamps, and removes the pending entry.
+
+This design honours two constraints:
+1. JSONL rows are one-per-interval, with both timestamps in the same
+   row (matches the rendered table's columns directly).
+2. All timestamps come from `datetime.now(UTC)` at CLI invocation —
+   never from repo events (`git log %cI`, ref ages, etc.). SHA and
+   subject can come from git; the timestamp cannot.
+
+If a `begin` is never closed (crash, eject, abort), the pending entry
+remains as a diagnostic; `maverick report verify` surfaces dangling
+intervals.
+
+## Atomic events
+
+`run-start`, `phase-boundary`, `commit`, `note`, `resume` are atomic —
+one CLI call writes one row with `end_ts = null`. `phase-boundary`
+rows mark the **end** of a phase; the renderer computes phase intervals
+from successive `phase-boundary` rows.
+
+## Authoritativeness
+
+The JSONL is the authoritative record. The rendered Markdown is a pure
+function of the JSONL — re-running `maverick report generate` produces
+the same output. Narrative (agent commentary on what happened in a
+phase) is emitted into the JSONL as `note` rows during the run, not
+added post-hoc to the rendered file.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 import sys
 from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
-# Event type values accepted by `maverick report log`. Unknown types
-# parse and round-trip but are warned about and ignored at render time.
-KNOWN_EVENT_TYPES: frozenset[str] = frozenset(
+from maverick.cli import _get_version
+from maverick.coordinator import instance_id
+from maverick.gh_state import TASK_PROGRESS_PHASES
+
+# ---------------------------------------------------------------------------
+# Schema constants
+# ---------------------------------------------------------------------------
+
+
+SCHEMA_VERSION = 1
+
+# All actions the writer accepts. Atomic actions never carry `end_ts`;
+# interval actions are written by `end` with both timestamps populated.
+ACTIONS: frozenset[str] = frozenset(
     {
-        "phase-checkpoint",
-        "subagent-start",
-        "subagent-end",
-        "skill-start",
-        "skill-end",
-        "question-start",
-        "question-end",
+        "run-start",
+        "phase-boundary",
+        "agent-dispatch",
+        "skill-dispatch",
         "commit",
+        "question",
+        "note",
         "resume",
     }
 )
 
-# Display labels for the report. Order mirrors do-issue-solo phases.
+ATOMIC_ACTIONS: frozenset[str] = frozenset(
+    {"run-start", "phase-boundary", "commit", "note", "resume"}
+)
+
+INTERVAL_ACTIONS: frozenset[str] = frozenset(
+    {"agent-dispatch", "skill-dispatch", "question"}
+)
+
+OUTCOMES: frozenset[str] = frozenset({"success", "failure", "blocked", "skipped"})
+
+PHASES: frozenset[str] = frozenset(TASK_PROGRESS_PHASES)
+
+# Display labels for the rendered Phases table.
 PHASE_LABELS: dict[str, str] = {
     "claimed": "Phase 0 — coordination",
     "design": "Phase 1-2 — understand + design",
@@ -64,6 +128,34 @@ PHASE_LABELS: dict[str, str] = {
 }
 
 
+class _RequiredEvent(TypedDict):
+    """Fields present on every well-formed event."""
+
+    schema_version: int
+    action: str
+    start_ts: str
+    instance_id: str
+    issue: int
+    maverick_version: str
+    phase: str
+
+
+class Event(_RequiredEvent, total=False):
+    """A single row in the timeline JSONL.
+
+    Inherits the required fields from `_RequiredEvent` and adds optional
+    payload that is meaningful only for some actions.
+    """
+
+    end_ts: str | None
+    maverick_skill: str | None
+    maverick_agent: str | None
+    outcome: str | None
+    notes: str | None
+    sha: str | None
+    subject: str | None
+
+
 # ---------------------------------------------------------------------------
 # Path resolution
 # ---------------------------------------------------------------------------
@@ -72,14 +164,15 @@ PHASE_LABELS: dict[str, str] = {
 def _main_repo_root(cwd: Path | None = None) -> Path:
     """Resolve the main repo root, even when called from inside a worktree.
 
-    `git rev-parse --git-common-dir` returns the **shared** `.git`
-    directory for the main checkout (whereas `--git-dir` points at the
-    worktree's `.git` file). The parent of the common dir is the main
-    repo root. Falls back to ``cwd`` (or ``Path.cwd()``) when not in a
-    git repo — keeps unit tests trivial.
+    `git rev-parse --git-common-dir` returns the shared `.git` directory
+    for the main checkout (whereas `--git-dir` points at the worktree's
+    `.git` file). The parent of the common dir is the main repo root.
+    Falls back to ``cwd`` when not in a git repo.
     """
+    import subprocess as _sp
+
     try:
-        out = subprocess.run(
+        out = _sp.run(
             ["git", "rev-parse", "--git-common-dir"],
             capture_output=True,
             text=True,
@@ -91,73 +184,169 @@ def _main_repo_root(cwd: Path | None = None) -> Path:
             base = cwd or Path.cwd()
             common_dir = (base / common_dir).resolve()
         return common_dir.parent
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    except (_sp.CalledProcessError, FileNotFoundError):
         return cwd or Path.cwd()
 
 
 def timeline_path(issue: int, repo_root: Path | None = None) -> Path:
-    """Resolve the JSONL path for an issue's timeline."""
+    """JSONL timeline for an issue."""
     root = repo_root or _main_repo_root()
     return root / ".maverick" / "reports" / f".do-issue-solo-{issue}.timeline.jsonl"
 
 
+def pending_path(issue: int, repo_root: Path | None = None) -> Path:
+    """Sidecar holding open intervals (begin called, end not yet)."""
+    root = repo_root or _main_repo_root()
+    return root / ".maverick" / "reports" / f".do-issue-solo-{issue}.pending.json"
+
+
 def report_path(issue: int, repo_root: Path | None = None) -> Path:
-    """Resolve the rendered-report path for an issue."""
+    """Rendered Markdown report for an issue."""
     root = repo_root or _main_repo_root()
     return root / ".maverick" / "reports" / f"do-issue-solo-{issue}.md"
 
 
 # ---------------------------------------------------------------------------
-# JSONL writer
+# Time helpers
 # ---------------------------------------------------------------------------
 
 
 def _now_iso() -> str:
+    """Current UTC time in `YYYY-MM-DDTHH:MM:SSZ` form."""
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def _parse_ts(s: str) -> datetime:
+    return datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
+def _seconds_between(start: str, end: str) -> int:
+    """Whole-seconds duration between two ISO timestamps."""
+    try:
+        return int(round((_parse_ts(end) - _parse_ts(start)).total_seconds()))
+    except (ValueError, TypeError):
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class SchemaError(ValueError):
+    """Raised when an event violates the v1 schema."""
+
+
+def _validate(event: dict[str, Any]) -> None:
+    """Validate an event against the v1 schema. Raise SchemaError on any issue.
+
+    Used both at write time (reject early) and at load time (skip + warn).
+    """
+    if not isinstance(event, dict):
+        raise SchemaError("event must be a dict")
+
+    sv = event.get("schema_version")
+    if sv != SCHEMA_VERSION:
+        raise SchemaError(f"schema_version must be {SCHEMA_VERSION}, got {sv!r}")
+
+    action = event.get("action")
+    if action not in ACTIONS:
+        raise SchemaError(
+            f"action must be one of {sorted(ACTIONS)}, got {action!r}"
+        )
+
+    start_ts = event.get("start_ts")
+    if not isinstance(start_ts, str) or not start_ts.endswith("Z"):
+        raise SchemaError(f"start_ts must be ISO-8601 UTC string ending 'Z', got {start_ts!r}")
+
+    end_ts = event.get("end_ts")
+    if action in ATOMIC_ACTIONS:
+        if end_ts is not None:
+            raise SchemaError(f"atomic action {action!r} must not carry end_ts")
+    elif action in INTERVAL_ACTIONS:
+        if end_ts is None:
+            # Interval rows are written by `end`, so end_ts should always be
+            # set. A null end_ts here means a malformed row (or one that the
+            # write path forgot to populate). Reject.
+            raise SchemaError(f"interval action {action!r} requires end_ts")
+        if not isinstance(end_ts, str) or not end_ts.endswith("Z"):
+            raise SchemaError(f"end_ts must be ISO-8601 UTC string, got {end_ts!r}")
+
+    phase = event.get("phase")
+    if phase not in PHASES:
+        raise SchemaError(f"phase must be one of {sorted(PHASES)}, got {phase!r}")
+
+    outcome = event.get("outcome")
+    if outcome is not None and outcome not in OUTCOMES:
+        raise SchemaError(f"outcome must be one of {sorted(OUTCOMES)}, got {outcome!r}")
+    if action in INTERVAL_ACTIONS and outcome is None:
+        raise SchemaError(f"interval action {action!r} requires outcome")
+
+    for required in ("instance_id", "issue", "maverick_version"):
+        if required not in event or event[required] in (None, ""):
+            raise SchemaError(f"missing required field {required!r}")
+
+    if action == "commit":
+        if not event.get("sha"):
+            raise SchemaError("commit action requires sha")
+        if not event.get("subject"):
+            raise SchemaError("commit action requires subject")
+
+    if action == "note":
+        if not event.get("notes"):
+            raise SchemaError("note action requires notes text")
+
+    if action == "run-start":
+        if not event.get("maverick_skill"):
+            raise SchemaError("run-start action requires maverick_skill")
+
+
+# ---------------------------------------------------------------------------
+# Write path
+# ---------------------------------------------------------------------------
+
+
+def _system_fields(issue: int) -> dict[str, Any]:
+    """Fields the writer fills in on every row."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "instance_id": instance_id(),
+        "issue": issue,
+        "maverick_version": _get_version(),
+    }
+
+
 def append_event(
-    issue: int,
     event: dict[str, Any],
     repo_root: Path | None = None,
 ) -> bool:
-    """Append a single event to the issue's timeline JSONL.
+    """Validate and append an event to its issue's timeline JSONL.
 
-    Returns True on success, False if the write failed for any reason.
-    Never raises — logging must never break a do-issue-solo run.
+    Returns True on success, False on validation or I/O failure. Errors
+    are written to stderr but do not raise — a logging failure must never
+    break a workflow run.
     """
     try:
-        path = timeline_path(issue, repo_root=repo_root)
+        _validate(event)
+    except SchemaError as e:
+        print(f"warning: report event rejected: {e}", file=sys.stderr)
+        return False
+    try:
+        path = timeline_path(event["issue"], repo_root=repo_root)
         path.parent.mkdir(parents=True, exist_ok=True)
-        record = dict(event)
-        record.setdefault("ts", _now_iso())
-        record.setdefault("issue", issue)
         with path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(record, sort_keys=True) + "\n")
+            f.write(json.dumps(event, sort_keys=True) + "\n")
         return True
-    except Exception as e:  # noqa: BLE001 — best-effort; warn-not-raise
+    except OSError as e:
         print(f"warning: report log append failed: {e}", file=sys.stderr)
         return False
 
 
-def _validate_event(d: Any) -> bool:
-    """Defensive validator. Returns False for malformed records (skipped
-    at render time with a stderr warning)."""
-    if not isinstance(d, dict):
-        return False
-    ts = d.get("ts")
-    if not isinstance(ts, str) or not ts.endswith("Z"):
-        return False
-    if not isinstance(d.get("type"), str):
-        return False
-    return True
-
-
-def load_timeline(path: Path) -> list[dict[str, Any]]:
-    """Load and validate a JSONL timeline. Skips malformed lines."""
+def load_timeline(path: Path) -> list[Event]:
+    """Load a timeline JSONL. Skips malformed lines with a warning."""
     if not path.exists():
         return []
-    events: list[dict[str, Any]] = []
+    events: list[Event] = []
     for i, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
         raw = raw.strip()
         if not raw:
@@ -165,323 +354,340 @@ def load_timeline(path: Path) -> list[dict[str, Any]]:
         try:
             d = json.loads(raw)
         except json.JSONDecodeError:
-            print(
-                f"warning: skipping malformed JSON at {path}:{i}",
-                file=sys.stderr,
-            )
+            print(f"warning: skipping malformed JSON at {path}:{i}", file=sys.stderr)
             continue
-        if not _validate_event(d):
-            print(
-                f"warning: skipping invalid event at {path}:{i}: {raw[:80]}",
-                file=sys.stderr,
-            )
+        try:
+            _validate(d)
+        except SchemaError as e:
+            print(f"warning: skipping invalid event at {path}:{i}: {e}", file=sys.stderr)
             continue
         events.append(d)
-    events.sort(key=lambda e: e["ts"])
+    events.sort(key=lambda e: e["start_ts"])
     return events
 
 
 # ---------------------------------------------------------------------------
-# Rendering
+# Pending-interval sidecar (begin/end pairing)
 # ---------------------------------------------------------------------------
 
 
-def _parse_ts(s: str) -> datetime:
-    return datetime.fromisoformat(s.replace("Z", "+00:00"))
+def _pending_key(action: str, **identifiers: str | None) -> str:
+    """Compose a key that uniquely identifies an open interval.
+
+    do-issue-solo dispatches sequentially, so (action, identifier) is
+    unique while the interval is open. The identifier is the most
+    specific name field for the action — `agent` for agent-dispatch,
+    `skill` for skill-dispatch, `topic` for question.
+    """
+    ident = identifiers.get("agent") or identifiers.get("skill") or identifiers.get("topic") or ""
+    return f"{action}:{ident}"
 
 
-def _fmt_duration(seconds: float) -> str:
-    """Human-readable duration. <1s shows '<1s'; otherwise compact form."""
-    if seconds is None:
-        return "—"
-    secs = int(round(seconds))
-    if secs < 1:
-        return "<1s"
-    if secs < 60:
-        return f"{secs}s"
-    minutes, secs = divmod(secs, 60)
-    if minutes < 60:
-        if secs == 0:
-            return f"{minutes}m"
-        return f"{minutes}m {secs}s"
-    hours, minutes = divmod(minutes, 60)
-    return f"{hours}h {minutes}m"
-
-
-def _fmt_time(ts: str) -> str:
-    """Render an ISO timestamp as HH:MM:SS (UTC)."""
+def _read_pending(path: Path) -> dict[str, dict[str, Any]]:
+    if not path.exists():
+        return {}
     try:
-        return _parse_ts(ts).strftime("%H:%M:%S")
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"warning: pending file unreadable ({e}); starting fresh", file=sys.stderr)
+        return {}
+
+
+def _write_pending(path: Path, state: dict[str, dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Skill lookup (latest run-start row)
+# ---------------------------------------------------------------------------
+
+
+def _current_skill(issue: int, repo_root: Path | None = None) -> str | None:
+    """Read the most recent `run-start` row for this issue."""
+    events = load_timeline(timeline_path(issue, repo_root=repo_root))
+    for e in reversed(events):
+        if e.get("action") == "run-start":
+            return e.get("maverick_skill")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Renderer
+# ---------------------------------------------------------------------------
+
+
+def _fmt_ts(ts: str | None) -> str:
+    """Render an ISO timestamp as `YYYY-MM-DD HH:MM:SS` (UTC). `—` for None."""
+    if not ts:
+        return "—"
+    try:
+        return _parse_ts(ts).strftime("%Y-%m-%d %H:%M:%S")
     except (ValueError, TypeError):
         return ts
 
 
-def _pair_intervals(
-    events: Sequence[dict[str, Any]],
-    start_type: str,
-    end_type: str,
-    key_field: str,
-) -> list[tuple[str, str, str, str]]:
-    """Pair start/end events by `key_field`. Returns
-    [(key, start_ts, end_ts, owning_phase), ...]. Unmatched starts get
-    end=start (zero duration); unmatched ends are ignored.
+def _phase_intervals(events: Sequence[Event]) -> list[tuple[str, str, str]]:
+    """Build [(phase, start_ts, end_ts), ...] from phase-boundary rows.
+
+    Each phase-boundary row marks the **end** of its phase. The first
+    phase's start is the first event's `start_ts`.
     """
-    open_intervals: dict[str, tuple[str, str]] = {}
-    out: list[tuple[str, str, str, str]] = []
-    current_phase = ""
-    for e in events:
-        if e["type"] == "phase-checkpoint":
-            current_phase = e.get("phase", "")
-            continue
-        if e["type"] == start_type:
-            key = str(e.get(key_field, ""))
-            open_intervals[key] = (e["ts"], current_phase)
-        elif e["type"] == end_type:
-            key = str(e.get(key_field, ""))
-            opened = open_intervals.pop(key, None)
-            if opened is None:
-                continue
-            start_ts, phase = opened
-            out.append((key, start_ts, e["ts"], phase))
-    for key, (start_ts, phase) in open_intervals.items():
-        out.append((key, start_ts, start_ts, phase))
+    phase_boundaries = [e for e in events if e.get("action") == "phase-boundary"]
+    if not phase_boundaries:
+        return []
+    out: list[tuple[str, str, str]] = []
+    prev_end = events[0]["start_ts"] if events else None
+    for pb in phase_boundaries:
+        phase = pb.get("phase", "")
+        start_ts = prev_end or pb["start_ts"]
+        end_ts = pb["start_ts"]
+        out.append((phase, start_ts, end_ts))
+        prev_end = end_ts
     return out
 
 
-def _phase_intervals(
-    events: Sequence[dict[str, Any]],
-    claim_created_at: str | None,
-) -> list[tuple[str, str, str]]:
-    """Build [(phase, start_ts, end_ts), ...] from phase-checkpoint events.
+def _phase_for_ts(ts: str, phases: Sequence[tuple[str, str, str]]) -> str | None:
+    """Which phase interval contains this timestamp?"""
+    for phase, s, e in phases:
+        if s <= ts <= e:
+            return phase
+    return None
 
-    Each checkpoint marks the **end** of its phase. The first phase's
-    start is `claim_created_at` (if available) or the first event's
-    timestamp.
+
+def _outcome_label(events: Sequence[Event]) -> str:
+    """The run's overall outcome: PASS | FAIL-eject | BLOCKED | IN-PROGRESS."""
+    phases_seen = {e.get("phase") for e in events if e.get("action") == "phase-boundary"}
+    if "complete" in phases_seen:
+        return "PASS"
+    if "ejected" in phases_seen:
+        return "FAIL-eject"
+    return "IN-PROGRESS"
+
+
+def render(issue: int, events: Sequence[Event], pr: dict[str, Any] | None = None) -> str:
+    """Render the timeline as a Markdown workflow report.
+
+    Pure function. The CLI handler loads `events` and optionally fetches
+    `pr` metadata; this function is fully deterministic given its inputs.
     """
-    cps = [e for e in events if e["type"] == "phase-checkpoint"]
-    if not cps:
-        return []
-    intervals: list[tuple[str, str, str]] = []
-    prev_end = claim_created_at
-    if not prev_end and events:
-        prev_end = events[0]["ts"]
-    for cp in cps:
-        phase = cp.get("phase", "")
-        start_ts = prev_end or cp["ts"]
-        end_ts = cp["ts"]
-        intervals.append((phase, start_ts, end_ts))
-        prev_end = end_ts
-    return intervals
-
-
-def _seconds_between(start: str, end: str) -> float:
-    try:
-        return (_parse_ts(end) - _parse_ts(start)).total_seconds()
-    except (ValueError, TypeError):
-        return 0.0
-
-
-def _facts_for_phase(
-    phase: str,
-    events: Sequence[dict[str, Any]],
-    subagents: Sequence[tuple[str, str, str, str]],
-    questions: Sequence[tuple[str, str, str, str]],
-    skills: Sequence[tuple[str, str, str, str]],
-) -> str:
-    """Build the auto-generated facts portion of a phase's Activity cell."""
-    pieces: list[str] = []
-    for name, s, e, p in subagents:
-        if p == phase:
-            pieces.append(f"{name} ({_fmt_duration(_seconds_between(s, e))})")
-    for name, s, e, p in skills:
-        if p == phase:
-            pieces.append(f"{name} ({_fmt_duration(_seconds_between(s, e))})")
-    for topic, s, e, p in questions:
-        if p == phase:
-            pieces.append(f"question: {topic} ({_fmt_duration(_seconds_between(s, e))})")
-    return " + ".join(pieces) if pieces else ""
-
-
-def render(
-    issue: int,
-    events: Sequence[dict[str, Any]],
-    commits: Sequence[dict[str, Any]] | None = None,
-    pr: dict[str, Any] | None = None,
-    claim_created_at: str | None = None,
-) -> str:
-    """Render the timing report to markdown.
-
-    Pure function — all inputs are passed; no I/O. The CLI command
-    `maverick report generate` fetches `commits`/`pr`/`claim_created_at`
-    and calls this.
-
-    - `events` — chronological timeline events (already validated/sorted).
-    - `commits` — list of {sha, committed_at, subject} for Phase 5
-      sub-rows. May be empty if branch info is unavailable.
-    - `pr` — {created_at, merged_at, number} from `gh pr view`. May be None.
-    - `claim_created_at` — ISO timestamp from the maverick-claim marker.
-      Anchors the first phase's start.
-    """
-    commits = list(commits or [])
     if not events:
-        return f"# Issue #{issue} — time breakdown\n\nNo timeline events recorded.\n"
+        return f"# Maverick workflow report\n\nNo timeline events recorded for issue #{issue}.\n"
 
-    subagents = _pair_intervals(events, "subagent-start", "subagent-end", "name")
-    questions = _pair_intervals(events, "question-start", "question-end", "topic")
-    skills = _pair_intervals(events, "skill-start", "skill-end", "name")
-    phases = _phase_intervals(events, claim_created_at)
+    skill = _current_skill_from_events(events) or "(unknown)"
+    version = events[-1].get("maverick_version", "?")
+    instances: list[str] = []
+    seen: set[str] = set()
+    for e in events:
+        iid = e.get("instance_id")
+        if iid and iid not in seen:
+            seen.add(iid)
+            instances.append(iid)
 
-    first_ts = claim_created_at or events[0]["ts"]
-    last_ts = events[-1]["ts"]
-    total = _seconds_between(first_ts, last_ts)
+    phases = _phase_intervals(events)
+    first_ts = events[0]["start_ts"]
+    last_ts = phases[-1][2] if phases else events[-1].get("end_ts") or events[-1]["start_ts"]
+    total_seconds = _seconds_between(first_ts, last_ts)
 
     out: list[str] = []
-    out.append(f"# Issue #{issue} — time breakdown")
+    out.append("# Maverick workflow report")
     out.append("")
-    out.append(
-        f"Wall-clock: **{_fmt_duration(total)}** from "
-        f"{first_ts} to {last_ts}. All timestamps below are UTC. "
-        "Phase boundaries come from `maverick task-progress` checkpoints; "
-        "sub-task rows in the implement phase come from commit times; "
-        "PR open/merge timestamps come from `gh pr view`."
-    )
+    out.append(f"- Issue: #{issue}")
+    if pr:
+        pr_num = pr.get("number")
+        merged_at = pr.get("merged_at")
+        if pr_num is not None:
+            line = f"- PR:    #{pr_num}"
+            if merged_at:
+                line += f" (merged {merged_at})"
+            out.append(line)
+    out.append(f"- Skill: {skill}")
+    out.append(f"- Outcome: {_outcome_label(events)}")
+    out.append(f"- Maverick: {version}")
+    if instances:
+        if len(instances) == 1:
+            out.append(f"- Instance: {instances[0]}")
+        else:
+            tail = ", ".join(f"{i} (resumed)" for i in instances[1:])
+            out.append(f"- Instances: {instances[0]}, {tail}")
     out.append("")
+    out.append("_All timestamps UTC. Durations in seconds._")
+    out.append("")
+
+    out.append("## Total Time")
+    out.append("")
+    out.append(f"seconds: {total_seconds}")
+    out.append("")
+
     out.append("## Phases")
     out.append("")
-    out.append("| Phase | Activity | Start | End | Duration |")
-    out.append("|---|---|---|---|---|")
+    out.append("| Phase | Maverick Action | Maverick Agent | Start | End | Duration |")
+    out.append("|---|---|---|---|---|---|")
 
-    implement_seen = False
+    intervals_by_phase = _intervals_by_phase(events, phases)
+    commits_by_phase = _commits_by_phase(events, phases)
+
     for phase, s, e in phases:
         label = PHASE_LABELS.get(phase, phase)
-        facts = _facts_for_phase(phase, events, subagents, questions, skills)
-        activity = f"PLACEHOLDER — {facts}" if facts else "PLACEHOLDER"
-        dur = _fmt_duration(_seconds_between(s, e))
-        out.append(f"| {label} | {activity} | {_fmt_time(s)} | {_fmt_time(e)} | {dur} |")
-        if phase == "implement" and commits and not implement_seen:
-            implement_seen = True
-            prev_ts = s
-            for c in commits:
-                sub = (c.get("subject") or "").replace("|", "\\|")
-                sha = (c.get("sha") or "")[:7]
-                c_ts = c.get("committed_at") or ""
-                dur_c = _fmt_duration(_seconds_between(prev_ts, c_ts)) if c_ts else "—"
+        rows_for_phase = intervals_by_phase.get(phase, [])
+        if rows_for_phase:
+            for action, agent, start_ts, end_ts in rows_for_phase:
                 out.append(
-                    f"| ↳ commit | `{sha}` — {sub} | "
-                    f"{_fmt_time(prev_ts)} | {_fmt_time(c_ts)} | {dur_c} |"
+                    f"| {label} | {action} | {agent or '—'} | "
+                    f"{_fmt_ts(start_ts)} | {_fmt_ts(end_ts)} | "
+                    f"{_seconds_between(start_ts, end_ts)} |"
                 )
-                prev_ts = c_ts
+        else:
+            out.append(
+                f"| {label} | phase-boundary | — | "
+                f"{_fmt_ts(s)} | {_fmt_ts(e)} | {_seconds_between(s, e)} |"
+            )
+        for sha, ts, subject in commits_by_phase.get(phase, []):
+            short_sha = sha[:7]
+            sub = subject.replace("|", "\\|")
+            out.append(
+                f"| ↳ commit | `{short_sha}` — {sub} | — | — | {_fmt_ts(ts)} | — |"
+            )
 
     out.append("")
-    out.append("## Where the time actually went")
+    out.append("## Analysis")
     out.append("")
-    out.append("| Slice | Wall-clock |")
-    out.append("|---|---|")
+    _append_analysis_table(out, events, total_seconds)
 
-    subagent_total = sum(_seconds_between(s, e) for _, s, e, _ in subagents)
-    skill_total = sum(_seconds_between(s, e) for _, s, e, _ in skills)
-    question_total = sum(_seconds_between(s, e) for _, s, e, _ in questions)
-
-    impl_total = 0.0
-    if commits and phases:
-        for phase, s, _e in phases:
-            if phase == "implement":
-                prev_ts = s
-                for c in commits:
-                    c_ts = c.get("committed_at") or ""
-                    if c_ts:
-                        impl_total += _seconds_between(prev_ts, c_ts)
-                        prev_ts = c_ts
-                break
-
-    coord_total = total - subagent_total - skill_total - question_total - impl_total
-    if coord_total < 0:
-        coord_total = 0.0
-
-    out.append(f"| Subagent compute | {_fmt_duration(subagent_total)} |")
-    out.append(f"| Skill dispatches (do-cybersecurity-review etc.) | {_fmt_duration(skill_total)} |")
-    out.append(f"| Implementation (commit-to-commit inside Phase 5) | {_fmt_duration(impl_total)} |")
-    out.append(f"| User decision points | {_fmt_duration(question_total)} |")
-    out.append(f"| Coordination / CLI / checkpoint overhead | {_fmt_duration(coord_total)} |")
-
-    if pr:
+    notes = [e for e in events if e.get("action") == "note"]
+    if notes:
         out.append("")
-        out.append("## PR")
+        out.append("_Notes from the run, in order:_")
         out.append("")
-        pr_num = pr.get("number")
-        out.append(f"- PR #{pr_num}: opened {pr.get('created_at') or '?'} → merged {pr.get('merged_at') or '?'}")
-
-    out.append("")
-    out.append(
-        "_Activity cells marked `PLACEHOLDER` are intended to be replaced "
-        "with a one-sentence narrative of what happened in that phase. "
-        "Re-run `maverick report generate` to regenerate from the timeline._"
-    )
+        for n in notes:
+            phase = n.get("phase", "")
+            text = n.get("notes", "") or ""
+            out.append(f"- {PHASE_LABELS.get(phase, phase)}: {text}")
     out.append("")
     return "\n".join(out)
 
 
-# ---------------------------------------------------------------------------
-# External data helpers (network/shell — not exercised in unit tests)
-# ---------------------------------------------------------------------------
+def _current_skill_from_events(events: Sequence[Event]) -> str | None:
+    for e in reversed(events):
+        if e.get("action") == "run-start":
+            return e.get("maverick_skill")
+    return None
 
 
-def _fetch_commits(branch: str | None, base: str | None) -> list[dict[str, Any]]:
-    """Resolve commit log via `git log`. Returns [] on failure or when
-    `branch`/`base` cannot be resolved."""
-    if not branch:
-        return []
-    base = base or "origin/main"
-    try:
-        out = subprocess.run(
-            ["git", "log", f"{base}..{branch}", "--reverse", "--pretty=%H|%cI|%s"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError) as e:
-        print(f"warning: git log failed for {base}..{branch}: {e}", file=sys.stderr)
-        return []
-    commits: list[dict[str, Any]] = []
-    for line in out.stdout.splitlines():
-        parts = line.split("|", 2)
-        if len(parts) != 3:
+def _intervals_by_phase(
+    events: Sequence[Event],
+    phases: Sequence[tuple[str, str, str]],
+) -> dict[str, list[tuple[str, str | None, str, str]]]:
+    """Bucket interval events by their owning phase (matched on start_ts).
+
+    Returns {phase: [(action, agent, start_ts, end_ts), ...]}.
+    """
+    buckets: dict[str, list[tuple[str, str | None, str, str]]] = {}
+    for e in events:
+        action = e.get("action")
+        if action not in INTERVAL_ACTIONS:
             continue
-        sha, c_ts, subject = parts
-        commits.append({"sha": sha, "committed_at": c_ts, "subject": subject})
-    return commits
+        start_ts = e["start_ts"]
+        end_ts = e.get("end_ts") or start_ts
+        phase = _phase_for_ts(start_ts, phases) or e.get("phase", "")
+        agent = e.get("maverick_agent")
+        buckets.setdefault(phase, []).append((str(action), agent, start_ts, end_ts))
+    return buckets
+
+
+def _commits_by_phase(
+    events: Sequence[Event],
+    phases: Sequence[tuple[str, str, str]],
+) -> dict[str, list[tuple[str, str, str]]]:
+    """Bucket commit events by their owning phase. Returns {phase: [(sha, ts, subject), ...]}."""
+    buckets: dict[str, list[tuple[str, str, str]]] = {}
+    for e in events:
+        if e.get("action") != "commit":
+            continue
+        ts = e["start_ts"]
+        phase = _phase_for_ts(ts, phases) or e.get("phase", "")
+        buckets.setdefault(phase, []).append(
+            (str(e.get("sha", "")), ts, str(e.get("subject", "")))
+        )
+    return buckets
+
+
+def _append_analysis_table(out: list[str], events: Sequence[Event], total: int) -> None:
+    """The 'where the time went' summary table, in seconds."""
+    agent_total = sum(
+        _seconds_between(e["start_ts"], e.get("end_ts") or e["start_ts"])
+        for e in events
+        if e.get("action") == "agent-dispatch"
+    )
+    skill_total = sum(
+        _seconds_between(e["start_ts"], e.get("end_ts") or e["start_ts"])
+        for e in events
+        if e.get("action") == "skill-dispatch"
+    )
+    question_total = sum(
+        _seconds_between(e["start_ts"], e.get("end_ts") or e["start_ts"])
+        for e in events
+        if e.get("action") == "question"
+    )
+    commit_total = _implementation_seconds(events)
+    coord_total = max(0, total - agent_total - skill_total - question_total - commit_total)
+
+    out.append("| Slice | Seconds |")
+    out.append("|---|---|")
+    out.append(f"| Agent dispatches | {agent_total} |")
+    out.append(f"| Skill dispatches | {skill_total} |")
+    out.append(f"| Implementation (commit-to-commit inside Phase 5) | {commit_total} |")
+    out.append(f"| User decision points | {question_total} |")
+    out.append(f"| Coordination / CLI / checkpoint overhead | {coord_total} |")
+
+
+def _implementation_seconds(events: Sequence[Event]) -> int:
+    """Sum of commit-to-commit deltas inside the implement phase."""
+    phases = _phase_intervals(events)
+    implement = next((p for p in phases if p[0] == "implement"), None)
+    if not implement:
+        return 0
+    _, impl_start, impl_end = implement
+    commits = sorted(
+        (e["start_ts"] for e in events if e.get("action") == "commit"),
+        key=lambda ts: ts,
+    )
+    impl_commits = [ts for ts in commits if impl_start <= ts <= impl_end]
+    if not impl_commits:
+        return 0
+    total = 0
+    prev = impl_start
+    for ts in impl_commits:
+        total += _seconds_between(prev, ts)
+        prev = ts
+    return total
+
+
+# ---------------------------------------------------------------------------
+# External data helpers
+# ---------------------------------------------------------------------------
 
 
 def _fetch_pr(repo: str, issue: int) -> dict[str, Any] | None:
     """Look up the PR for an issue via `gh pr list --search '<issue-ref>'`."""
+    import subprocess as _sp
+
     try:
-        out = subprocess.run(
+        out = _sp.run(
             [
-                "gh",
-                "pr",
-                "list",
-                "--repo",
-                repo,
-                "--state",
-                "all",
-                "--search",
-                f"#{issue} in:body",
-                "--json",
-                "number,createdAt,mergedAt,state",
-                "--limit",
-                "5",
+                "gh", "pr", "list", "--repo", repo, "--state", "all",
+                "--search", f"#{issue} in:body",
+                "--json", "number,createdAt,mergedAt,state",
+                "--limit", "5",
             ],
-            capture_output=True,
-            text=True,
-            check=True,
+            capture_output=True, text=True, check=True,
         )
         data = json.loads(out.stdout)
-    except (subprocess.CalledProcessError, FileNotFoundError, json.JSONDecodeError) as e:
+    except (_sp.CalledProcessError, FileNotFoundError, json.JSONDecodeError) as e:
         print(f"warning: gh pr lookup failed: {e}", file=sys.stderr)
         return None
     if not data:
         return None
-    # Prefer the most-recently-merged one; otherwise first.
     merged = [p for p in data if p.get("mergedAt")]
     chosen = merged[0] if merged else data[0]
     return {
@@ -491,48 +697,108 @@ def _fetch_pr(repo: str, issue: int) -> dict[str, Any] | None:
     }
 
 
-def _fetch_claim_created_at(repo: str, issue: int) -> str | None:
-    """Read the claim marker's claimed_at field via `maverick gh-state read`."""
-    try:
-        from maverick import gh_state
-
-        m = gh_state.latest_marker(repo, issue, "maverick-claim")
-        if m and isinstance(m.payload, dict):
-            return m.payload.get("claimed_at")
-    except Exception as e:  # noqa: BLE001 — best-effort enrichment
-        print(f"warning: claim marker lookup failed: {e}", file=sys.stderr)
-    return None
-
-
 # ---------------------------------------------------------------------------
 # CLI handlers
 # ---------------------------------------------------------------------------
 
 
-def _report_log(args: argparse.Namespace) -> int:
-    event: dict[str, Any] = {"type": args.event_type}
-    if args.name:
-        event["name"] = args.name
-    if args.topic:
-        event["topic"] = args.topic
-    if args.phase:
-        event["phase"] = args.phase
-    if args.sha:
-        event["sha"] = args.sha
-    if args.task:
-        event["task"] = args.task
-    for raw in args.meta or []:
-        if "=" not in raw:
-            print(f"warning: ignoring --meta without '=': {raw}", file=sys.stderr)
-            continue
-        k, v = raw.split("=", 1)
-        event[k] = v
-    if args.event_type not in KNOWN_EVENT_TYPES:
-        print(
-            f"warning: unknown event type '{args.event_type}' (logging anyway)",
-            file=sys.stderr,
-        )
-    append_event(args.issue, event)
+def _build_base(args: argparse.Namespace, action: str) -> dict[str, Any]:
+    """Shared scaffold for every write — system fields, schema, action."""
+    base = _system_fields(args.issue)
+    base["action"] = action
+    base["start_ts"] = _now_iso()
+    skill = getattr(args, "skill", None)
+    if not skill:
+        skill = _current_skill(args.issue)
+    if skill:
+        base["maverick_skill"] = skill
+    return base
+
+
+def _report_run_start(args: argparse.Namespace) -> int:
+    """Mark the start of a workflow run. Subsequent rows inherit `maverick_skill`."""
+    event = _build_base(args, "run-start")
+    event["maverick_skill"] = args.skill  # explicit even though base set it
+    event["phase"] = args.phase or "claimed"
+    append_event(event)
+    return 0
+
+
+def _report_phase(args: argparse.Namespace) -> int:
+    """Mark the end of a phase (atomic phase-boundary event)."""
+    event = _build_base(args, "phase-boundary")
+    event["phase"] = args.phase
+    append_event(event)
+    return 0
+
+
+def _report_begin(args: argparse.Namespace) -> int:
+    """Open an interval. Records start_ts to the pending sidecar."""
+    if args.action not in INTERVAL_ACTIONS:
+        print(f"error: `begin` only valid for interval actions: {sorted(INTERVAL_ACTIONS)}", file=sys.stderr)
+        return 2
+    pending = _read_pending(pending_path(args.issue))
+    key = _pending_key(args.action, agent=args.agent, skill=args.skill_name, topic=args.topic)
+    if key in pending:
+        print(f"warning: `begin {args.action}` overwriting still-open interval ({key})", file=sys.stderr)
+    pending[key] = {
+        "start_ts": _now_iso(),
+        "phase": args.phase,
+        "agent": args.agent,
+        "skill_name": args.skill_name,
+        "topic": args.topic,
+    }
+    _write_pending(pending_path(args.issue), pending)
+    return 0
+
+
+def _report_end(args: argparse.Namespace) -> int:
+    """Close an interval. Writes the final row with start_ts + end_ts + outcome."""
+    if args.action not in INTERVAL_ACTIONS:
+        print(f"error: `end` only valid for interval actions: {sorted(INTERVAL_ACTIONS)}", file=sys.stderr)
+        return 2
+    pending = _read_pending(pending_path(args.issue))
+    key = _pending_key(args.action, agent=args.agent, skill=args.skill_name, topic=args.topic)
+    open_iv = pending.pop(key, None)
+    if open_iv is None:
+        print(f"warning: `end {args.action}` with no matching open begin ({key}); skipping row", file=sys.stderr)
+        return 1
+    _write_pending(pending_path(args.issue), pending)
+
+    event = _build_base(args, args.action)
+    event["start_ts"] = open_iv["start_ts"]
+    event["end_ts"] = _now_iso()
+    event["phase"] = args.phase or open_iv.get("phase") or ""
+    event["outcome"] = args.outcome
+    if args.agent or open_iv.get("agent"):
+        event["maverick_agent"] = args.agent or open_iv.get("agent")
+    if args.notes:
+        event["notes"] = args.notes
+    append_event(event)
+    return 0
+
+
+def _report_commit(args: argparse.Namespace) -> int:
+    event = _build_base(args, "commit")
+    event["phase"] = args.phase
+    event["sha"] = args.sha
+    event["subject"] = args.subject
+    append_event(event)
+    return 0
+
+
+def _report_note(args: argparse.Namespace) -> int:
+    event = _build_base(args, "note")
+    event["phase"] = args.phase
+    event["notes"] = args.text
+    append_event(event)
+    return 0
+
+
+def _report_resume(args: argparse.Namespace) -> int:
+    event = _build_base(args, "resume")
+    event["phase"] = args.phase
+    append_event(event)
     return 0
 
 
@@ -545,24 +811,47 @@ def _report_generate(args: argparse.Namespace) -> int:
         print(f"no timeline data for issue {issue} at {tpath}", file=sys.stderr)
         return 2
 
-    branch = args.branch
-    base = args.base or "origin/main"
-    commits = _fetch_commits(branch, base)
     pr = _fetch_pr(args.repo, issue) if args.repo else None
-    claim_ts = _fetch_claim_created_at(args.repo, issue) if args.repo else None
-
-    md = render(
-        issue=issue,
-        events=events,
-        commits=commits,
-        pr=pr,
-        claim_created_at=claim_ts,
-    )
+    md = render(issue=issue, events=events, pr=pr)
 
     out_path = Path(args.out) if args.out else report_path(issue, repo_root=repo_root)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(md, encoding="utf-8")
     print(str(out_path))
+    return 0
+
+
+def _report_verify(args: argparse.Namespace) -> int:
+    """Lint a timeline JSONL against the v1 schema."""
+    tpath = timeline_path(args.issue)
+    if not tpath.exists():
+        print(f"no timeline at {tpath}", file=sys.stderr)
+        return 2
+    errors = 0
+    for i, raw in enumerate(tpath.read_text(encoding="utf-8").splitlines(), 1):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            d = json.loads(raw)
+        except json.JSONDecodeError as e:
+            print(f"{tpath}:{i}: malformed JSON: {e}")
+            errors += 1
+            continue
+        try:
+            _validate(d)
+        except SchemaError as e:
+            print(f"{tpath}:{i}: schema violation: {e}")
+            errors += 1
+    pending = _read_pending(pending_path(args.issue))
+    if pending:
+        print(f"warning: {len(pending)} dangling open interval(s) in {pending_path(args.issue)}:")
+        for key, state in pending.items():
+            print(f"  {key} — started {state.get('start_ts')}")
+    if errors:
+        print(f"\n{errors} schema violation(s) found")
+        return 1
+    print("ok")
     return 0
 
 
@@ -572,59 +861,100 @@ def _report_path(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
-# Subparser wiring
+# argparse wiring
 # ---------------------------------------------------------------------------
+
+
+def _add_issue(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--issue", type=int, required=True, help="GitHub issue number")
+
+
+def _add_phase(p: argparse.ArgumentParser, required: bool = True) -> None:
+    p.add_argument(
+        "--phase",
+        required=required,
+        choices=sorted(PHASES),
+        help="Phase the event belongs to (closed enum)",
+    )
 
 
 def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
     r = subparsers.add_parser(
         "report",
-        help="do-issue-solo timing reports (log events / render markdown)",
+        help="Maverick workflow report (log events / render markdown)",
     )
     r_sub = r.add_subparsers(dest="report_cmd", required=True)
 
-    p = r_sub.add_parser(
-        "log",
-        help="Append a timeline event for an issue (used by do-issue-solo)",
-    )
-    p.add_argument(
-        "event_type",
-        help="Event type, e.g. subagent-start, subagent-end, question-start",
-    )
-    p.add_argument("--issue", type=int, required=True, help="GitHub issue number")
-    p.add_argument("--name", help="Agent or skill name (subagent-* / skill-*)")
-    p.add_argument("--topic", help="Question topic (question-*)")
-    p.add_argument("--phase", help="Phase name (phase-checkpoint)")
-    p.add_argument("--sha", help="Commit SHA (commit)")
-    p.add_argument("--task", help="Task label (subagent-* / commit)")
-    p.add_argument(
-        "--meta",
-        action="append",
-        help="Extra key=value pair; may be repeated",
-    )
-    p.set_defaults(_handler=_report_log)
+    # run-start
+    p = r_sub.add_parser("run-start", help="Mark the start of a workflow run")
+    p.add_argument("skill", help="The /do-* skill driving this run (e.g. do-issue-solo)")
+    _add_issue(p)
+    _add_phase(p, required=False)
+    p.set_defaults(_handler=_report_run_start)
 
-    p = r_sub.add_parser(
-        "generate",
-        help="Render the timing-report markdown to .maverick/reports/",
-    )
-    p.add_argument("repo", help="owner/repo (used to look up PR + claim metadata)")
+    # phase
+    p = r_sub.add_parser("phase", help="Mark the end of a phase (phase-boundary event)")
+    _add_phase(p)
+    _add_issue(p)
+    p.set_defaults(_handler=_report_phase)
+
+    # begin
+    p = r_sub.add_parser("begin", help="Open an interval (agent-dispatch / skill-dispatch / question)")
+    p.add_argument("action", choices=sorted(INTERVAL_ACTIONS))
+    _add_issue(p)
+    _add_phase(p)
+    p.add_argument("--agent", help="Agent name (for agent-dispatch)")
+    p.add_argument("--skill-name", dest="skill_name", help="Skill name (for skill-dispatch)")
+    p.add_argument("--topic", help="Question topic (for question)")
+    p.set_defaults(_handler=_report_begin)
+
+    # end
+    p = r_sub.add_parser("end", help="Close an interval opened by `begin`")
+    p.add_argument("action", choices=sorted(INTERVAL_ACTIONS))
+    _add_issue(p)
+    p.add_argument("--outcome", required=True, choices=sorted(OUTCOMES))
+    p.add_argument("--phase", choices=sorted(PHASES))
+    p.add_argument("--agent")
+    p.add_argument("--skill-name", dest="skill_name")
+    p.add_argument("--topic")
+    p.add_argument("--notes")
+    p.set_defaults(_handler=_report_end)
+
+    # commit
+    p = r_sub.add_parser("commit", help="Log a commit landing")
+    _add_issue(p)
+    _add_phase(p)
+    p.add_argument("--sha", required=True)
+    p.add_argument("--subject", required=True)
+    p.set_defaults(_handler=_report_commit)
+
+    # note
+    p = r_sub.add_parser("note", help="Record narrative for the report's Analysis section")
+    _add_issue(p)
+    _add_phase(p)
+    p.add_argument("--text", required=True)
+    p.set_defaults(_handler=_report_note)
+
+    # resume
+    p = r_sub.add_parser("resume", help="Mark a workflow resume after a crash")
+    _add_issue(p)
+    _add_phase(p)
+    p.set_defaults(_handler=_report_resume)
+
+    # generate
+    p = r_sub.add_parser("generate", help="Render the timing-report markdown")
+    p.add_argument("repo", help="owner/repo (used to look up PR metadata)")
     p.add_argument("issue", type=int)
-    p.add_argument(
-        "--branch",
-        help="Feature branch (defaults to current branch via `git rev-parse`)",
-    )
-    p.add_argument(
-        "--base",
-        help="Base branch for git-log range (default: origin/main)",
-    )
-    p.add_argument("--out", help="Override output path (default: .maverick/reports/...)")
+    p.add_argument("--out", help="Override output path")
     p.set_defaults(_handler=_report_generate)
 
-    p = r_sub.add_parser(
-        "path",
-        help="Print the resolved timeline JSONL path for an issue",
-    )
+    # verify
+    p = r_sub.add_parser("verify", help="Lint a timeline JSONL against the schema")
+    p.add_argument("issue", type=int)
+    p.set_defaults(_handler=_report_verify)
+
+    # path
+    p = r_sub.add_parser("path", help="Print the timeline JSONL path for an issue")
     p.add_argument("issue", type=int)
     p.set_defaults(_handler=_report_path)
 
@@ -638,12 +968,20 @@ def dispatch(args: argparse.Namespace) -> int:
 
 
 __all__ = [
-    "KNOWN_EVENT_TYPES",
+    "ACTIONS",
+    "ATOMIC_ACTIONS",
+    "INTERVAL_ACTIONS",
+    "OUTCOMES",
+    "PHASES",
     "PHASE_LABELS",
+    "SCHEMA_VERSION",
+    "Event",
+    "SchemaError",
     "append_event",
     "build_subparsers",
     "dispatch",
     "load_timeline",
+    "pending_path",
     "render",
     "report_path",
     "timeline_path",

--- a/src/maverick/skills/do-code/body.md.j2
+++ b/src/maverick/skills/do-code/body.md.j2
@@ -1,0 +1,82 @@
+
+**Depends on:** {{ DEPENDS_ON }}
+
+# Implement a Code Change
+
+Wraps implementation work in a Maverick skill so the workflow report
+records what was done and the agent applies the project's coding
+standards before editing. Invoke this skill **once per task** from
+inside `{{ SKILLS.DO_ISSUE_SOLO }}` / `{{ SKILLS.DO_ISSUE_GUIDED }}` /
+`{{ SKILLS.DO_EPIC }}` Phase 5. The argument is a one-line task
+description that gets logged in the report.
+
+This skill is a thin wrapper. The actual edits are made by the
+orchestrating Claude Code session using its built-in tools (Read, Edit,
+Write, Bash, Grep). The skill's job is to pin standards and scope, not
+to perform the edits in a subagent.
+
+## Preflight (mandatory)
+
+Run this **first**. If it exits non-zero, halt and report the stderr
+output to the user verbatim. Do not proceed.
+
+```bash
+uv run maverick preflight do-code
+```
+
+The check verifies the project is initialised and `uv` is on PATH.
+
+## Standards to apply
+
+Before editing, read and follow:
+
+- `{{ SKILLS.MAV_SCOPE_BOUNDARIES }}` — implement only what `{{ ARGUMENTS }}`
+  asks for. No unrelated cleanup, no opportunistic refactors, no
+  abstractions for hypothetical future requirements. Three similar
+  lines is better than a premature abstraction.
+- `{{ SKILLS.MAV_BP_ERROR_HANDLING }}` — error handling at system
+  boundaries only (user input, external APIs). Don't catch what
+  framework guarantees rule out. No defensive code for scenarios that
+  can't happen.
+- `{{ SKILLS.MAV_BP_LOGGING }}` — log levels, structured fields, and
+  the project's logging conventions.
+- `{{ SKILLS.MAV_BP_APPLICATION_SECURITY }}` — input validation, secret
+  handling, authn/authz patterns. If the change touches any of these,
+  surface the design choice in your verification.
+
+Also read **any project-level skills** at `docs/maverick/skills/` —
+topic-specific guidance for this codebase that supplements the
+maverick-wide best practices.
+
+## Implementation loop
+
+1. **Read before writing.** Open the files you're about to change.
+   Grep for existing patterns nearby — the goal is for the edit to
+   look like it was written by whoever wrote the surrounding code.
+2. **Make the change.** Smallest diff that satisfies the task. If you
+   notice an unrelated bug or a tempting refactor, **do not fix it**
+   in this skill — write it down for a follow-up.
+3. **Verify** per `{{ SKILLS.MAV_LOCAL_VERIFICATION }}` (lint,
+   typecheck, tests). Run the project's verification commands.
+4. **If verification fails**, diagnose per
+   `{{ SKILLS.MAV_SYSTEMATIC_DEBUGGING }}` and fix. Do not paper over
+   a failing test or silence a lint warning. Do not commit red.
+5. **Return** when (a) the task is done and (b) verification is green.
+
+## Rules
+
+- **Default to no comments.** Identifiers carry the WHAT. Only add a
+  comment when the WHY is non-obvious (hidden constraint, subtle
+  invariant, workaround for a specific bug). No "removed X" /
+  "added Y" / "used by Z" comments — those rot.
+- **No half-finished implementations.** If the task can't be completed
+  cleanly, halt and report rather than leaving partial state.
+- **No unauthorised destructive actions.** Don't `git push --force`,
+  `git reset --hard`, `rm -rf`, drop tables, or delete data. If the
+  task description doesn't explicitly authorise a destructive step,
+  treat it as out of scope and ask.
+- **Tests are part of the change.** If the change is testable, write
+  or update tests in the same task (or wrap that work in
+  `{{ SKILLS.DO_TEST }}` as a sibling call before the commit).
+- **Stay inside the task envelope.** When `{{ ARGUMENTS }}` is
+  ambiguous, ask for clarification rather than guess.

--- a/src/maverick/skills/do-code/config.py
+++ b/src/maverick/skills/do-code/config.py
@@ -1,0 +1,32 @@
+from maverick.models import SkillConfig
+from maverick.names import (
+    DO_CODE,
+    MAV_BP_APPLICATION_SECURITY,
+    MAV_BP_ERROR_HANDLING,
+    MAV_BP_LOGGING,
+    MAV_LOCAL_VERIFICATION,
+    MAV_SCOPE_BOUNDARIES,
+    MAV_SYSTEMATIC_DEBUGGING,
+)
+
+CONFIG = SkillConfig(
+    name=DO_CODE,
+    description=(
+        "Implement a focused code change. Use this skill as the wrapper for"
+        " any implementation work so the Maverick workflow report captures"
+        " what was done and so the agent applies the project's coding"
+        " standards before editing. Intended to be invoked once per task"
+        " from inside a do-issue-* or do-epic phase, not standalone."
+    ),
+    argument_hint="brief description of the task (one line)",
+    user_invocable=True,
+    disable_model_invocation=False,
+    depends_on=[
+        MAV_BP_ERROR_HANDLING,
+        MAV_BP_LOGGING,
+        MAV_BP_APPLICATION_SECURITY,
+        MAV_LOCAL_VERIFICATION,
+        MAV_SCOPE_BOUNDARIES,
+        MAV_SYSTEMATIC_DEBUGGING,
+    ],
+)

--- a/src/maverick/skills/do-issue-solo/body.md.j2
+++ b/src/maverick/skills/do-issue-solo/body.md.j2
@@ -52,7 +52,12 @@ This phase is new in the workflow overhaul. Before any other phase.
 2. Claim the issue: `uv run maverick coord claim <repo> {{ ARGUMENTS }}`.
    The command exits non-zero if the claim is rejected — treat that as
    abort.
-3. Start a heartbeat loop that refreshes the lease every
+3. **Start the workflow report** (writes a `run-start` row that later
+   `report` calls inherit `maverick_skill` from):
+   ```bash
+   uv run maverick report run-start do-issue-solo --issue {{ ARGUMENTS }} --phase claimed
+   ```
+4. Start a heartbeat loop that refreshes the lease every
    `HEARTBEAT_INTERVAL_MINUTES` minutes for as long as you hold the
    claim. The CLI provides a self-terminating foreground loop — run it
    in the background and let it exit on its own when `coord release`
@@ -62,9 +67,9 @@ This phase is new in the workflow overhaul. Before any other phase.
    ```
    If two consecutive heartbeats fail, the loop exits non-zero — treat
    that as claim-lost and abort (do not push further work).
-4. Register a release handler that fires on every exit path (success,
+5. Register a release handler that fires on every exit path (success,
    eject, abort): `uv run maverick coord release <repo> {{ ARGUMENTS }} --reason <reason>`.
-5. Cold-start hydrate per `{{ SKILLS.MAV_DURABILITY_ON_GH }}`. The
+6. Cold-start hydrate per `{{ SKILLS.MAV_DURABILITY_ON_GH }}`. The
    skill is fully resumable — a fresh agent re-entering after a crash,
    stop, or context-exhaustion must skip phases that already completed
    rather than re-running them against an in-flight or merged PR (#41).
@@ -100,18 +105,19 @@ implementation.
 
 1. Initialise the issue state file per the
    {{ SKILLS.MAV_GITHUB_ISSUE_WORKFLOW }} skill.
-2. Log subagent start: `uv run maverick report log subagent-start --issue {{ ARGUMENTS }} --name {{ AGENTS.AGENT_ISSUE_ANALYST }}`.
+2. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue {{ ARGUMENTS }} --phase design --agent {{ AGENTS.AGENT_ISSUE_ANALYST }}`.
 3. Dispatch the **{{ AGENTS.AGENT_ISSUE_ANALYST }}** agent with:
    - Issue number: `{{ ARGUMENTS }}`
    - Mode: `solo`
-4. Log subagent end: `uv run maverick report log subagent-end --issue {{ ARGUMENTS }} --name {{ AGENTS.AGENT_ISSUE_ANALYST }}`.
+4. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue {{ ARGUMENTS }} --phase design --agent {{ AGENTS.AGENT_ISSUE_ANALYST }} --outcome success`.
+   (Use `--outcome failure` if the agent returned an error rather than a design.)
 5. When the agent returns, verify:
    - `.claude/issue-state.json` has `phase` set to `design`
    - `.claude/issue-state.json` has `comments.design` set to a comment ID
 6. If the agent flagged ambiguities it could not resolve:
-   - Log question start: `uv run maverick report log question-start --issue {{ ARGUMENTS }} --topic ambiguity-resolution`.
+   - Open the question interval: `uv run maverick report begin question --issue {{ ARGUMENTS }} --phase design --topic ambiguity-resolution`.
    - Ask the user.
-   - Log question end: `uv run maverick report log question-end --issue {{ ARGUMENTS }} --topic ambiguity-resolution`.
+   - Close it: `uv run maverick report end question --issue {{ ARGUMENTS }} --phase design --topic ambiguity-resolution --outcome success`.
 
    Otherwise continue.
 7. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} design`.
@@ -120,19 +126,19 @@ implementation.
 
 Run Phase 3 as a subagent.
 
-1. Log subagent start: `uv run maverick report log subagent-start --issue {{ ARGUMENTS }} --name {{ AGENTS.AGENT_GITHUB_ISSUE_PLANNER }}`.
+1. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue {{ ARGUMENTS }} --phase tasks --agent {{ AGENTS.AGENT_GITHUB_ISSUE_PLANNER }}`.
 2. Dispatch the **{{ AGENTS.AGENT_GITHUB_ISSUE_PLANNER }}** agent with:
    - Issue number: `{{ ARGUMENTS }}`
    - Design comment ID from `.claude/issue-state.json`
-3. Log subagent end: `uv run maverick report log subagent-end --issue {{ ARGUMENTS }} --name {{ AGENTS.AGENT_GITHUB_ISSUE_PLANNER }}`.
+3. Close it: `uv run maverick report end agent-dispatch --issue {{ ARGUMENTS }} --phase tasks --agent {{ AGENTS.AGENT_GITHUB_ISSUE_PLANNER }} --outcome success`.
 4. When the agent returns, verify:
    - `.claude/issue-state.json` has `phase` set to `tasks`
    - If < 5 tasks: `.claude/issue-state.json` has `comments.tasks` set to a comment ID
    - If >= 5 tasks: `.claude/issue-state.json` has `has_sub_issues` set to `true`
 5. If the agent flagged scope concerns:
-   - Log question start: `uv run maverick report log question-start --issue {{ ARGUMENTS }} --topic scope-concerns`.
+   - Open the question interval: `uv run maverick report begin question --issue {{ ARGUMENTS }} --phase tasks --topic scope-concerns`.
    - Ask the user.
-   - Log question end: `uv run maverick report log question-end --issue {{ ARGUMENTS }} --topic scope-concerns`.
+   - Close it: `uv run maverick report end question --issue {{ ARGUMENTS }} --phase tasks --topic scope-concerns --outcome success`.
 6. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} tasks`.
 
 ## Phase 4: Create Worktree + Branch
@@ -175,8 +181,16 @@ This phase has changed. **Push after every task, not at the end.** See
      `git push -u origin <branch>`.
    - If on a stacked branch, run the retarget check per
      `{{ SKILLS.MAV_STACKED_PRS }}` **before every push**.
-6. Update the tasks comment (or close the sub-issue).
-7. Heartbeat: `uv run maverick coord heartbeat <repo> {{ ARGUMENTS }}` if it
+6. **Log the commit** to the workflow report. SHA and subject come from
+   git; the timestamp is wall-clock at the moment of this CLI call:
+   ```bash
+   SHA=$(git rev-parse HEAD)
+   SUBJECT=$(git log -1 --pretty=%s)
+   uv run maverick report commit --issue {{ ARGUMENTS }} \
+       --phase implement --sha "$SHA" --subject "$SUBJECT"
+   ```
+7. Update the tasks comment (or close the sub-issue).
+8. Heartbeat: `uv run maverick coord heartbeat <repo> {{ ARGUMENTS }}` if it
    is time for a refresh.
 
 After the last task, run the full verification suite once more.
@@ -236,7 +250,7 @@ PR body as a follow-up note rather than being silently rewritten.
    fi
    ```
 {% endraw %}
-3. Log subagent start: `uv run maverick report log subagent-start --issue {{ ARGUMENTS }} --name {{ AGENTS.AGENT_TECH_DOCS_WRITER }}`.
+3. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue {{ ARGUMENTS }} --phase docs --agent {{ AGENTS.AGENT_TECH_DOCS_WRITER }}`.
 4. Dispatch **{{ AGENTS.AGENT_TECH_DOCS_WRITER }}** with:
    - **Mode:** `update` (per `{{ SKILLS.DO_DOCS }}`)
    - **Diff:** `/tmp/diff.patch`
@@ -256,7 +270,7 @@ PR body as a follow-up note rather than being silently rewritten.
        human reviewer.
      - Returning "no doc changes required" is a valid outcome and must
        be reported explicitly (not silently inferred).
-5. Log subagent end: `uv run maverick report log subagent-end --issue {{ ARGUMENTS }} --name {{ AGENTS.AGENT_TECH_DOCS_WRITER }}`.
+5. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue {{ ARGUMENTS }} --phase docs --agent {{ AGENTS.AGENT_TECH_DOCS_WRITER }} --outcome success`.
 6. **Record the outcome** in the PR body or as a one-line PR comment so
    the gate is auditable:
    - If docs were updated or created: list the files changed.
@@ -265,7 +279,14 @@ PR body as a follow-up note rather than being silently rewritten.
      sees them.
    - If no changes were required: post `Docs review: no changes required.`
 7. Commit any doc changes with a `docs:` conventional commit and push
-   per the push-per-task rule.
+   per the push-per-task rule. If a commit was made, log it so the
+   docs phase row gets its own sub-row in the report:
+   ```bash
+   SHA=$(git rev-parse HEAD)
+   SUBJECT=$(git log -1 --pretty=%s)
+   uv run maverick report commit --issue {{ ARGUMENTS }} \
+       --phase docs --sha "$SHA" --subject "$SUBJECT"
+   ```
 8. The PR cannot proceed to Phase 7 until this phase has produced
    either committed doc changes or the auditable no-op record.
 9. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} docs`.
@@ -278,7 +299,7 @@ changes (callers, importers, dependents) must be reviewed by
 `{{ SKILLS.DO_CYBERSECURITY_REVIEW }}` before the PR can be opened.
 
 1. Compute the full diff: `git diff origin/<base>...HEAD`.
-2. Log skill start: `uv run maverick report log skill-start --issue {{ ARGUMENTS }} --name {{ SKILLS.DO_CYBERSECURITY_REVIEW }}`.
+2. Open the skill-dispatch interval: `uv run maverick report begin skill-dispatch --issue {{ ARGUMENTS }} --phase security --skill-name {{ SKILLS.DO_CYBERSECURITY_REVIEW }}`.
 3. Dispatch the **{{ SKILLS.DO_CYBERSECURITY_REVIEW }}** skill with:
    - **Mode:** `update`
    - **Diff:** the output of step 1, passed via stdin or as a file path
@@ -286,7 +307,7 @@ changes (callers, importers, dependents) must be reviewed by
      (callers, importers, dependents — bounded to one or two hops).
      Return the structured outcome (verdict + findings) defined in the
      skill's Update Mode contract.
-4. Log skill end: `uv run maverick report log skill-end --issue {{ ARGUMENTS }} --name {{ SKILLS.DO_CYBERSECURITY_REVIEW }}`.
+4. Close the skill-dispatch interval: `uv run maverick report end skill-dispatch --issue {{ ARGUMENTS }} --phase security --skill-name {{ SKILLS.DO_CYBERSECURITY_REVIEW }} --outcome <success|failure|blocked>` (use `blocked` if the verdict was BLOCKING).
 5. **Act on the verdict:**
    - **BLOCKING** — halt. Surface the findings to the user verbatim.
      Do not open the PR. The user resolves the BLOCKING items by
@@ -352,11 +373,11 @@ The local **{{ AGENTS.AGENT_CODE_REVIEWER }}** subagent's verdict is the
 review gate the auto-merge path trusts. This is a binary verdict against
 the open PR, not a local-diff advisory loop.
 
-1. Log subagent start: `uv run maverick report log subagent-start --issue {{ ARGUMENTS }} --name {{ AGENTS.AGENT_CODE_REVIEWER }}`.
+1. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue {{ ARGUMENTS }} --phase review --agent {{ AGENTS.AGENT_CODE_REVIEWER }}`.
 2. Dispatch **{{ AGENTS.AGENT_CODE_REVIEWER }}** with:
    - The PR URL
    - The issue body, design comment, and tasks list (so it has the spec)
-3. Log subagent end: `uv run maverick report log subagent-end --issue {{ ARGUMENTS }} --name {{ AGENTS.AGENT_CODE_REVIEWER }}`.
+3. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue {{ ARGUMENTS }} --phase review --agent {{ AGENTS.AGENT_CODE_REVIEWER }} --outcome <success|failure>` (use `failure` on FAIL verdict).
 4. The agent returns exactly one of two verdicts:
    - **PASS** — proceed to Phase 10 (merge).
    - **FAIL** — proceed to Phase 11 (eject). Do not attempt to auto-fix.
@@ -421,21 +442,23 @@ next step is eject-to-human, not iterate.
     - Local state file
     - Destroy the worktree: `uv run maverick worktree destroy <worktree-path>`.
 11. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} complete`.
-12. **Generate the timing report** (#83). The report is written to the
-    **main repo's** `.maverick/reports/` (resolved via `git rev-parse
-    --git-common-dir`), not the destroyed worktree's:
+12. **Emit per-phase narrative notes** so the report's Analysis section
+    has context for what happened. The JSONL is the authoritative
+    record; the report is a pure render of it, so notes must land in
+    the JSONL — do not edit the rendered Markdown by hand:
     ```bash
-    uv run maverick report generate <repo> {{ ARGUMENTS }} --branch <branch>
+    uv run maverick report note --issue {{ ARGUMENTS }} --phase design \
+        --text "<one-sentence summary of what the analyst returned>"
+    uv run maverick report note --issue {{ ARGUMENTS }} --phase implement \
+        --text "<one-sentence summary of what landed in Phase 5>"
+    # ... one `report note` per phase that produced work worth narrating
     ```
-13. **Fill in the per-phase narratives.** Read
-    `.maverick/reports/do-issue-solo-{{ ARGUMENTS }}.md`. For each phase
-    row whose Activity cell starts with `PLACEHOLDER`, replace the
-    `PLACEHOLDER` prefix with a single sentence summarising what
-    actually happened in that phase (from your session memory — e.g.
-    "Issue analyst summarised the bug and proposed three rollout
-    options."). Keep the structured facts that follow the `—` and
-    leave timestamps, durations, sub-task rows, and the summary table
-    untouched. Write the file back.
+13. **Generate the workflow report**. Written to the **main repo's**
+    `.maverick/reports/` (resolved via `git rev-parse --git-common-dir`),
+    not the destroyed worktree's. Re-runs are deterministic:
+    ```bash
+    uv run maverick report generate <repo> {{ ARGUMENTS }}
+    ```
 
 ## Phase 11: Eject (on FAIL)
 
@@ -460,16 +483,18 @@ next step is eject-to-human, not iterate.
      apply `blocked-by:#{{ ARGUMENTS }}` to every transitive descendant.
    - Cancel any in-flight subagent work for stories now in the blocked set.
 5. **Checkpoint the eject** (#83): `uv run maverick task-progress set <repo> {{ ARGUMENTS }} ejected`.
-6. **Generate the timing report** for the run so the human reviewer
-   can see how time was spent leading up to the eject:
+6. **Emit per-phase narrative notes** so the eject report has context
+   for the human reviewer:
    ```bash
-   uv run maverick report generate <repo> {{ ARGUMENTS }} --branch <branch>
+   uv run maverick report note --issue {{ ARGUMENTS }} --phase review \
+       --text "<one-sentence summary of what the reviewer flagged>"
+   # ... one `report note` per phase that produced work worth narrating
    ```
-7. **Fill in the per-phase narratives.** Same as the PASS path: read
-   `.maverick/reports/do-issue-solo-{{ ARGUMENTS }}.md` and replace each
-   `PLACEHOLDER` prefix with a one-sentence narrative from session
-   memory. Write the file back. Generate the report **before**
-   releasing the claim so it lands even if release errors.
+7. **Generate the workflow report**. Do this **before** releasing the
+   claim so the report lands even if release errors:
+   ```bash
+   uv run maverick report generate <repo> {{ ARGUMENTS }}
+   ```
 8. Release the claim: `uv run maverick coord release <repo> {{ ARGUMENTS }} --reason ejected`.
 9. Do **not** destroy the worktree — the human may want to inspect it.
    Log the worktree path so the user can find it.

--- a/src/maverick/skills/do-issue-solo/body.md.j2
+++ b/src/maverick/skills/do-issue-solo/body.md.j2
@@ -105,11 +105,11 @@ implementation.
 
 1. Initialise the issue state file per the
    {{ SKILLS.MAV_GITHUB_ISSUE_WORKFLOW }} skill.
-2. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue {{ ARGUMENTS }} --phase design --agent {{ AGENTS.AGENT_ISSUE_ANALYST }}`.
+2. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue {{ ARGUMENTS }} --phase design --agent {{ AGENTS.AGENT_ISSUE_ANALYST }} --skill-name {{ SKILLS.MAV_CREATE_SOLUTION_DESIGN }}`.
 3. Dispatch the **{{ AGENTS.AGENT_ISSUE_ANALYST }}** agent with:
    - Issue number: `{{ ARGUMENTS }}`
    - Mode: `solo`
-4. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue {{ ARGUMENTS }} --phase design --agent {{ AGENTS.AGENT_ISSUE_ANALYST }} --outcome success`.
+4. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue {{ ARGUMENTS }} --phase design --agent {{ AGENTS.AGENT_ISSUE_ANALYST }} --skill-name {{ SKILLS.MAV_CREATE_SOLUTION_DESIGN }} --outcome success`.
    (Use `--outcome failure` if the agent returned an error rather than a design.)
 5. When the agent returns, verify:
    - `.claude/issue-state.json` has `phase` set to `design`
@@ -126,11 +126,11 @@ implementation.
 
 Run Phase 3 as a subagent.
 
-1. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue {{ ARGUMENTS }} --phase tasks --agent {{ AGENTS.AGENT_GITHUB_ISSUE_PLANNER }}`.
+1. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue {{ ARGUMENTS }} --phase tasks --agent {{ AGENTS.AGENT_GITHUB_ISSUE_PLANNER }} --skill-name {{ SKILLS.MAV_CREATE_TASKS }}`.
 2. Dispatch the **{{ AGENTS.AGENT_GITHUB_ISSUE_PLANNER }}** agent with:
    - Issue number: `{{ ARGUMENTS }}`
    - Design comment ID from `.claude/issue-state.json`
-3. Close it: `uv run maverick report end agent-dispatch --issue {{ ARGUMENTS }} --phase tasks --agent {{ AGENTS.AGENT_GITHUB_ISSUE_PLANNER }} --outcome success`.
+3. Close it: `uv run maverick report end agent-dispatch --issue {{ ARGUMENTS }} --phase tasks --agent {{ AGENTS.AGENT_GITHUB_ISSUE_PLANNER }} --skill-name {{ SKILLS.MAV_CREATE_TASKS }} --outcome success`.
 4. When the agent returns, verify:
    - `.claude/issue-state.json` has `phase` set to `tasks`
    - If < 5 tasks: `.claude/issue-state.json` has `comments.tasks` set to a comment ID
@@ -250,7 +250,7 @@ PR body as a follow-up note rather than being silently rewritten.
    fi
    ```
 {% endraw %}
-3. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue {{ ARGUMENTS }} --phase docs --agent {{ AGENTS.AGENT_TECH_DOCS_WRITER }}`.
+3. Open the agent-dispatch interval. The agent operates under `{{ SKILLS.DO_DOCS }}` — pass it as `--skill-name` so the Maverick Skill column in the report names the inner skill: `uv run maverick report begin agent-dispatch --issue {{ ARGUMENTS }} --phase docs --agent {{ AGENTS.AGENT_TECH_DOCS_WRITER }} --skill-name {{ SKILLS.DO_DOCS }}`.
 4. Dispatch **{{ AGENTS.AGENT_TECH_DOCS_WRITER }}** with:
    - **Mode:** `update` (per `{{ SKILLS.DO_DOCS }}`)
    - **Diff:** `/tmp/diff.patch`
@@ -270,7 +270,7 @@ PR body as a follow-up note rather than being silently rewritten.
        human reviewer.
      - Returning "no doc changes required" is a valid outcome and must
        be reported explicitly (not silently inferred).
-5. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue {{ ARGUMENTS }} --phase docs --agent {{ AGENTS.AGENT_TECH_DOCS_WRITER }} --outcome success`.
+5. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue {{ ARGUMENTS }} --phase docs --agent {{ AGENTS.AGENT_TECH_DOCS_WRITER }} --skill-name {{ SKILLS.DO_DOCS }} --outcome success`.
 6. **Record the outcome** in the PR body or as a one-line PR comment so
    the gate is auditable:
    - If docs were updated or created: list the files changed.
@@ -373,11 +373,11 @@ The local **{{ AGENTS.AGENT_CODE_REVIEWER }}** subagent's verdict is the
 review gate the auto-merge path trusts. This is a binary verdict against
 the open PR, not a local-diff advisory loop.
 
-1. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue {{ ARGUMENTS }} --phase review --agent {{ AGENTS.AGENT_CODE_REVIEWER }}`.
+1. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue {{ ARGUMENTS }} --phase review --agent {{ AGENTS.AGENT_CODE_REVIEWER }} --skill-name {{ SKILLS.MAV_BP_CODE_REVIEW }}`.
 2. Dispatch **{{ AGENTS.AGENT_CODE_REVIEWER }}** with:
    - The PR URL
    - The issue body, design comment, and tasks list (so it has the spec)
-3. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue {{ ARGUMENTS }} --phase review --agent {{ AGENTS.AGENT_CODE_REVIEWER }} --outcome <success|failure>` (use `failure` on FAIL verdict).
+3. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue {{ ARGUMENTS }} --phase review --agent {{ AGENTS.AGENT_CODE_REVIEWER }} --skill-name {{ SKILLS.MAV_BP_CODE_REVIEW }} --outcome <success|failure>` (use `failure` on FAIL verdict).
 4. The agent returns exactly one of two verdicts:
    - **PASS** — proceed to Phase 10 (merge).
    - **FAIL** — proceed to Phase 11 (eject). Do not attempt to auto-fix.

--- a/src/maverick/skills/do-test/body.md.j2
+++ b/src/maverick/skills/do-test/body.md.j2
@@ -1,0 +1,108 @@
+
+**Depends on:** {{ DEPENDS_ON }}
+
+# Write or Update Tests
+
+Wraps test-writing work in a Maverick skill so the workflow report
+records what was tested and the agent applies the project's testing
+standards before writing tests. Invoke this skill **once per testable
+change** from inside `{{ SKILLS.DO_ISSUE_SOLO }}` /
+`{{ SKILLS.DO_ISSUE_GUIDED }}` / `{{ SKILLS.DO_EPIC }}` Phase 5 —
+typically as a sibling call to `{{ SKILLS.DO_CODE }}`, before the
+commit for that task.
+
+This skill is a thin wrapper. The actual test files are written by the
+orchestrating Claude Code session using its built-in tools (Read, Edit,
+Write, Bash). The skill's job is to pin the right standards for the
+mode and keep scope tight.
+
+## Preflight (mandatory)
+
+Run this **first**. If it exits non-zero, halt and report the stderr
+output to the user verbatim. Do not proceed.
+
+```bash
+uv run maverick preflight do-test
+```
+
+The check verifies the project is initialised and `uv` is on PATH.
+
+## Mode Selection
+
+`{{ ARGUMENTS }}` must specify a mode:
+
+- `unit` — module-scoped, fast, deterministic. No network, no real
+  database, no real filesystem outside the test's own `tmp_path`.
+  Use this for any change that can be exercised through its public
+  surface in-process.
+- `integration` — crosses module / service / database / external API
+  boundaries. Real I/O is allowed (and usually required). Slower;
+  reserved for changes whose behaviour only emerges across that
+  boundary.
+
+If no mode is specified, halt and ask the caller to pick one. Do not
+guess — getting the mode wrong invites flaky tests or fast-but-untrue
+coverage.
+
+## Unit Mode
+
+Apply `{{ SKILLS.MAV_BP_UNIT_TESTING }}` for the project's unit-testing
+conventions (test framework, naming, fixture style, assertion
+patterns).
+
+1. **Locate the test file.** Look for an existing test file that
+   corresponds to the production code you just changed. If none
+   exists, follow the project's convention for placement
+   (`tests/unit/test_<module>.py`, `<module>.test.ts`, etc.) — check
+   how nearby modules are tested.
+2. **Identify what changed in observable behaviour.** Write tests
+   against the public surface, not the internals. If the change is
+   purely refactoring with no behaviour change, the existing tests
+   should already cover it — re-running them is the validation.
+3. **Write one test per branch / case.** Cover the happy path,
+   relevant edge cases, and any error paths the change introduced.
+   Don't write a single mega-test that exercises everything.
+4. **Verify** by running the project's unit suite per
+   `{{ SKILLS.MAV_LOCAL_VERIFICATION }}`. The whole suite — not just
+   the new tests — must stay green.
+
+## Integration Mode
+
+Apply `{{ SKILLS.MAV_BP_INTEGRATION_TESTING }}` for the project's
+integration-testing conventions (which real services are stood up,
+fixture lifecycle, isolation strategy, slowness budget).
+
+1. **Locate or create the integration test file.** Integration tests
+   typically live separately from unit tests
+   (`tests/integration/`, `e2e/`, `__tests__/integration/`, etc.) and
+   have their own runner config.
+2. **Stand up real dependencies.** Do not mock the boundary the test
+   is supposed to exercise — if a test "covers" the database layer
+   with a mocked database, it's a unit test, not an integration test.
+3. **Test the boundary, not the unit.** Assert observable end-to-end
+   behaviour, not implementation details on either side of the
+   boundary.
+4. **Clean up.** Integration tests must leave no state behind —
+   transactions roll back, fixtures tear down, temporary resources
+   are released. Failure to clean up makes the next test flaky.
+5. **Verify** by running the project's integration suite. Note the
+   wall-clock cost — if a new test pushes a green CI run past the
+   project's slowness budget, refactor it or split it.
+
+## Rules
+
+- **No mocks at the unit's own boundary.** If you're testing `foo()`,
+  don't mock `foo()`'s direct collaborators with such fidelity that
+  the test passes regardless of `foo()`'s behaviour. Mock at one hop
+  out: the network, the database, the clock.
+- **Tests describe behaviour, not implementation.** A test that breaks
+  on internal refactors without a behaviour change is a maintenance
+  cost. Write assertions against return values, side effects, and
+  invariants — not against private call sequences.
+- **No `assert True` placeholders.** If you don't know how to test
+  the change, halt and ask rather than ship an empty test.
+- **Stay inside the task envelope.** Don't refactor adjacent unrelated
+  tests in this skill. Follow `{{ SKILLS.MAV_SCOPE_BOUNDARIES }}`.
+- **Tests must be deterministic.** No reliance on system time, random
+  seeds, network availability outside the boundary under test, or
+  ordering between independent tests.

--- a/src/maverick/skills/do-test/config.py
+++ b/src/maverick/skills/do-test/config.py
@@ -1,0 +1,28 @@
+from maverick.models import SkillConfig
+from maverick.names import (
+    DO_TEST,
+    MAV_BP_INTEGRATION_TESTING,
+    MAV_BP_UNIT_TESTING,
+    MAV_LOCAL_VERIFICATION,
+    MAV_SCOPE_BOUNDARIES,
+)
+
+CONFIG = SkillConfig(
+    name=DO_TEST,
+    description=(
+        "Write or update tests for a code change. Operates in two modes:"
+        " `unit` (module-scoped, fast, deterministic) and `integration`"
+        " (crosses module / service / database boundaries). Intended to be"
+        " invoked once per testable change from inside a do-issue-* or"
+        " do-epic phase. Mode is required."
+    ),
+    argument_hint="mode: unit or integration",
+    user_invocable=True,
+    disable_model_invocation=False,
+    depends_on=[
+        MAV_BP_UNIT_TESTING,
+        MAV_BP_INTEGRATION_TESTING,
+        MAV_LOCAL_VERIFICATION,
+        MAV_SCOPE_BOUNDARIES,
+    ],
+)

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -434,12 +434,13 @@ class TestTaskProgressCli:
             return 1
 
         monkeypatch.setattr(gh_state, "upsert_marker", fake_upsert)
-        # Redirect the timeline append (#83) to tmp_path so the test
-        # doesn't litter the working tree's .maverick/reports/.
+        # Redirect the timeline append to a captured list so the test
+        # doesn't litter the working tree's .maverick/reports/. The new
+        # append_event signature takes a single typed event dict.
         timeline_events: list[dict] = []
 
-        def fake_append(issue, event, repo_root=None):
-            timeline_events.append({"issue": issue, **event})
+        def fake_append(event, repo_root=None):
+            timeline_events.append(event)
             return True
 
         monkeypatch.setattr(report_cli, "append_event", fake_append)
@@ -456,12 +457,13 @@ class TestTaskProgressCli:
         assert captured["payload"]["instance_id"] == "i-abc"
         assert captured["payload"]["updated_at"].endswith("Z")
         assert "task-progress" in captured["preamble"]
-        # #83: task-progress set must also append a phase-checkpoint
-        # event to the local timeline JSONL so the report generator
-        # can reconstruct per-phase timestamps.
+        # task-progress set must also append a phase-boundary event to
+        # the local timeline JSONL so the report generator can
+        # reconstruct per-phase timestamps.
         assert len(timeline_events) == 1
-        assert timeline_events[0]["type"] == "phase-checkpoint"
+        assert timeline_events[0]["action"] == "phase-boundary"
         assert timeline_events[0]["phase"] == "review"
+        assert timeline_events[0]["issue"] == 42
         assert timeline_events[0]["issue"] == 42
 
     def test_read_returns_latest_marker_payload(self, monkeypatch):

--- a/tests/unit/test_report_cli.py
+++ b/tests/unit/test_report_cli.py
@@ -159,6 +159,28 @@ class TestValidation:
         with pytest.raises(report_cli.SchemaError, match="instance_id"):
             report_cli._validate(e)
 
+    def test_skill_dispatch_requires_dispatched_skill(self):
+        with pytest.raises(report_cli.SchemaError, match="skill-dispatch.*dispatched_skill"):
+            report_cli._validate(_full_event(
+                action="skill-dispatch", phase="security",
+                end_ts="2026-05-19T10:01:00Z", outcome="success",
+            ))
+
+    def test_agent_dispatch_dispatched_skill_optional(self):
+        # An agent that operates under a skill: valid
+        report_cli._validate(_full_event(
+            action="agent-dispatch", phase="docs",
+            end_ts="2026-05-19T10:01:00Z", outcome="success",
+            maverick_agent="agent-tech-docs-writer",
+            dispatched_skill="do-docs",
+        ))
+        # An agent dispatched without an associated skill: also valid
+        report_cli._validate(_full_event(
+            action="agent-dispatch", phase="design",
+            end_ts="2026-05-19T10:01:00Z", outcome="success",
+            maverick_agent="agent-issue-analyst",
+        ))
+
 
 # ---------------------------------------------------------------------------
 # append_event + load_timeline
@@ -256,6 +278,224 @@ class TestBeginEnd:
         # pending file should be empty (or absent of this key)
         pending = report_cli._read_pending(report_cli.pending_path(321, repo_root=tmp_path))
         assert "agent-dispatch:agent-x" not in pending
+
+    def test_agent_dispatch_skill_name_persists_as_dispatched_skill(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """`--skill-name` on agent-dispatch lands on the row as `dispatched_skill`."""
+        self._setup(tmp_path, monkeypatch)
+        report_cli._report_begin(_parse(
+            "report", "begin", "agent-dispatch", "--issue", "321",
+            "--phase", "docs", "--agent", "agent-tech-docs-writer",
+            "--skill-name", "do-docs",
+        ))
+        report_cli._report_end(_parse(
+            "report", "end", "agent-dispatch", "--issue", "321",
+            "--agent", "agent-tech-docs-writer", "--outcome", "success",
+        ))
+        events = report_cli.load_timeline(report_cli.timeline_path(321, repo_root=tmp_path))
+        assert events[0]["dispatched_skill"] == "do-docs"
+        assert events[0]["maverick_agent"] == "agent-tech-docs-writer"
+
+    def test_skill_dispatch_skill_name_persists(self, tmp_path: Path, monkeypatch):
+        self._setup(tmp_path, monkeypatch)
+        report_cli._report_begin(_parse(
+            "report", "begin", "skill-dispatch", "--issue", "321",
+            "--phase", "security", "--skill-name", "do-cybersecurity-review",
+        ))
+        report_cli._report_end(_parse(
+            "report", "end", "skill-dispatch", "--issue", "321",
+            "--skill-name", "do-cybersecurity-review", "--outcome", "success",
+        ))
+        events = report_cli.load_timeline(report_cli.timeline_path(321, repo_root=tmp_path))
+        assert events[0]["dispatched_skill"] == "do-cybersecurity-review"
+        assert events[0].get("maverick_agent") is None
+
+
+class TestLLMResolution:
+    """The fallback chain in `_current_llm`:
+    explicit → env → config.agents → config.skills → config.default →
+    run-start lookup → FALLBACK_LLM.
+    """
+
+    def _setup(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(report_cli, "_main_repo_root", lambda cwd=None: tmp_path)
+        monkeypatch.setenv("MAVERICK_INSTANCE_ID", "test1234ab")
+        monkeypatch.delenv("MAVERICK_LLM", raising=False)
+
+    def _patch_config(self, monkeypatch, **overrides):
+        """Replace `read_llm_config` with a fixture that returns the given values."""
+        from maverick import config
+
+        defaults = {
+            "default": overrides.get("default", "claude-opus-4-7"),
+            "agents": overrides.get("agents", {}),
+            "skills": overrides.get("skills", {}),
+        }
+        monkeypatch.setattr(config, "read_llm_config", lambda path=None: defaults)
+
+    def test_falls_back_to_literal_when_config_read_fails(
+        self, tmp_path: Path, monkeypatch
+    ):
+        self._setup(tmp_path, monkeypatch)
+        # Force the config loader to raise so the resolution falls through.
+        from maverick import config
+
+        def boom(path=None):
+            raise RuntimeError("config unreadable")
+
+        monkeypatch.setattr(config, "read_llm_config", boom)
+        assert report_cli._current_llm() == report_cli.FALLBACK_LLM
+        assert report_cli.FALLBACK_LLM == "claude-code"
+
+    def test_config_default_used_when_no_explicit_or_env(
+        self, tmp_path: Path, monkeypatch
+    ):
+        self._setup(tmp_path, monkeypatch)
+        self._patch_config(monkeypatch, default="claude-opus-4-7")
+        assert report_cli._current_llm() == "claude-opus-4-7"
+
+    def test_explicit_wins_over_env_and_config(
+        self, tmp_path: Path, monkeypatch
+    ):
+        self._setup(tmp_path, monkeypatch)
+        monkeypatch.setenv("MAVERICK_LLM", "claude-sonnet-4-6")
+        self._patch_config(monkeypatch, default="claude-opus-4-7")
+        assert report_cli._current_llm(explicit="claude-haiku-4-5") == "claude-haiku-4-5"
+
+    def test_env_wins_over_config(self, tmp_path: Path, monkeypatch):
+        self._setup(tmp_path, monkeypatch)
+        monkeypatch.setenv("MAVERICK_LLM", "claude-sonnet-4-6")
+        self._patch_config(monkeypatch, default="claude-opus-4-7")
+        assert report_cli._current_llm() == "claude-sonnet-4-6"
+
+    def test_config_per_agent_override(self, tmp_path: Path, monkeypatch):
+        self._setup(tmp_path, monkeypatch)
+        self._patch_config(
+            monkeypatch,
+            default="claude-opus-4-7",
+            agents={"agent-tech-docs-writer": "claude-sonnet-4-6"},
+        )
+        # Same agent as the per-agent rule → Sonnet
+        assert (
+            report_cli._current_llm(agent="agent-tech-docs-writer")
+            == "claude-sonnet-4-6"
+        )
+        # Different agent → falls through to default (Opus)
+        assert (
+            report_cli._current_llm(agent="agent-issue-analyst") == "claude-opus-4-7"
+        )
+
+    def test_config_per_skill_override(self, tmp_path: Path, monkeypatch):
+        self._setup(tmp_path, monkeypatch)
+        self._patch_config(
+            monkeypatch,
+            default="claude-opus-4-7",
+            skills={"do-test": "claude-sonnet-4-6"},
+        )
+        assert report_cli._current_llm(skill_name="do-test") == "claude-sonnet-4-6"
+        assert report_cli._current_llm(skill_name="do-code") == "claude-opus-4-7"
+
+    def test_per_agent_beats_per_skill_when_both_apply(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """agent-tech-docs-writer dispatched under do-docs: agent rule wins."""
+        self._setup(tmp_path, monkeypatch)
+        self._patch_config(
+            monkeypatch,
+            default="claude-opus-4-7",
+            agents={"agent-tech-docs-writer": "claude-haiku-4-5"},
+            skills={"do-docs": "claude-sonnet-4-6"},
+        )
+        assert (
+            report_cli._current_llm(
+                agent="agent-tech-docs-writer", skill_name="do-docs"
+            )
+            == "claude-haiku-4-5"
+        )
+
+    def test_run_start_inherited_when_no_other_source(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """If config raises and nothing else applies, fall back to the latest
+        run-start's llm before the literal."""
+        self._setup(tmp_path, monkeypatch)
+        from maverick import config
+
+        monkeypatch.setattr(
+            config, "read_llm_config", lambda path=None: (_ for _ in ()).throw(RuntimeError())
+        )
+        report_cli.append_event(
+            _full_event(action="run-start", phase="claimed",
+                        maverick_skill="do-issue-solo", llm="claude-opus-4-7"),
+            repo_root=tmp_path,
+        )
+        assert report_cli._current_llm(issue=321, repo_root=tmp_path) == "claude-opus-4-7"
+
+    def test_writer_auto_populates_llm_on_every_row(
+        self, tmp_path: Path, monkeypatch
+    ):
+        self._setup(tmp_path, monkeypatch)
+        monkeypatch.setenv("MAVERICK_LLM", "claude-opus-4-7")
+        report_cli._report_run_start(_parse(
+            "report", "run-start", "do-issue-solo", "--issue", "321"
+        ))
+        report_cli._report_commit(_parse(
+            "report", "commit", "--issue", "321", "--phase", "implement",
+            "--sha", "abc1234", "--subject", "feat: x"
+        ))
+        events = report_cli.load_timeline(report_cli.timeline_path(321, repo_root=tmp_path))
+        assert all(e.get("llm") == "claude-opus-4-7" for e in events)
+
+    def test_per_row_llm_override_for_subagent(self, tmp_path: Path, monkeypatch):
+        """Multi-model: orchestrator runs Opus, one subagent runs Sonnet."""
+        self._setup(tmp_path, monkeypatch)
+        monkeypatch.setenv("MAVERICK_LLM", "claude-opus-4-7")
+        report_cli._report_run_start(_parse(
+            "report", "run-start", "do-issue-solo", "--issue", "321"
+        ))
+        # Subagent dispatch with explicit override
+        report_cli._report_begin(_parse(
+            "report", "begin", "agent-dispatch", "--issue", "321",
+            "--phase", "design", "--agent", "agent-issue-analyst",
+            "--llm", "claude-sonnet-4-6",
+        ))
+        report_cli._report_end(_parse(
+            "report", "end", "agent-dispatch", "--issue", "321",
+            "--agent", "agent-issue-analyst", "--outcome", "success",
+            "--llm", "claude-sonnet-4-6",
+        ))
+        events = report_cli.load_timeline(report_cli.timeline_path(321, repo_root=tmp_path))
+        by_action = {e["action"]: e for e in events}
+        assert by_action["run-start"]["llm"] == "claude-opus-4-7"
+        assert by_action["agent-dispatch"]["llm"] == "claude-sonnet-4-6"
+
+    def test_render_surfaces_per_row_llm(self):
+        """Rendered table's LLM column reflects the row's llm, not a default."""
+        events = [
+            _full_event(action="run-start", phase="claimed",
+                        maverick_skill="do-issue-solo", llm="claude-opus-4-7",
+                        start_ts="2026-05-20T10:00:00Z"),
+            _full_event(action="agent-dispatch", phase="design",
+                        start_ts="2026-05-20T10:01:00Z",
+                        end_ts="2026-05-20T10:02:00Z",
+                        maverick_agent="agent-issue-analyst",
+                        outcome="success", llm="claude-sonnet-4-6"),
+            _full_event(action="phase-boundary", phase="design",
+                        start_ts="2026-05-20T10:02:00Z",
+                        llm="claude-opus-4-7"),
+            _full_event(action="phase-boundary", phase="complete",
+                        start_ts="2026-05-20T10:03:00Z",
+                        llm="claude-opus-4-7"),
+        ]
+        md = report_cli.render(issue=321, events=events)
+        # Metadata block lists both distinct LLMs
+        assert "- LLMs: claude-opus-4-7, claude-sonnet-4-6" in md
+        # The agent-dispatch row in the table shows Sonnet
+        design_row = next(ln for ln in md.splitlines()
+                          if "| Phase 1-2 |" in ln and "agent-dispatch" in ln)
+        assert "claude-sonnet-4-6" in design_row
+        assert "claude-opus-4-7" not in design_row
 
     def test_end_without_begin_writes_warning_no_row(self, tmp_path: Path, monkeypatch, capsys):
         self._setup(tmp_path, monkeypatch)
@@ -379,6 +619,7 @@ def _pass_path_events() -> list[dict[str, Any]]:
         start_ts="2026-05-19T10:13:00Z",
         end_ts="2026-05-19T10:14:30Z",
         maverick_agent="agent-tech-docs-writer",
+        dispatched_skill="do-docs",
         outcome="success",
     ))
     e.append(_full_event(
@@ -394,6 +635,7 @@ def _pass_path_events() -> list[dict[str, Any]]:
         action="skill-dispatch", phase="security",
         start_ts="2026-05-19T10:15:30Z",
         end_ts="2026-05-19T10:16:00Z",
+        dispatched_skill="do-cybersecurity-review",
         outcome="success",
     ))
     e.append(_full_event(
@@ -432,62 +674,71 @@ class TestRender:
         assert "## Total Time" in md
         assert "seconds: 1200" in md
 
-    def test_phase_rows_carry_action_and_agent_columns(self):
+    def test_phase_rows_carry_all_columns(self):
         md = report_cli.render(issue=321, events=_pass_path_events())
-        assert "| Maverick Action | Maverick Agent |" in md
-        # The docs phase has an agent-dispatch row carrying the agent name
-        docs_rows = [ln for ln in md.splitlines() if "Phase 6 — documentation review" in ln]
-        assert any("agent-dispatch" in r and "agent-tech-docs-writer" in r for r in docs_rows)
+        # Header includes the four-way identity split + timing
+        assert (
+            "| Phase | LLM | Maverick Root Skill | Maverick Sub Agent | "
+            "Maverick Skill | Start | End | Duration | Maverick Action |"
+        ) in md
+        # Phase 6 row carries the docs agent in Sub Agent, the inner
+        # skill in Maverick Skill, claude-code as LLM, do-issue-solo as
+        # the Root Skill.
+        docs_rows = [ln for ln in md.splitlines() if "| Phase 6 |" in ln]
+        agent_row = next(r for r in docs_rows if "agent-dispatch" in r)
+        assert "agent-tech-docs-writer" in agent_row
+        assert "do-docs" in agent_row
+        assert "claude-code" in agent_row
+        assert "do-issue-solo" in agent_row
 
-    def test_one_row_per_action_within_a_phase(self):
-        """Phase 6 has BOTH a docs agent-dispatch and (in this fixture) no skill-dispatch.
-        The implement phase has commit sub-rows but no action row of its own
-        (no agent or skill ran inside it).
-        """
+    def test_phase_boundary_row_only_when_no_dispatch(self):
         md = report_cli.render(issue=321, events=_pass_path_events())
         lines = md.splitlines()
-        impl_rows = [ln for ln in lines if "Phase 5 — execute tasks" in ln]
-        # No agent ran in implement, so the phase row is a phase-boundary
-        assert any("phase-boundary" in r for r in impl_rows)
+        # Phase 5 in this fixture has no dispatches (only commits) — it
+        # gets a phase-boundary row plus commit rows.
+        impl_rows = [ln for ln in lines if "| Phase 5 |" in ln]
+        assert any("phase-boundary — execute tasks" in r for r in impl_rows)
+        # Phase 6 has an agent-dispatch — no separate phase-boundary row.
+        docs_rows = [ln for ln in lines if "| Phase 6 |" in ln]
+        assert not any("phase-boundary" in r for r in docs_rows)
 
-    def test_commit_subrows_render_under_their_phase(self):
+    def test_commit_rows_render_under_their_phase(self):
         md = report_cli.render(issue=321, events=_pass_path_events())
         lines = md.splitlines()
-        impl_idx = next(i for i, ln in enumerate(lines) if "Phase 5 — execute tasks" in ln)
-        # The implement commit sub-row appears soon after the phase row
-        window = "\n".join(lines[impl_idx:impl_idx + 4])
-        assert "↳ commit" in window
-        assert "abc1234" in window
-        assert "feat: a thing" in window
+        # Phase 5's commit shows the sha + subject in the Action column,
+        # with `—` placeholders in Start/Duration (commit is atomic).
+        impl_rows = [ln for ln in lines if "| Phase 5 |" in ln]
+        commit_rows = [r for r in impl_rows if "commit abc1234" in r]
+        assert commit_rows, f"no commit row found in: {impl_rows}"
+        assert "feat: a thing" in commit_rows[0]
 
     def test_docs_commit_lands_under_docs_phase(self):
         md = report_cli.render(issue=321, events=_pass_path_events())
         lines = md.splitlines()
-        docs_idx = next(i for i, ln in enumerate(lines) if "Phase 6 — documentation review" in ln)
-        next_phase_idx = next(
-            i for i, ln in enumerate(lines[docs_idx + 1:], start=docs_idx + 1)
-            if "Phase 7" in ln
-        )
-        window = "\n".join(lines[docs_idx:next_phase_idx])
-        assert "def4567" in window
-        assert "docs: that thing" in window
+        docs_rows = [ln for ln in lines if "| Phase 6 |" in ln]
+        assert any("commit def4567" in r and "docs: that thing" in r for r in docs_rows)
 
-    def test_notes_render_in_analysis_section(self):
+    def test_notes_render_in_analysis_section_with_split_phase_label(self):
         md = report_cli.render(issue=321, events=_pass_path_events())
         assert "## Analysis" in md
-        assert "pushed in one shot" in md
+        # Notes section labels each note with `Phase N — <descriptor>`
+        # (the combined label), reconstructed from the split dicts.
+        assert "- Phase 5 — execute tasks: pushed in one shot after vitest green" in md
 
     def test_durations_in_seconds(self):
         """Phase rows show whole-second durations, no `1m 30s` form."""
         md = report_cli.render(issue=321, events=_pass_path_events())
-        # The design row's agent-dispatch was 3 minutes = 180 seconds
+        # The design row's agent-dispatch was 3 minutes = 180 seconds.
+        # Phase column is just "Phase 1-2" (descriptor moved to Action).
         design_lines = [
             ln for ln in md.splitlines()
-            if "Phase 1-2 — understand + design" in ln and "agent-dispatch" in ln
+            if "| Phase 1-2 |" in ln and "agent-dispatch" in ln
         ]
         assert design_lines
-        # Last column is duration in seconds — should be the number 180
+        # Duration column carries the integer 180
         assert " 180 |" in design_lines[0]
+        # Descriptor sits in the Action column
+        assert "agent-dispatch — understand + design" in design_lines[0]
 
     def test_eject_path_renders_fail(self):
         events = _pass_path_events()

--- a/tests/unit/test_report_cli.py
+++ b/tests/unit/test_report_cli.py
@@ -1,14 +1,19 @@
-"""Unit tests for the `maverick report` CLI surface (#83)."""
+"""Unit tests for the v1 Maverick workflow report CLI surface."""
 
 from __future__ import annotations
 
 import argparse
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from maverick import report_cli
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
 def _parse(*argv: str) -> argparse.Namespace:
@@ -18,136 +23,189 @@ def _parse(*argv: str) -> argparse.Namespace:
     return parser.parse_args(list(argv))
 
 
+def _full_event(**overrides: Any) -> dict[str, Any]:
+    """A minimum-viable, schema-valid event. Override fields per test."""
+    base: dict[str, Any] = {
+        "schema_version": report_cli.SCHEMA_VERSION,
+        "action": "phase-boundary",
+        "start_ts": "2026-05-19T10:00:00Z",
+        "instance_id": "test1234ab",
+        "issue": 321,
+        "maverick_version": "3.3.2-dev",
+        "phase": "design",
+    }
+    base.update(overrides)
+    return base
+
+
 # ---------------------------------------------------------------------------
 # argparse wiring
 # ---------------------------------------------------------------------------
 
 
 class TestArgparseWiring:
-    def test_log_subcommand_parses(self):
-        args = _parse(
-            "report", "log", "subagent-start",
-            "--issue", "123", "--name", "agent-issue-analyst",
-        )
-        assert args._handler is report_cli._report_log
-        assert args.issue == 123
-        assert args.event_type == "subagent-start"
-        assert args.name == "agent-issue-analyst"
+    def test_run_start_parses(self):
+        args = _parse("report", "run-start", "do-issue-solo", "--issue", "5")
+        assert args._handler is report_cli._report_run_start
+        assert args.skill == "do-issue-solo"
+        assert args.issue == 5
 
-    def test_generate_subcommand_parses(self):
-        args = _parse(
-            "report", "generate", "owner/repo", "42",
-            "--branch", "feat/42-foo",
-        )
-        assert args._handler is report_cli._report_generate
-        assert args.repo == "owner/repo"
-        assert args.issue == 42
-        assert args.branch == "feat/42-foo"
+    def test_phase_parses(self):
+        args = _parse("report", "phase", "--issue", "5", "--phase", "design")
+        assert args._handler is report_cli._report_phase
+        assert args.phase == "design"
 
-    def test_path_subcommand_parses(self):
-        args = _parse("report", "path", "42")
-        assert args._handler is report_cli._report_path
-        assert args.issue == 42
+    def test_phase_rejects_unknown_value(self):
+        with pytest.raises(SystemExit):
+            _parse("report", "phase", "--issue", "5", "--phase", "not-a-phase")
+
+    def test_begin_end_parse(self):
+        a = _parse("report", "begin", "agent-dispatch", "--issue", "5",
+                   "--phase", "design", "--agent", "agent-x")
+        assert a._handler is report_cli._report_begin
+        b = _parse("report", "end", "agent-dispatch", "--issue", "5",
+                   "--outcome", "success", "--agent", "agent-x")
+        assert b._handler is report_cli._report_end
+        assert b.outcome == "success"
+
+    def test_end_outcome_required_and_validated(self):
+        with pytest.raises(SystemExit):
+            _parse("report", "end", "agent-dispatch", "--issue", "5", "--agent", "agent-x")
+        with pytest.raises(SystemExit):
+            _parse("report", "end", "agent-dispatch", "--issue", "5",
+                   "--outcome", "winning", "--agent", "agent-x")
+
+    def test_commit_parses(self):
+        args = _parse("report", "commit", "--issue", "5", "--phase", "implement",
+                      "--sha", "abc1234", "--subject", "feat: a thing")
+        assert args._handler is report_cli._report_commit
+        assert args.sha == "abc1234"
+
+    def test_note_parses(self):
+        args = _parse("report", "note", "--issue", "5", "--phase", "design",
+                      "--text", "narrative")
+        assert args._handler is report_cli._report_note
+
+    def test_generate_and_verify(self):
+        g = _parse("report", "generate", "owner/repo", "42")
+        assert g._handler is report_cli._report_generate
+        v = _parse("report", "verify", "42")
+        assert v._handler is report_cli._report_verify
 
 
 # ---------------------------------------------------------------------------
-# append_event
+# Schema validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_valid_minimal_event_passes(self):
+        report_cli._validate(_full_event())  # does not raise
+
+    def test_wrong_schema_version_rejected(self):
+        with pytest.raises(report_cli.SchemaError, match="schema_version"):
+            report_cli._validate(_full_event(schema_version=2))
+
+    def test_unknown_action_rejected(self):
+        with pytest.raises(report_cli.SchemaError, match="action"):
+            report_cli._validate(_full_event(action="invent-something"))
+
+    def test_unknown_phase_rejected(self):
+        with pytest.raises(report_cli.SchemaError, match="phase"):
+            report_cli._validate(_full_event(phase="bogus"))
+
+    def test_start_ts_must_be_z_suffixed(self):
+        with pytest.raises(report_cli.SchemaError, match="start_ts"):
+            report_cli._validate(_full_event(start_ts="2026-05-19T10:00:00+00:00"))
+
+    def test_atomic_action_must_not_carry_end_ts(self):
+        with pytest.raises(report_cli.SchemaError, match="must not carry end_ts"):
+            report_cli._validate(_full_event(action="phase-boundary",
+                                             end_ts="2026-05-19T10:01:00Z"))
+
+    def test_interval_action_requires_end_ts(self):
+        with pytest.raises(report_cli.SchemaError, match="requires end_ts"):
+            report_cli._validate(_full_event(action="agent-dispatch",
+                                             outcome="success", end_ts=None))
+
+    def test_interval_action_requires_outcome(self):
+        with pytest.raises(report_cli.SchemaError, match="requires outcome"):
+            report_cli._validate(_full_event(action="agent-dispatch",
+                                             end_ts="2026-05-19T10:01:00Z"))
+
+    def test_unknown_outcome_rejected(self):
+        with pytest.raises(report_cli.SchemaError, match="outcome"):
+            report_cli._validate(_full_event(action="agent-dispatch",
+                                             end_ts="2026-05-19T10:01:00Z",
+                                             outcome="meh"))
+
+    def test_commit_requires_sha_and_subject(self):
+        with pytest.raises(report_cli.SchemaError, match="commit action requires sha"):
+            report_cli._validate(_full_event(action="commit", phase="implement"))
+        with pytest.raises(report_cli.SchemaError, match="subject"):
+            report_cli._validate(_full_event(action="commit", phase="implement", sha="abc"))
+
+    def test_note_requires_text(self):
+        with pytest.raises(report_cli.SchemaError, match="notes text"):
+            report_cli._validate(_full_event(action="note"))
+
+    def test_run_start_requires_skill(self):
+        with pytest.raises(report_cli.SchemaError, match="run-start.*maverick_skill"):
+            report_cli._validate(_full_event(action="run-start", phase="claimed"))
+
+    def test_missing_required_system_field_rejected(self):
+        e = _full_event()
+        del e["instance_id"]
+        with pytest.raises(report_cli.SchemaError, match="instance_id"):
+            report_cli._validate(e)
+
+
+# ---------------------------------------------------------------------------
+# append_event + load_timeline
 # ---------------------------------------------------------------------------
 
 
 class TestAppendEvent:
-    def test_round_trip_writes_jsonl(self, tmp_path: Path):
-        ok = report_cli.append_event(
-            42,
-            {"type": "phase-checkpoint", "phase": "design"},
-            repo_root=tmp_path,
-        )
+    def test_round_trip(self, tmp_path: Path):
+        event = _full_event(action="phase-boundary", phase="design")
+        ok = report_cli.append_event(event, repo_root=tmp_path)
         assert ok is True
-        path = report_cli.timeline_path(42, repo_root=tmp_path)
+        path = report_cli.timeline_path(321, repo_root=tmp_path)
         assert path.exists()
-        line = path.read_text().strip()
-        record = json.loads(line)
-        assert record["type"] == "phase-checkpoint"
-        assert record["phase"] == "design"
-        assert record["issue"] == 42
-        assert record["ts"].endswith("Z")
+        loaded = json.loads(path.read_text().strip())
+        assert loaded["action"] == "phase-boundary"
+        assert loaded["phase"] == "design"
 
-    def test_creates_parent_directories(self, tmp_path: Path):
-        report_cli.append_event(
-            7,
-            {"type": "subagent-start", "name": "agent-x"},
-            repo_root=tmp_path,
-        )
-        path = report_cli.timeline_path(7, repo_root=tmp_path)
-        assert path.parent.exists()
-
-    def test_appends_not_overwrites(self, tmp_path: Path):
-        for phase in ("claimed", "design", "tasks"):
-            report_cli.append_event(
-                1,
-                {"type": "phase-checkpoint", "phase": phase, "ts": f"2026-01-01T00:00:0{['claimed','design','tasks'].index(phase)}Z"},
-                repo_root=tmp_path,
-            )
-        path = report_cli.timeline_path(1, repo_root=tmp_path)
-        lines = [ln for ln in path.read_text().splitlines() if ln.strip()]
-        assert len(lines) == 3
+    def test_invalid_event_returns_false_writes_nothing(self, tmp_path: Path):
+        bad = _full_event(action="phase-boundary", end_ts="2026-05-19T11:00:00Z")
+        ok = report_cli.append_event(bad, repo_root=tmp_path)
+        assert ok is False
+        path = report_cli.timeline_path(321, repo_root=tmp_path)
+        assert not path.exists()
 
     def test_failure_returns_false_does_not_raise(self, tmp_path: Path, monkeypatch):
-        # Force mkdir to raise — append_event must swallow the error.
         from pathlib import Path as P
 
         def boom(self, *a, **kw):
             raise PermissionError("nope")
 
         monkeypatch.setattr(P, "mkdir", boom)
-        ok = report_cli.append_event(
-            1, {"type": "phase-checkpoint", "phase": "design"}, repo_root=tmp_path
-        )
+        ok = report_cli.append_event(_full_event(), repo_root=tmp_path)
         assert ok is False
 
 
-# ---------------------------------------------------------------------------
-# Validation + loading
-# ---------------------------------------------------------------------------
-
-
-class TestValidation:
-    @pytest.mark.parametrize(
-        "evt",
-        [
-            {"ts": "2026-01-01T00:00:00Z", "type": "phase-checkpoint", "phase": "design"},
-            {"ts": "2026-01-01T00:00:00Z", "type": "subagent-start", "name": "x"},
-        ],
-    )
-    def test_valid(self, evt):
-        assert report_cli._validate_event(evt)
-
-    @pytest.mark.parametrize(
-        "evt",
-        [
-            None,
-            "not a dict",
-            {"type": "phase-checkpoint"},  # missing ts
-            {"ts": "not-iso", "type": "phase-checkpoint"},  # ts not Z-suffixed
-            {"ts": "2026-01-01T00:00:00Z"},  # missing type
-            {"ts": "2026-01-01T00:00:00Z", "type": 42},  # type not str
-        ],
-    )
-    def test_invalid(self, evt):
-        assert not report_cli._validate_event(evt)
-
-    def test_load_skips_malformed_lines(self, tmp_path: Path, capsys):
+class TestLoadTimeline:
+    def test_skips_invalid_rows_with_warning(self, tmp_path: Path, capsys):
         path = tmp_path / "t.jsonl"
+        good = _full_event(start_ts="2026-05-19T10:00:00Z")
+        bad = _full_event(start_ts="2026-05-19T10:01:00Z", action="invent-something")
         path.write_text(
-            "\n".join(
-                [
-                    json.dumps({"ts": "2026-01-01T00:00:01Z", "type": "phase-checkpoint", "phase": "design"}),
-                    "{not json",
-                    json.dumps({"type": "phase-checkpoint"}),  # invalid
-                    json.dumps({"ts": "2026-01-01T00:00:02Z", "type": "phase-checkpoint", "phase": "tasks"}),
-                    "",
-                ]
-            )
+            "\n".join([
+                json.dumps(good),
+                "{not json",
+                json.dumps(bad),
+                json.dumps(_full_event(start_ts="2026-05-19T10:02:00Z", phase="tasks")),
+            ])
         )
         events = report_cli.load_timeline(path)
         assert len(events) == 2
@@ -155,156 +213,346 @@ class TestValidation:
         captured = capsys.readouterr()
         assert "warning" in captured.err
 
-    def test_load_sorts_by_ts(self, tmp_path: Path):
+    def test_sorts_by_start_ts(self, tmp_path: Path):
         path = tmp_path / "t.jsonl"
-        path.write_text(
-            "\n".join(
-                json.dumps(e)
-                for e in [
-                    {"ts": "2026-01-01T00:00:02Z", "type": "phase-checkpoint", "phase": "tasks"},
-                    {"ts": "2026-01-01T00:00:01Z", "type": "phase-checkpoint", "phase": "design"},
-                ]
-            )
-        )
+        path.write_text("\n".join([
+            json.dumps(_full_event(start_ts="2026-05-19T10:02:00Z", phase="tasks")),
+            json.dumps(_full_event(start_ts="2026-05-19T10:01:00Z", phase="design")),
+        ]))
         events = report_cli.load_timeline(path)
         assert [e["phase"] for e in events] == ["design", "tasks"]
 
 
 # ---------------------------------------------------------------------------
-# Rendering
+# begin/end pairing via the pending sidecar
 # ---------------------------------------------------------------------------
 
 
-class TestPairIntervals:
-    def test_pairs_subagents_with_phase_attribution(self):
-        events = [
-            {"ts": "2026-01-01T00:00:01Z", "type": "phase-checkpoint", "phase": "claimed"},
-            {"ts": "2026-01-01T00:00:02Z", "type": "subagent-start", "name": "agent-x"},
-            {"ts": "2026-01-01T00:00:05Z", "type": "subagent-end", "name": "agent-x"},
-            {"ts": "2026-01-01T00:00:06Z", "type": "phase-checkpoint", "phase": "design"},
-        ]
-        pairs = report_cli._pair_intervals(events, "subagent-start", "subagent-end", "name")
-        assert pairs == [
-            ("agent-x", "2026-01-01T00:00:02Z", "2026-01-01T00:00:05Z", "claimed"),
-        ]
+class TestBeginEnd:
+    def _setup(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(report_cli, "_main_repo_root", lambda cwd=None: tmp_path)
+        monkeypatch.setenv("MAVERICK_INSTANCE_ID", "test1234ab")
 
-    def test_unmatched_start_gets_zero_duration(self):
-        events = [
-            {"ts": "2026-01-01T00:00:01Z", "type": "phase-checkpoint", "phase": "design"},
-            {"ts": "2026-01-01T00:00:02Z", "type": "subagent-start", "name": "agent-x"},
-        ]
-        pairs = report_cli._pair_intervals(events, "subagent-start", "subagent-end", "name")
-        assert len(pairs) == 1
-        assert pairs[0][1] == pairs[0][2]
+    def test_round_trip_writes_one_interval_row(self, tmp_path: Path, monkeypatch):
+        self._setup(tmp_path, monkeypatch)
+        # begin
+        begin_args = _parse("report", "begin", "agent-dispatch", "--issue", "321",
+                            "--phase", "design", "--agent", "agent-x")
+        report_cli._report_begin(begin_args)
+        # end
+        end_args = _parse("report", "end", "agent-dispatch", "--issue", "321",
+                          "--outcome", "success", "--agent", "agent-x")
+        report_cli._report_end(end_args)
+
+        events = report_cli.load_timeline(report_cli.timeline_path(321, repo_root=tmp_path))
+        assert len(events) == 1
+        e = events[0]
+        assert e["action"] == "agent-dispatch"
+        assert e["maverick_agent"] == "agent-x"
+        assert e["outcome"] == "success"
+        assert e["start_ts"].endswith("Z")
+        assert e["end_ts"].endswith("Z")
+        assert e["start_ts"] <= e["end_ts"]
+        # pending file should be empty (or absent of this key)
+        pending = report_cli._read_pending(report_cli.pending_path(321, repo_root=tmp_path))
+        assert "agent-dispatch:agent-x" not in pending
+
+    def test_end_without_begin_writes_warning_no_row(self, tmp_path: Path, monkeypatch, capsys):
+        self._setup(tmp_path, monkeypatch)
+        end_args = _parse("report", "end", "agent-dispatch", "--issue", "321",
+                          "--outcome", "success", "--agent", "agent-x")
+        rc = report_cli._report_end(end_args)
+        assert rc == 1
+        path = report_cli.timeline_path(321, repo_root=tmp_path)
+        assert not path.exists()
+        assert "no matching open begin" in capsys.readouterr().err
+
+    def test_concurrent_begins_for_different_agents_keep_separate_intervals(
+        self, tmp_path: Path, monkeypatch
+    ):
+        self._setup(tmp_path, monkeypatch)
+        for agent in ("agent-a", "agent-b"):
+            report_cli._report_begin(
+                _parse("report", "begin", "agent-dispatch", "--issue", "321",
+                       "--phase", "design", "--agent", agent)
+            )
+        for agent in ("agent-a", "agent-b"):
+            report_cli._report_end(
+                _parse("report", "end", "agent-dispatch", "--issue", "321",
+                       "--outcome", "success", "--agent", agent)
+            )
+        events = report_cli.load_timeline(report_cli.timeline_path(321, repo_root=tmp_path))
+        agents = sorted(e["maverick_agent"] for e in events)
+        assert agents == ["agent-a", "agent-b"]
 
 
-class TestPhaseIntervals:
-    def test_anchors_first_phase_to_claim_time(self):
-        events = [
-            {"ts": "2026-01-01T00:01:00Z", "type": "phase-checkpoint", "phase": "claimed"},
-            {"ts": "2026-01-01T00:05:00Z", "type": "phase-checkpoint", "phase": "design"},
-        ]
-        intervals = report_cli._phase_intervals(events, "2026-01-01T00:00:00Z")
-        assert intervals == [
-            ("claimed", "2026-01-01T00:00:00Z", "2026-01-01T00:01:00Z"),
-            ("design", "2026-01-01T00:01:00Z", "2026-01-01T00:05:00Z"),
-        ]
-
-    def test_no_claim_falls_back_to_first_event(self):
-        events = [
-            {"ts": "2026-01-01T00:01:00Z", "type": "phase-checkpoint", "phase": "claimed"},
-        ]
-        intervals = report_cli._phase_intervals(events, None)
-        assert intervals[0][1] == "2026-01-01T00:01:00Z"
-
-    def test_empty_returns_empty(self):
-        assert report_cli._phase_intervals([], None) == []
+# ---------------------------------------------------------------------------
+# Atomic actions via CLI
+# ---------------------------------------------------------------------------
 
 
-class TestFormatters:
-    @pytest.mark.parametrize(
-        "secs,expected",
-        [
-            (0, "<1s"),
-            (1, "1s"),
-            (59, "59s"),
-            (60, "1m"),
-            (90, "1m 30s"),
-            (3600, "1h 0m"),
-            (3700, "1h 1m"),
-        ],
-    )
-    def test_fmt_duration(self, secs, expected):
-        assert report_cli._fmt_duration(secs) == expected
+class TestAtomicCommands:
+    def _setup(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(report_cli, "_main_repo_root", lambda cwd=None: tmp_path)
+        monkeypatch.setenv("MAVERICK_INSTANCE_ID", "test1234ab")
 
-    def test_fmt_time(self):
-        assert report_cli._fmt_time("2026-01-01T08:17:35Z") == "08:17:35"
+    def test_run_start_writes_skill(self, tmp_path: Path, monkeypatch):
+        self._setup(tmp_path, monkeypatch)
+        args = _parse("report", "run-start", "do-issue-solo", "--issue", "321")
+        report_cli._report_run_start(args)
+        events = report_cli.load_timeline(report_cli.timeline_path(321, repo_root=tmp_path))
+        assert events[0]["maverick_skill"] == "do-issue-solo"
+        assert events[0]["action"] == "run-start"
 
-    def test_fmt_time_invalid_passes_through(self):
-        assert report_cli._fmt_time("garbage") == "garbage"
+    def test_commit_writes_sha_and_subject(self, tmp_path: Path, monkeypatch):
+        self._setup(tmp_path, monkeypatch)
+        report_cli._report_commit(_parse(
+            "report", "commit", "--issue", "321", "--phase", "implement",
+            "--sha", "abc1234", "--subject", "feat: x"
+        ))
+        events = report_cli.load_timeline(report_cli.timeline_path(321, repo_root=tmp_path))
+        assert events[0]["sha"] == "abc1234"
+        assert events[0]["subject"] == "feat: x"
+        assert events[0].get("end_ts") is None
+
+    def test_note_writes_text(self, tmp_path: Path, monkeypatch):
+        self._setup(tmp_path, monkeypatch)
+        report_cli._report_note(_parse(
+            "report", "note", "--issue", "321", "--phase", "design",
+            "--text", "the analyst returned a clean design"
+        ))
+        events = report_cli.load_timeline(report_cli.timeline_path(321, repo_root=tmp_path))
+        assert events[0]["notes"] == "the analyst returned a clean design"
+
+    def test_run_start_inherited_by_later_calls(self, tmp_path: Path, monkeypatch):
+        self._setup(tmp_path, monkeypatch)
+        report_cli._report_run_start(_parse(
+            "report", "run-start", "do-issue-solo", "--issue", "321"
+        ))
+        report_cli._report_commit(_parse(
+            "report", "commit", "--issue", "321", "--phase", "implement",
+            "--sha", "deadbeef", "--subject", "feat: y"
+        ))
+        events = report_cli.load_timeline(report_cli.timeline_path(321, repo_root=tmp_path))
+        commit_row = next(e for e in events if e["action"] == "commit")
+        assert commit_row["maverick_skill"] == "do-issue-solo"
+
+
+# ---------------------------------------------------------------------------
+# Renderer
+# ---------------------------------------------------------------------------
+
+
+def _pass_path_events() -> list[dict[str, Any]]:
+    """A minimal but representative PASS-path timeline."""
+    e = []
+    e.append(_full_event(
+        action="run-start", start_ts="2026-05-19T10:00:00Z",
+        phase="claimed", maverick_skill="do-issue-solo",
+    ))
+    e.append(_full_event(
+        action="agent-dispatch", phase="design",
+        start_ts="2026-05-19T10:01:00Z",
+        end_ts="2026-05-19T10:04:00Z",
+        maverick_agent="agent-issue-analyst",
+        outcome="success",
+    ))
+    e.append(_full_event(
+        action="phase-boundary", phase="design",
+        start_ts="2026-05-19T10:05:00Z",
+    ))
+    e.append(_full_event(
+        action="phase-boundary", phase="branch",
+        start_ts="2026-05-19T10:06:00Z",
+    ))
+    e.append(_full_event(
+        action="commit", phase="implement",
+        start_ts="2026-05-19T10:10:00Z",
+        sha="abc1234567", subject="feat: a thing",
+    ))
+    e.append(_full_event(
+        action="phase-boundary", phase="implement",
+        start_ts="2026-05-19T10:12:00Z",
+    ))
+    e.append(_full_event(
+        action="agent-dispatch", phase="docs",
+        start_ts="2026-05-19T10:13:00Z",
+        end_ts="2026-05-19T10:14:30Z",
+        maverick_agent="agent-tech-docs-writer",
+        outcome="success",
+    ))
+    e.append(_full_event(
+        action="commit", phase="docs",
+        start_ts="2026-05-19T10:14:45Z",
+        sha="def4567890", subject="docs: that thing",
+    ))
+    e.append(_full_event(
+        action="phase-boundary", phase="docs",
+        start_ts="2026-05-19T10:15:00Z",
+    ))
+    e.append(_full_event(
+        action="skill-dispatch", phase="security",
+        start_ts="2026-05-19T10:15:30Z",
+        end_ts="2026-05-19T10:16:00Z",
+        outcome="success",
+    ))
+    e.append(_full_event(
+        action="phase-boundary", phase="security",
+        start_ts="2026-05-19T10:16:30Z",
+    ))
+    e.append(_full_event(
+        action="phase-boundary", phase="complete",
+        start_ts="2026-05-19T10:20:00Z",
+    ))
+    e.append(_full_event(
+        action="note", phase="implement",
+        start_ts="2026-05-19T10:19:00Z",
+        notes="pushed in one shot after vitest green",
+    ))
+    return e
 
 
 class TestRender:
     def test_empty_events_returns_stub(self):
         md = report_cli.render(issue=42, events=[])
-        assert "Issue #42" in md
+        assert "Maverick workflow report" in md
         assert "No timeline events" in md
 
-    def test_minimal_run_renders_table_and_summary(self):
-        events = [
-            {"ts": "2026-01-01T00:00:30Z", "type": "phase-checkpoint", "phase": "claimed"},
-            {"ts": "2026-01-01T00:00:31Z", "type": "subagent-start", "name": "agent-issue-analyst"},
-            {"ts": "2026-01-01T00:04:04Z", "type": "subagent-end", "name": "agent-issue-analyst"},
-            {"ts": "2026-01-01T00:05:00Z", "type": "phase-checkpoint", "phase": "design"},
-            {"ts": "2026-01-01T00:06:00Z", "type": "phase-checkpoint", "phase": "complete"},
-        ]
-        md = report_cli.render(
-            issue=42,
-            events=events,
-            claim_created_at="2026-01-01T00:00:00Z",
-        )
-        # Header
-        assert "# Issue #42 — time breakdown" in md
-        assert "Wall-clock:" in md
-        # Phase rows
-        assert "Phase 0 — coordination" in md
-        assert "Phase 1-2 — understand + design" in md
-        assert "Phase 10 — complete" in md
-        # PLACEHOLDER prefix
-        assert "PLACEHOLDER" in md
-        # Subagent fact rendered into the design row
-        assert "agent-issue-analyst" in md
-        # Summary table
-        assert "Subagent compute" in md
-        assert "Coordination" in md
+    def test_pass_path_renders_metadata_and_outcome(self):
+        md = report_cli.render(issue=321, events=_pass_path_events())
+        assert "# Maverick workflow report" in md
+        assert "- Issue: #321" in md
+        assert "- Skill: do-issue-solo" in md
+        assert "- Outcome: PASS" in md
+        assert "- Maverick: 3.3.2-dev" in md
 
-    def test_implement_phase_renders_commit_subrows(self):
-        events = [
-            {"ts": "2026-01-01T00:00:00Z", "type": "phase-checkpoint", "phase": "branch"},
-            {"ts": "2026-01-01T00:10:00Z", "type": "phase-checkpoint", "phase": "implement"},
-        ]
-        commits = [
-            {"sha": "abc1234567", "committed_at": "2026-01-01T00:03:00Z", "subject": "feat: add helper"},
-            {"sha": "def4567890", "committed_at": "2026-01-01T00:07:00Z", "subject": "test: cover helper"},
-        ]
-        md = report_cli.render(
-            issue=99,
-            events=events,
-            commits=commits,
-            claim_created_at="2026-01-01T00:00:00Z",
+    def test_total_time_emits_seconds(self):
+        md = report_cli.render(issue=321, events=_pass_path_events())
+        # 10:00:00 to last phase-boundary at 10:20:00 = 1200s
+        assert "## Total Time" in md
+        assert "seconds: 1200" in md
+
+    def test_phase_rows_carry_action_and_agent_columns(self):
+        md = report_cli.render(issue=321, events=_pass_path_events())
+        assert "| Maverick Action | Maverick Agent |" in md
+        # The docs phase has an agent-dispatch row carrying the agent name
+        docs_rows = [ln for ln in md.splitlines() if "Phase 6 — documentation review" in ln]
+        assert any("agent-dispatch" in r and "agent-tech-docs-writer" in r for r in docs_rows)
+
+    def test_one_row_per_action_within_a_phase(self):
+        """Phase 6 has BOTH a docs agent-dispatch and (in this fixture) no skill-dispatch.
+        The implement phase has commit sub-rows but no action row of its own
+        (no agent or skill ran inside it).
+        """
+        md = report_cli.render(issue=321, events=_pass_path_events())
+        lines = md.splitlines()
+        impl_rows = [ln for ln in lines if "Phase 5 — execute tasks" in ln]
+        # No agent ran in implement, so the phase row is a phase-boundary
+        assert any("phase-boundary" in r for r in impl_rows)
+
+    def test_commit_subrows_render_under_their_phase(self):
+        md = report_cli.render(issue=321, events=_pass_path_events())
+        lines = md.splitlines()
+        impl_idx = next(i for i, ln in enumerate(lines) if "Phase 5 — execute tasks" in ln)
+        # The implement commit sub-row appears soon after the phase row
+        window = "\n".join(lines[impl_idx:impl_idx + 4])
+        assert "↳ commit" in window
+        assert "abc1234" in window
+        assert "feat: a thing" in window
+
+    def test_docs_commit_lands_under_docs_phase(self):
+        md = report_cli.render(issue=321, events=_pass_path_events())
+        lines = md.splitlines()
+        docs_idx = next(i for i, ln in enumerate(lines) if "Phase 6 — documentation review" in ln)
+        next_phase_idx = next(
+            i for i, ln in enumerate(lines[docs_idx + 1:], start=docs_idx + 1)
+            if "Phase 7" in ln
         )
-        assert "↳ commit" in md
-        assert "abc1234" in md
-        assert "feat: add helper" in md
-        assert "def4567" in md
+        window = "\n".join(lines[docs_idx:next_phase_idx])
+        assert "def4567" in window
+        assert "docs: that thing" in window
+
+    def test_notes_render_in_analysis_section(self):
+        md = report_cli.render(issue=321, events=_pass_path_events())
+        assert "## Analysis" in md
+        assert "pushed in one shot" in md
+
+    def test_durations_in_seconds(self):
+        """Phase rows show whole-second durations, no `1m 30s` form."""
+        md = report_cli.render(issue=321, events=_pass_path_events())
+        # The design row's agent-dispatch was 3 minutes = 180 seconds
+        design_lines = [
+            ln for ln in md.splitlines()
+            if "Phase 1-2 — understand + design" in ln and "agent-dispatch" in ln
+        ]
+        assert design_lines
+        # Last column is duration in seconds — should be the number 180
+        assert " 180 |" in design_lines[0]
+
+    def test_eject_path_renders_fail(self):
+        events = _pass_path_events()
+        # Swap the trailing complete phase for ejected
+        events = [e for e in events if e["phase"] != "complete"]
+        events.append(_full_event(
+            action="phase-boundary", phase="ejected",
+            start_ts="2026-05-19T10:21:00Z",
+        ))
+        md = report_cli.render(issue=321, events=events)
+        assert "- Outcome: FAIL-eject" in md
 
     def test_pipe_in_commit_subject_is_escaped(self):
-        events = [
-            {"ts": "2026-01-01T00:00:00Z", "type": "phase-checkpoint", "phase": "branch"},
-            {"ts": "2026-01-01T00:10:00Z", "type": "phase-checkpoint", "phase": "implement"},
-        ]
-        commits = [
-            {"sha": "abc1234", "committed_at": "2026-01-01T00:01:00Z", "subject": "feat: a|b helper"},
-        ]
-        md = report_cli.render(issue=1, events=events, commits=commits)
+        events = _pass_path_events()
+        for e in events:
+            if e.get("action") == "commit" and e.get("phase") == "implement":
+                e["subject"] = "feat: a|b helper"
+        md = report_cli.render(issue=321, events=events)
         assert "a\\|b" in md
+
+
+# ---------------------------------------------------------------------------
+# verify command
+# ---------------------------------------------------------------------------
+
+
+class TestVerify:
+    def test_clean_timeline_returns_zero(self, tmp_path: Path, monkeypatch, capsys):
+        monkeypatch.setattr(report_cli, "_main_repo_root", lambda cwd=None: tmp_path)
+        path = report_cli.timeline_path(321, repo_root=tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(_full_event()) + "\n")
+        rc = report_cli._report_verify(argparse.Namespace(issue=321))
+        assert rc == 0
+        assert "ok" in capsys.readouterr().out
+
+    def test_schema_violations_return_nonzero_and_print_location(
+        self, tmp_path: Path, monkeypatch, capsys
+    ):
+        monkeypatch.setattr(report_cli, "_main_repo_root", lambda cwd=None: tmp_path)
+        path = report_cli.timeline_path(321, repo_root=tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("\n".join([
+            json.dumps(_full_event()),
+            json.dumps(_full_event(phase="nonsense")),
+            "{not json",
+        ]))
+        rc = report_cli._report_verify(argparse.Namespace(issue=321))
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "schema violation" in out
+        assert "malformed JSON" in out
+
+    def test_dangling_pending_intervals_surfaced(
+        self, tmp_path: Path, monkeypatch, capsys
+    ):
+        monkeypatch.setattr(report_cli, "_main_repo_root", lambda cwd=None: tmp_path)
+        path = report_cli.timeline_path(321, repo_root=tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(_full_event()) + "\n")
+        pending = report_cli.pending_path(321, repo_root=tmp_path)
+        report_cli._write_pending(pending, {
+            "agent-dispatch:agent-x": {"start_ts": "2026-05-19T10:00:00Z"},
+        })
+        report_cli._report_verify(argparse.Namespace(issue=321))
+        out = capsys.readouterr().out
+        assert "dangling" in out
+        assert "agent-dispatch:agent-x" in out


### PR DESCRIPTION
## Summary

- **Schema v1** for the workflow report (`a1f03f2`): structured timeline events with phase/action/agent/skill/outcome fields, new `do-code` and `do-test` skills. **BREAKING** — pre-v1 timelines don't load.
- **Per-project LLM defaults** (`d324aaf`): repos can override which Claude model powers each agent or skill via a new `llm` block in `.maverick/config.json`. Maverick ships baseline defaults (Opus 4.7 for reasoning-heavy work; Sonnet 4.6 for pattern-following agents/skills).
- **`dispatched_skill` field**: required on `skill-dispatch` rows, optional on `agent-dispatch` rows when the agent operates under a named skill. Surfaces in the report's Maverick Skill column.
- **Renderer**: one row per (phase, action) tuple — phases with multiple dispatches no longer collapse. New columns: LLM, Maverick Root Skill, Maverick Sub Agent, Maverick Skill. Header surfaces distinct LLMs used across the run.
- **Template plumbing**: every agent-dispatch and skill-dispatch site in `do-issue-solo` now passes `--skill-name`, so the Maverick Skill column is populated on every row.

## LLM resolution chain

Each row's `llm` field is resolved at write time:

1. Explicit `--llm` on the CLI call
2. `MAVERICK_LLM` env var
3. Per-agent entry in project `llm.agents`
4. Per-skill entry in project `llm.skills`
5. Project `llm.default`
6. Latest `run-start` row's `llm` for this issue
7. `FALLBACK_LLM` literal (`"claude-code"`)

Per-agent rules beat per-skill rules when both apply to the same row.

## Test plan

- [x] `pytest tests/unit/test_report_cli.py` — 62 passing, including a new `TestLLMResolution` class covering each link in the fallback chain
- [x] `make build` produces no further diffs (build output in sync with source templates)
- [ ] Smoke-test `uv run maverick report render <issue>` against a real timeline once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)