### PR TITLE
feat: wrap Phase 5 implementation in /do-code + /do-test (#100)

### DIFF
--- a/skills/do-issue-solo/SKILL.md
+++ b/skills/do-issue-solo/SKILL.md
@@ -6,7 +6,7 @@ user-invocable: true
 disable-model-invocation: false
 ---
 
-**Depends on:** mav-scope-boundaries, mav-multi-instance-coordination, mav-durability-on-gh, mav-block-propagation, mav-git-workflow, mav-stacked-prs, mav-github-issue-workflow, mav-create-solution-design, mav-create-tasks, mav-plan-execution, mav-local-verification, mav-bp-cicd, mav-bp-remote-code-review, mav-claude-code-recovery, mav-bp-logging, mav-bp-alerting, mav-systematic-debugging, do-docs, do-cybersecurity-review, do-pullrequest-review
+**Depends on:** mav-scope-boundaries, mav-multi-instance-coordination, mav-durability-on-gh, mav-block-propagation, mav-git-workflow, mav-stacked-prs, mav-github-issue-workflow, mav-create-solution-design, mav-create-tasks, mav-plan-execution, mav-local-verification, mav-bp-cicd, mav-bp-remote-code-review, mav-claude-code-recovery, mav-bp-logging, mav-bp-alerting, mav-systematic-debugging, do-code, do-test, do-docs, do-cybersecurity-review, do-pullrequest-review
 
 # Work on GitHub Issue (Autonomous)
 
@@ -177,18 +177,46 @@ This phase has changed. **Push after every task, not at the end.** See
 
 **For each task (sub-issue or checklist item), in order:**
 
-1. Implement the change.
-2. Run local verification per `mav-local-verification` (lint,
-   typecheck, tests).
-3. If verification fails, diagnose per `mav-systematic-debugging`
-   and fix. Do not commit red.
-4. Create a conventional commit referencing the issue number.
-5. **Push immediately**:
+1. **Wrap the implementation in `do-code`** so the workflow
+   report logs a `skill-dispatch` row for the task, and so the project's
+   coding standards (scope, error handling, logging, application
+   security) are pinned before any edit. Open the interval, run the
+   skill, close the interval:
+   ```bash
+   uv run maverick report begin skill-dispatch --issue  \
+       --phase implement --skill-name do-code
+   ```
+   Invoke `/do-code <one-line task description>`. The skill
+   reads before writing, makes the smallest diff that satisfies the
+   task, verifies per `mav-local-verification`, and refuses
+   to return on red. Then:
+   ```bash
+   uv run maverick report end skill-dispatch --issue  \
+       --phase implement --skill-name do-code \
+       --outcome <success|failure>
+   ```
+   On `failure`, halt the per-task loop and diagnose per
+   `mav-systematic-debugging` — do not proceed to the
+   commit step with a failing build or red tests.
+2. **If the change needs new or updated tests and `do-code`
+   did not already cover them**, wrap that work in `do-test`
+   as a sibling dispatch (pick `unit` or `integration` per the change's
+   boundary):
+   ```bash
+   uv run maverick report begin skill-dispatch --issue  \
+       --phase implement --skill-name do-test
+   # Invoke /do-test <unit|integration>
+   uv run maverick report end skill-dispatch --issue  \
+       --phase implement --skill-name do-test \
+       --outcome <success|failure>
+   ```
+3. Create a conventional commit referencing the issue number.
+4. **Push immediately**:
    - If this is the first push on the branch, set upstream:
      `git push -u origin <branch>`.
    - If on a stacked branch, run the retarget check per
      `mav-stacked-prs` **before every push**.
-6. **Log the commit** to the workflow report. SHA and subject come from
+5. **Log the commit** to the workflow report. SHA and subject come from
    git; the timestamp is wall-clock at the moment of this CLI call:
    ```bash
    SHA=$(git rev-parse HEAD)
@@ -196,8 +224,8 @@ This phase has changed. **Push after every task, not at the end.** See
    uv run maverick report commit --issue  \
        --phase implement --sha "$SHA" --subject "$SUBJECT"
    ```
-7. Update the tasks comment (or close the sub-issue).
-8. Heartbeat: `uv run maverick coord heartbeat <repo> ` if it
+6. Update the tasks comment (or close the sub-issue).
+7. Heartbeat: `uv run maverick coord heartbeat <repo> ` if it
    is time for a refresh.
 
 After the last task, run the full verification suite once more.

--- a/src/maverick/skills/do-issue-solo/body.md.j2
+++ b/src/maverick/skills/do-issue-solo/body.md.j2
@@ -170,18 +170,46 @@ This phase has changed. **Push after every task, not at the end.** See
 
 **For each task (sub-issue or checklist item), in order:**
 
-1. Implement the change.
-2. Run local verification per `{{ SKILLS.MAV_LOCAL_VERIFICATION }}` (lint,
-   typecheck, tests).
-3. If verification fails, diagnose per `{{ SKILLS.MAV_SYSTEMATIC_DEBUGGING }}`
-   and fix. Do not commit red.
-4. Create a conventional commit referencing the issue number.
-5. **Push immediately**:
+1. **Wrap the implementation in `{{ SKILLS.DO_CODE }}`** so the workflow
+   report logs a `skill-dispatch` row for the task, and so the project's
+   coding standards (scope, error handling, logging, application
+   security) are pinned before any edit. Open the interval, run the
+   skill, close the interval:
+   ```bash
+   uv run maverick report begin skill-dispatch --issue {{ ARGUMENTS }} \
+       --phase implement --skill-name {{ SKILLS.DO_CODE }}
+   ```
+   Invoke `/{{ SKILLS.DO_CODE }} <one-line task description>`. The skill
+   reads before writing, makes the smallest diff that satisfies the
+   task, verifies per `{{ SKILLS.MAV_LOCAL_VERIFICATION }}`, and refuses
+   to return on red. Then:
+   ```bash
+   uv run maverick report end skill-dispatch --issue {{ ARGUMENTS }} \
+       --phase implement --skill-name {{ SKILLS.DO_CODE }} \
+       --outcome <success|failure>
+   ```
+   On `failure`, halt the per-task loop and diagnose per
+   `{{ SKILLS.MAV_SYSTEMATIC_DEBUGGING }}` — do not proceed to the
+   commit step with a failing build or red tests.
+2. **If the change needs new or updated tests and `{{ SKILLS.DO_CODE }}`
+   did not already cover them**, wrap that work in `{{ SKILLS.DO_TEST }}`
+   as a sibling dispatch (pick `unit` or `integration` per the change's
+   boundary):
+   ```bash
+   uv run maverick report begin skill-dispatch --issue {{ ARGUMENTS }} \
+       --phase implement --skill-name {{ SKILLS.DO_TEST }}
+   # Invoke /{{ SKILLS.DO_TEST }} <unit|integration>
+   uv run maverick report end skill-dispatch --issue {{ ARGUMENTS }} \
+       --phase implement --skill-name {{ SKILLS.DO_TEST }} \
+       --outcome <success|failure>
+   ```
+3. Create a conventional commit referencing the issue number.
+4. **Push immediately**:
    - If this is the first push on the branch, set upstream:
      `git push -u origin <branch>`.
    - If on a stacked branch, run the retarget check per
      `{{ SKILLS.MAV_STACKED_PRS }}` **before every push**.
-6. **Log the commit** to the workflow report. SHA and subject come from
+5. **Log the commit** to the workflow report. SHA and subject come from
    git; the timestamp is wall-clock at the moment of this CLI call:
    ```bash
    SHA=$(git rev-parse HEAD)
@@ -189,8 +217,8 @@ This phase has changed. **Push after every task, not at the end.** See
    uv run maverick report commit --issue {{ ARGUMENTS }} \
        --phase implement --sha "$SHA" --subject "$SUBJECT"
    ```
-7. Update the tasks comment (or close the sub-issue).
-8. Heartbeat: `uv run maverick coord heartbeat <repo> {{ ARGUMENTS }}` if it
+6. Update the tasks comment (or close the sub-issue).
+7. Heartbeat: `uv run maverick coord heartbeat <repo> {{ ARGUMENTS }}` if it
    is time for a refresh.
 
 After the last task, run the full verification suite once more.

--- a/src/maverick/skills/do-issue-solo/config.py
+++ b/src/maverick/skills/do-issue-solo/config.py
@@ -1,9 +1,11 @@
 from maverick.models import SkillConfig
 from maverick.names import (
+    DO_CODE,
     DO_CYBERSECURITY_REVIEW,
     DO_DOCS,
     DO_ISSUE_SOLO,
     DO_PULLREQUEST_REVIEW,
+    DO_TEST,
     MAV_BLOCK_PROPAGATION,
     MAV_BP_ALERTING,
     MAV_BP_CICD,
@@ -49,6 +51,8 @@ CONFIG = SkillConfig(
         MAV_BP_LOGGING,
         MAV_BP_ALERTING,
         MAV_SYSTEMATIC_DEBUGGING,
+        DO_CODE,
+        DO_TEST,
         DO_DOCS,
         DO_CYBERSECURITY_REVIEW,
         DO_PULLREQUEST_REVIEW,


### PR DESCRIPTION
## Summary

- `do-issue-solo` Phase 5 never invoked the `do-code` / `do-test` skills introduced by #95, so a real workflow report had no `skill-dispatch` rows for the implementation work — the schema fields existed but nothing emitted them.
- Phase 5 per-task loop now opens a `skill-dispatch` interval, runs `/do-code`, and closes the interval with `--outcome`. An optional sibling `skill-dispatch` for `do-test` is documented for tests that aren't folded into `do-code`.
- Commit / push / log-commit / tasks-update / heartbeat stay *outside* the dispatch — they are workflow plumbing, not implementation work.
- `DO_CODE` / `DO_TEST` added to `do-issue-solo`'s `depends_on` so the rendered "Depends on:" line surfaces the new dependencies.

Closes #100

## Out of scope

`do-issue-guided` and `do-epic` Phase 5 sections have the same gap. Tracking those separately so this change stays scoped to the report that surfaced the problem.

## Test plan

- [x] `make build` regenerates `skills/do-issue-solo/SKILL.md` with the new wrapping, the new `Depends on:` line, and the new template references resolve cleanly.
- [x] `make lint typecheck test` (532 tests).
- [ ] Run \`/do-issue-solo\` on a real issue and confirm the workflow report's Phase 5 row now contains `skill-dispatch — do-code` (and optionally `do-test`) entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)