### PR TITLE
fix: refresh local base branch before Phase 1 analyst dispatch (#102)

### DIFF
--- a/skills/do-issue-solo/SKILL.md
+++ b/skills/do-issue-solo/SKILL.md
@@ -110,24 +110,43 @@ This phase is new in the workflow overhaul. Before any other phase.
 Run Phases 1 and 2 as a subagent to keep the main context window clean for
 implementation.
 
-1. Initialise the issue state file per the
+1. **Refresh the local base branch** before the analyst reads anything.
+   The analyst runs against the main checkout — Phase 4 hasn't created
+   the worktree yet — so a stale local base lets pre-resolved
+   ambiguities slip into the design pass and surface as phantom
+   blockers (#102). Follow the "Base Branch Freshness" rule in
+   `mav-git-workflow`:
+   ```bash
+   STORY_BASE=$(uv run maverick git-workflow story-base)
+   git fetch origin "$STORY_BASE"
+   CURRENT=$(git rev-parse --abbrev-ref HEAD)
+   if [ "$CURRENT" = "$STORY_BASE" ]; then
+       git pull --ff-only origin "$STORY_BASE"
+   else
+       git fetch origin "$STORY_BASE:$STORY_BASE"
+   fi
+   ```
+   If either form refuses a non-fast-forward, halt and report to the
+   user — there are local commits on `$STORY_BASE` that have not been
+   pushed, which violates trunk-based discipline.
+2. Initialise the issue state file per the
    mav-github-issue-workflow skill.
-2. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue  --phase design --agent agent-issue-analyst --skill-name mav-create-solution-design`.
-3. Dispatch the **agent-issue-analyst** agent with:
+3. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue  --phase design --agent agent-issue-analyst --skill-name mav-create-solution-design`.
+4. Dispatch the **agent-issue-analyst** agent with:
    - Issue number: ``
    - Mode: `solo`
-4. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue  --phase design --agent agent-issue-analyst --skill-name mav-create-solution-design --outcome success`.
+5. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue  --phase design --agent agent-issue-analyst --skill-name mav-create-solution-design --outcome success`.
    (Use `--outcome failure` if the agent returned an error rather than a design.)
-5. When the agent returns, verify:
+6. When the agent returns, verify:
    - `.claude/issue-state.json` has `phase` set to `design`
    - `.claude/issue-state.json` has `comments.design` set to a comment ID
-6. If the agent flagged ambiguities it could not resolve:
+7. If the agent flagged ambiguities it could not resolve:
    - Open the question interval: `uv run maverick report begin question --issue  --phase design --topic ambiguity-resolution`.
    - Ask the user.
    - Close it: `uv run maverick report end question --issue  --phase design --topic ambiguity-resolution --outcome success`.
 
    Otherwise continue.
-7. **Checkpoint**: `uv run maverick task-progress set <repo>  design`.
+8. **Checkpoint**: `uv run maverick task-progress set <repo>  design`.
 
 ## Phase 3: Create Tasks (subagent)
 

--- a/skills/mav-git-workflow/SKILL.md
+++ b/skills/mav-git-workflow/SKILL.md
@@ -226,6 +226,35 @@ This reads `git_workflow.story_base` from `.maverick/config.json`
 (default: `main`). Do not auto-detect or hard-code the branch — the
 config is the single source of truth, written once by `maverick init`.
 
+### Base Branch Freshness (rule)
+
+Any workflow that reads from the main checkout before opening a
+worktree — typically the design / planning subagents in
+`do-issue-solo` / `do-issue-guided` / `do-epic` Phase 1 — must
+refresh the local base branch against origin first. A stale local
+base lets pre-resolved ambiguities slip into the analyst's design
+pass and surfaces as phantom blockers (#102).
+
+The pattern advances the local ref without forcing the user out of
+whatever branch they happen to be on:
+
+```bash
+STORY_BASE=$(uv run maverick git-workflow story-base)
+git fetch origin "$STORY_BASE"
+CURRENT=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT" = "$STORY_BASE" ]; then
+    git pull --ff-only origin "$STORY_BASE"
+else
+    # Update the local ref directly; safe because $STORY_BASE is not the
+    # checked-out branch (git refuses to fetch onto the current branch).
+    git fetch origin "$STORY_BASE:$STORY_BASE"
+fi
+```
+
+Both forms refuse a non-fast-forward — that means the local base has
+commits that are not on origin, which violates trunk-based discipline.
+Halt and report to the user; do not auto-rebase or force-update.
+
 ### Create the Branch
 
 ```bash

--- a/src/maverick/skills/do-issue-solo/body.md.j2
+++ b/src/maverick/skills/do-issue-solo/body.md.j2
@@ -103,24 +103,43 @@ This phase is new in the workflow overhaul. Before any other phase.
 Run Phases 1 and 2 as a subagent to keep the main context window clean for
 implementation.
 
-1. Initialise the issue state file per the
+1. **Refresh the local base branch** before the analyst reads anything.
+   The analyst runs against the main checkout — Phase 4 hasn't created
+   the worktree yet — so a stale local base lets pre-resolved
+   ambiguities slip into the design pass and surface as phantom
+   blockers (#102). Follow the "Base Branch Freshness" rule in
+   `{{ SKILLS.MAV_GIT_WORKFLOW }}`:
+   ```bash
+   STORY_BASE=$(uv run maverick git-workflow story-base)
+   git fetch origin "$STORY_BASE"
+   CURRENT=$(git rev-parse --abbrev-ref HEAD)
+   if [ "$CURRENT" = "$STORY_BASE" ]; then
+       git pull --ff-only origin "$STORY_BASE"
+   else
+       git fetch origin "$STORY_BASE:$STORY_BASE"
+   fi
+   ```
+   If either form refuses a non-fast-forward, halt and report to the
+   user — there are local commits on `$STORY_BASE` that have not been
+   pushed, which violates trunk-based discipline.
+2. Initialise the issue state file per the
    {{ SKILLS.MAV_GITHUB_ISSUE_WORKFLOW }} skill.
-2. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue {{ ARGUMENTS }} --phase design --agent {{ AGENTS.AGENT_ISSUE_ANALYST }} --skill-name {{ SKILLS.MAV_CREATE_SOLUTION_DESIGN }}`.
-3. Dispatch the **{{ AGENTS.AGENT_ISSUE_ANALYST }}** agent with:
+3. Open the agent-dispatch interval: `uv run maverick report begin agent-dispatch --issue {{ ARGUMENTS }} --phase design --agent {{ AGENTS.AGENT_ISSUE_ANALYST }} --skill-name {{ SKILLS.MAV_CREATE_SOLUTION_DESIGN }}`.
+4. Dispatch the **{{ AGENTS.AGENT_ISSUE_ANALYST }}** agent with:
    - Issue number: `{{ ARGUMENTS }}`
    - Mode: `solo`
-4. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue {{ ARGUMENTS }} --phase design --agent {{ AGENTS.AGENT_ISSUE_ANALYST }} --skill-name {{ SKILLS.MAV_CREATE_SOLUTION_DESIGN }} --outcome success`.
+5. Close the agent-dispatch interval: `uv run maverick report end agent-dispatch --issue {{ ARGUMENTS }} --phase design --agent {{ AGENTS.AGENT_ISSUE_ANALYST }} --skill-name {{ SKILLS.MAV_CREATE_SOLUTION_DESIGN }} --outcome success`.
    (Use `--outcome failure` if the agent returned an error rather than a design.)
-5. When the agent returns, verify:
+6. When the agent returns, verify:
    - `.claude/issue-state.json` has `phase` set to `design`
    - `.claude/issue-state.json` has `comments.design` set to a comment ID
-6. If the agent flagged ambiguities it could not resolve:
+7. If the agent flagged ambiguities it could not resolve:
    - Open the question interval: `uv run maverick report begin question --issue {{ ARGUMENTS }} --phase design --topic ambiguity-resolution`.
    - Ask the user.
    - Close it: `uv run maverick report end question --issue {{ ARGUMENTS }} --phase design --topic ambiguity-resolution --outcome success`.
 
    Otherwise continue.
-7. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} design`.
+8. **Checkpoint**: `uv run maverick task-progress set <repo> {{ ARGUMENTS }} design`.
 
 ## Phase 3: Create Tasks (subagent)
 

--- a/src/maverick/skills/mav-git-workflow/body.md.j2
+++ b/src/maverick/skills/mav-git-workflow/body.md.j2
@@ -222,6 +222,35 @@ This reads `git_workflow.story_base` from `.maverick/config.json`
 (default: `main`). Do not auto-detect or hard-code the branch — the
 config is the single source of truth, written once by `maverick init`.
 
+### Base Branch Freshness (rule)
+
+Any workflow that reads from the main checkout before opening a
+worktree — typically the design / planning subagents in
+`do-issue-solo` / `do-issue-guided` / `do-epic` Phase 1 — must
+refresh the local base branch against origin first. A stale local
+base lets pre-resolved ambiguities slip into the analyst's design
+pass and surfaces as phantom blockers (#102).
+
+The pattern advances the local ref without forcing the user out of
+whatever branch they happen to be on:
+
+```bash
+STORY_BASE=$(uv run maverick git-workflow story-base)
+git fetch origin "$STORY_BASE"
+CURRENT=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT" = "$STORY_BASE" ]; then
+    git pull --ff-only origin "$STORY_BASE"
+else
+    # Update the local ref directly; safe because $STORY_BASE is not the
+    # checked-out branch (git refuses to fetch onto the current branch).
+    git fetch origin "$STORY_BASE:$STORY_BASE"
+fi
+```
+
+Both forms refuse a non-fast-forward — that means the local base has
+commits that are not on origin, which violates trunk-based discipline.
+Halt and report to the user; do not auto-rebase or force-update.
+
 ### Create the Branch
 
 ```bash


### PR DESCRIPTION
## Summary

- Phase 1's \`agent-issue-analyst\` runs against the main checkout — Phase 4 hasn't created the worktree yet — so a stale local base branch lets pre-resolved ambiguities slip into the design pass and surface as phantom blockers.
- Add a base-branch freshness step at the top of Phase 1 in \`do-issue-solo\`. The pattern uses \`git fetch origin <base>:<base>\` when the user isn't on the base branch (no forced checkout) and \`git pull --ff-only\` when they are. Both refuse non-fast-forward, so divergent local commits halt cleanly rather than getting silently overwritten.
- Document the rule once in \`mav-git-workflow\` as "Base Branch Freshness" so the other workflows can cite the same source when they adopt it.

Closes #102

## Out of scope

\`do-issue-guided\` and \`do-epic\` have the same gap (their Phase 1 analyst dispatch also reads the main checkout). Tracking those separately so this change stays scoped to the workflow that surfaced the friction.

## Test plan

- [x] \`make build\` regenerates \`skills/do-issue-solo/SKILL.md\` and \`skills/mav-git-workflow/SKILL.md\`.
- [x] \`make lint typecheck test\` (533 tests).
- [ ] Run \`/do-issue-solo\` on a deliberately stale local checkout and confirm the workflow either fast-forwards silently or halts with a clear diagnostic — no phantom analyst ambiguities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)