### PR TITLE
fix: stamp llm on task-progress phase-boundary events (#98)

### DIFF
--- a/src/maverick/coord_cli.py
+++ b/src/maverick/coord_cli.py
@@ -38,6 +38,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 from maverick import (
     coordinator,
@@ -265,17 +266,20 @@ def _task_progress_set(args: argparse.Namespace) -> int:
     try:
         from maverick import report_cli
 
-        report_cli.append_event(
-            {
-                "schema_version": report_cli.SCHEMA_VERSION,
-                "action": "phase-boundary",
-                "start_ts": payload["updated_at"],
-                "instance_id": payload["instance_id"],
-                "issue": args.issue,
-                "maverick_version": report_cli._get_version(),
-                "phase": args.phase,
-            }
-        )
+        event: dict[str, Any] = {
+            "schema_version": report_cli.SCHEMA_VERSION,
+            "action": "phase-boundary",
+            "start_ts": payload["updated_at"],
+            "instance_id": payload["instance_id"],
+            "issue": args.issue,
+            "maverick_version": report_cli._get_version(),
+            "phase": args.phase,
+            "llm": report_cli._current_llm(issue=args.issue),
+        }
+        skill = report_cli._current_skill(args.issue)
+        if skill:
+            event["maverick_skill"] = skill
+        report_cli.append_event(event)
     except Exception as e:  # noqa: BLE001 — best-effort
         print(f"warning: timeline append failed: {e}", file=sys.stderr)
     _json_print(payload)

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -466,6 +466,39 @@ class TestTaskProgressCli:
         assert timeline_events[0]["issue"] == 42
         assert timeline_events[0]["issue"] == 42
 
+    def test_set_stamps_llm_on_phase_boundary_event(self, monkeypatch, tmp_path):
+        """The phase-boundary event must carry an `llm` field resolved via
+        `_current_llm` (#98). Without it, the renderer falls back to the
+        literal FALLBACK_LLM ("claude-code") whenever a phase contains no
+        agent-dispatch sibling to inherit from — surfaced as misleading
+        `claude-code` cells on the LLM column for phases like Phase 8
+        ("open PR" / "CI green") and the final Phase 10 ("complete")."""
+        import argparse
+
+        from maverick import coord_cli, gh_state, report_cli
+
+        monkeypatch.setattr(
+            coordinator, "_instance_id_path", lambda: tmp_path / "instance_id"
+        )
+        monkeypatch.setenv("MAVERICK_INSTANCE_ID", "i-llm")
+        # Distinctive sentinel so the assertion proves the resolver ran,
+        # rather than coincidentally matching the baked-in default.
+        monkeypatch.setenv("MAVERICK_LLM", "test-sentinel-llm")
+        monkeypatch.setattr(gh_state, "upsert_marker", lambda *a, **k: 1)
+
+        timeline_events: list[dict] = []
+        monkeypatch.setattr(
+            report_cli, "append_event", lambda e, repo_root=None: timeline_events.append(e) or True
+        )
+
+        rc = coord_cli._task_progress_set(
+            argparse.Namespace(repo="me/r", issue=42, phase="pr_open")
+        )
+
+        assert rc == 0
+        assert len(timeline_events) == 1
+        assert timeline_events[0]["llm"] == "test-sentinel-llm"
+
     def test_read_returns_latest_marker_payload(self, monkeypatch):
         import argparse
 


### PR DESCRIPTION
## Summary

- `_task_progress_set` hand-built the phase-boundary event dict and called `append_event` directly, bypassing the `_build_base` path that resolves `llm` (and `maverick_skill`) for every other write path.
- Phase-boundary rows for dispatch-free phases (Phase 8 "open PR" / "CI green", final Phase 10 "complete") therefore rendered as `claude-code` — the literal `FALLBACK_LLM` — because the render-time inheritance loop in `_rows_for_phase` had no sibling event with an `llm` to copy from.
- Resolve `llm` (and `maverick_skill` for consistency) via the same `_current_llm` / `_current_skill` helpers every other write path uses, before `append_event`.

Closes #98

## Test plan

- [x] New unit test `test_set_stamps_llm_on_phase_boundary_event` asserts the resolver actually runs (uses a distinctive `MAVERICK_LLM` sentinel rather than the baked-in default to rule out a false positive).
- [x] Existing `test_set_writes_marker_with_phase_and_instance_id` still passes.
- [x] `make lint typecheck test` (533 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)