### PR TITLE
fix: stop /do-* skills from terminating their callers early (#106)

### DIFF
--- a/skills/do-code/SKILL.md
+++ b/skills/do-code/SKILL.md
@@ -88,4 +88,31 @@ maverick-wide best practices.
 - **Stay inside the task envelope.** When `` is
   ambiguous, ask for clarification rather than guess.
 
+## Return Protocol
+
+`do-code` is a **subroutine of the calling workflow's
+per-task loop** — not a terminal action. Returning from this skill is a
+hand-back to the caller's next numbered step, not a completion event
+(#106).
+
+When you return from this skill, **do not** post a closing summary, do
+not stop, do not treat verification-green as "task done." The calling
+workflow's loop still owns, in order:
+
+1. Closing the `skill-dispatch` interval that wrapped this invocation
+   (`uv run maverick report end skill-dispatch … --outcome success`).
+2. Optionally sibling-calling `do-test` for tests that
+   weren't folded into this skill.
+3. Conventional commit referencing the issue number, then push (with
+   stacked-PR retarget if applicable).
+4. Logging the commit row to the workflow report
+   (`uv run maverick report commit …`).
+5. Updating the tasks comment / closing the sub-issue.
+6. Heartbeat refresh.
+
+If you find yourself drafting a final summary after returning here,
+that is the signal: scroll back to the calling workflow's per-task
+loop and resume from the step immediately after the
+`/do-code` invocation.
+
 <!-- maverick-plugin-version: 3.3.5-dev -->

--- a/skills/do-cybersecurity-review/SKILL.md
+++ b/skills/do-cybersecurity-review/SKILL.md
@@ -245,4 +245,31 @@ Update mode produces transient findings, not a snapshot of the whole codebase. W
 - **Defer to mav-bp-application-security** for what "good" looks like in each category. This skill is the audit; that one is the standard.
 - **Follow mav-scope-boundaries** — do not run anything that would modify production systems, change auth/permissions, or take destructive action.
 
+## Return Protocol (update mode)
+
+When invoked from `do-issue-solo` Phase 7 (or any other
+caller) in `update` mode, `do-cybersecurity-review` is a
+**subroutine of the calling workflow** — not a terminal action.
+Returning the structured verdict is a hand-back to the caller's next
+numbered step, not a phase-complete signal (#106).
+
+When you return from this skill, **do not** post a closing summary, do
+not stop. The calling workflow still owns, in order:
+
+1. Closing the `skill-dispatch` interval that wrapped this invocation
+   (`uv run maverick report end skill-dispatch … --outcome <success|failure|blocked>`).
+   The outcome maps from the verdict: `PASS` → `success`,
+   `FINDINGS` → `success` (with the findings folded into the PR body
+   draft), `BLOCKING` → `blocked`.
+2. Acting on the verdict — halting on `BLOCKING`, folding findings
+   into the PR body draft on `FINDINGS`, or recording
+   `Security review: no concerns.` on `PASS`.
+3. Advancing to the next phase (open the PR) once the verdict has
+   been folded in.
+
+If you find yourself drafting a final summary after returning here,
+that is the signal: scroll back to the calling workflow and resume
+from the step immediately after the
+`/do-cybersecurity-review` dispatch.
+
 <!-- maverick-plugin-version: 3.3.5-dev -->

--- a/skills/do-issue-solo/SKILL.md
+++ b/skills/do-issue-solo/SKILL.md
@@ -196,19 +196,23 @@ This phase has changed. **Push after every task, not at the end.** See
 
 **For each task (sub-issue or checklist item), in order:**
 
-1. **Wrap the implementation in `do-code`** so the workflow
-   report logs a `skill-dispatch` row for the task, and so the project's
-   coding standards (scope, error handling, logging, application
-   security) are pinned before any edit. Open the interval, run the
-   skill, close the interval:
+Each step below is its own obligation. After `/do-code` returns
+in step 2, **do not stop** — continue with step 3. The inner skill's
+return is a hand-back, not a task-complete signal (#106).
+
+1. **Open the `skill-dispatch` interval for `do-code`.** This
+   pins the project's coding standards before any edit and gives the
+   workflow report a `skill-dispatch` row for the task:
    ```bash
    uv run maverick report begin skill-dispatch --issue  \
        --phase implement --skill-name do-code
    ```
-   Invoke `/do-code <one-line task description>`. The skill
-   reads before writing, makes the smallest diff that satisfies the
-   task, verifies per `mav-local-verification`, and refuses
-   to return on red. Then:
+2. **Invoke `/do-code <one-line task description>`.** The
+   skill reads before writing, makes the smallest diff that satisfies
+   the task, verifies per `mav-local-verification`, and
+   refuses to return on red. When it returns, proceed to step 3 — do
+   not summarise and stop.
+3. **Close the `skill-dispatch` interval** with the outcome:
    ```bash
    uv run maverick report end skill-dispatch --issue  \
        --phase implement --skill-name do-code \
@@ -217,10 +221,9 @@ This phase has changed. **Push after every task, not at the end.** See
    On `failure`, halt the per-task loop and diagnose per
    `mav-systematic-debugging` — do not proceed to the
    commit step with a failing build or red tests.
-2. **If the change needs new or updated tests and `do-code`
-   did not already cover them**, wrap that work in `do-test`
-   as a sibling dispatch (pick `unit` or `integration` per the change's
-   boundary):
+4. **(Optional) Sibling-dispatch `/do-test`** if the change
+   needs new or updated tests that `do-code` did not
+   already cover. Same three-step shape as above:
    ```bash
    uv run maverick report begin skill-dispatch --issue  \
        --phase implement --skill-name do-test
@@ -229,13 +232,14 @@ This phase has changed. **Push after every task, not at the end.** See
        --phase implement --skill-name do-test \
        --outcome <success|failure>
    ```
-3. Create a conventional commit referencing the issue number.
-4. **Push immediately**:
+   When `/do-test` returns, proceed to step 5.
+5. **Create a conventional commit** referencing the issue number.
+6. **Push immediately.**
    - If this is the first push on the branch, set upstream:
      `git push -u origin <branch>`.
    - If on a stacked branch, run the retarget check per
      `mav-stacked-prs` **before every push**.
-5. **Log the commit** to the workflow report. SHA and subject come from
+7. **Log the commit** to the workflow report. SHA and subject come from
    git; the timestamp is wall-clock at the moment of this CLI call:
    ```bash
    SHA=$(git rev-parse HEAD)
@@ -243,9 +247,9 @@ This phase has changed. **Push after every task, not at the end.** See
    uv run maverick report commit --issue  \
        --phase implement --sha "$SHA" --subject "$SUBJECT"
    ```
-6. Update the tasks comment (or close the sub-issue).
-7. Heartbeat: `uv run maverick coord heartbeat <repo> ` if it
-   is time for a refresh.
+8. **Update the tasks comment** (or close the sub-issue).
+9. **Heartbeat:** `uv run maverick coord heartbeat <repo> ` if
+   it is time for a refresh.
 
 After the last task, run the full verification suite once more.
 
@@ -352,16 +356,25 @@ path. Any changed code AND any code that could be impacted by the
 changes (callers, importers, dependents) must be reviewed by
 `do-cybersecurity-review` before the PR can be opened.
 
-1. Compute the full diff: `git diff origin/<base>...HEAD`.
-2. Open the skill-dispatch interval: `uv run maverick report begin skill-dispatch --issue  --phase security --skill-name do-cybersecurity-review`.
-3. Dispatch the **do-cybersecurity-review** skill with:
+Each step below is its own obligation. After `/do-cybersecurity-review`
+returns in step 3, **do not stop** — continue with step 4. The inner
+skill's return is a hand-back, not a phase-complete signal (#106).
+
+1. **Compute the full diff:** `git diff origin/<base>...HEAD`.
+2. **Open the `skill-dispatch` interval** for the review:
+   `uv run maverick report begin skill-dispatch --issue  --phase security --skill-name do-cybersecurity-review`.
+3. **Dispatch `/do-cybersecurity-review`** with:
    - **Mode:** `update`
    - **Diff:** the output of step 1, passed via stdin or as a file path
    - **Instructions:** review the changed code AND the impact set
      (callers, importers, dependents — bounded to one or two hops).
      Return the structured outcome (verdict + findings) defined in the
      skill's Update Mode contract.
-4. Close the skill-dispatch interval: `uv run maverick report end skill-dispatch --issue  --phase security --skill-name do-cybersecurity-review --outcome <success|failure|blocked>` (use `blocked` if the verdict was BLOCKING).
+
+   When the skill returns, proceed to step 4 — do not summarise and
+   stop.
+4. **Close the `skill-dispatch` interval** with the outcome:
+   `uv run maverick report end skill-dispatch --issue  --phase security --skill-name do-cybersecurity-review --outcome <success|failure|blocked>` (use `blocked` if the verdict was BLOCKING).
 5. **Act on the verdict:**
    - **BLOCKING** — halt. Surface the findings to the user verbatim.
      Do not open the PR. The user resolves the BLOCKING items by

--- a/skills/do-test/SKILL.md
+++ b/skills/do-test/SKILL.md
@@ -114,4 +114,29 @@ fixture lifecycle, isolation strategy, slowness budget).
   seeds, network availability outside the boundary under test, or
   ordering between independent tests.
 
+## Return Protocol
+
+`do-test` is a **subroutine of the calling workflow's
+per-task loop** — not a terminal action. Returning from this skill is a
+hand-back to the caller's next numbered step, not a completion event
+(#106).
+
+When you return from this skill, **do not** post a closing summary, do
+not stop, do not treat green-tests as "task done." The calling
+workflow's loop still owns, in order:
+
+1. Closing the `skill-dispatch` interval that wrapped this invocation
+   (`uv run maverick report end skill-dispatch … --outcome success`).
+2. Conventional commit referencing the issue number, then push (with
+   stacked-PR retarget if applicable).
+3. Logging the commit row to the workflow report
+   (`uv run maverick report commit …`).
+4. Updating the tasks comment / closing the sub-issue.
+5. Heartbeat refresh.
+
+If you find yourself drafting a final summary after returning here,
+that is the signal: scroll back to the calling workflow's per-task
+loop and resume from the step immediately after the
+`/do-test` invocation.
+
 <!-- maverick-plugin-version: 3.3.5-dev -->

--- a/src/maverick/skills/do-code/body.md.j2
+++ b/src/maverick/skills/do-code/body.md.j2
@@ -80,3 +80,30 @@ maverick-wide best practices.
   `{{ SKILLS.DO_TEST }}` as a sibling call before the commit).
 - **Stay inside the task envelope.** When `{{ ARGUMENTS }}` is
   ambiguous, ask for clarification rather than guess.
+
+## Return Protocol
+
+`{{ SKILLS.DO_CODE }}` is a **subroutine of the calling workflow's
+per-task loop** — not a terminal action. Returning from this skill is a
+hand-back to the caller's next numbered step, not a completion event
+(#106).
+
+When you return from this skill, **do not** post a closing summary, do
+not stop, do not treat verification-green as "task done." The calling
+workflow's loop still owns, in order:
+
+1. Closing the `skill-dispatch` interval that wrapped this invocation
+   (`uv run maverick report end skill-dispatch … --outcome success`).
+2. Optionally sibling-calling `{{ SKILLS.DO_TEST }}` for tests that
+   weren't folded into this skill.
+3. Conventional commit referencing the issue number, then push (with
+   stacked-PR retarget if applicable).
+4. Logging the commit row to the workflow report
+   (`uv run maverick report commit …`).
+5. Updating the tasks comment / closing the sub-issue.
+6. Heartbeat refresh.
+
+If you find yourself drafting a final summary after returning here,
+that is the signal: scroll back to the calling workflow's per-task
+loop and resume from the step immediately after the
+`/{{ SKILLS.DO_CODE }}` invocation.

--- a/src/maverick/skills/do-cybersecurity-review/body.md.j2
+++ b/src/maverick/skills/do-cybersecurity-review/body.md.j2
@@ -238,3 +238,30 @@ Update mode produces transient findings, not a snapshot of the whole codebase. W
 - **Be honest about coverage.** If a category requires runtime testing or production data the audit cannot reach, mark it N/A and note what would be needed for a thorough review.
 - **Defer to {{ SKILLS.MAV_BP_APPLICATION_SECURITY }}** for what "good" looks like in each category. This skill is the audit; that one is the standard.
 - **Follow {{ SKILLS.MAV_SCOPE_BOUNDARIES }}** — do not run anything that would modify production systems, change auth/permissions, or take destructive action.
+
+## Return Protocol (update mode)
+
+When invoked from `{{ SKILLS.DO_ISSUE_SOLO }}` Phase 7 (or any other
+caller) in `update` mode, `{{ SKILLS.DO_CYBERSECURITY_REVIEW }}` is a
+**subroutine of the calling workflow** — not a terminal action.
+Returning the structured verdict is a hand-back to the caller's next
+numbered step, not a phase-complete signal (#106).
+
+When you return from this skill, **do not** post a closing summary, do
+not stop. The calling workflow still owns, in order:
+
+1. Closing the `skill-dispatch` interval that wrapped this invocation
+   (`uv run maverick report end skill-dispatch … --outcome <success|failure|blocked>`).
+   The outcome maps from the verdict: `PASS` → `success`,
+   `FINDINGS` → `success` (with the findings folded into the PR body
+   draft), `BLOCKING` → `blocked`.
+2. Acting on the verdict — halting on `BLOCKING`, folding findings
+   into the PR body draft on `FINDINGS`, or recording
+   `Security review: no concerns.` on `PASS`.
+3. Advancing to the next phase (open the PR) once the verdict has
+   been folded in.
+
+If you find yourself drafting a final summary after returning here,
+that is the signal: scroll back to the calling workflow and resume
+from the step immediately after the
+`/{{ SKILLS.DO_CYBERSECURITY_REVIEW }}` dispatch.

--- a/src/maverick/skills/do-issue-solo/body.md.j2
+++ b/src/maverick/skills/do-issue-solo/body.md.j2
@@ -189,19 +189,23 @@ This phase has changed. **Push after every task, not at the end.** See
 
 **For each task (sub-issue or checklist item), in order:**
 
-1. **Wrap the implementation in `{{ SKILLS.DO_CODE }}`** so the workflow
-   report logs a `skill-dispatch` row for the task, and so the project's
-   coding standards (scope, error handling, logging, application
-   security) are pinned before any edit. Open the interval, run the
-   skill, close the interval:
+Each step below is its own obligation. After `/{{ SKILLS.DO_CODE }}` returns
+in step 2, **do not stop** — continue with step 3. The inner skill's
+return is a hand-back, not a task-complete signal (#106).
+
+1. **Open the `skill-dispatch` interval for `{{ SKILLS.DO_CODE }}`.** This
+   pins the project's coding standards before any edit and gives the
+   workflow report a `skill-dispatch` row for the task:
    ```bash
    uv run maverick report begin skill-dispatch --issue {{ ARGUMENTS }} \
        --phase implement --skill-name {{ SKILLS.DO_CODE }}
    ```
-   Invoke `/{{ SKILLS.DO_CODE }} <one-line task description>`. The skill
-   reads before writing, makes the smallest diff that satisfies the
-   task, verifies per `{{ SKILLS.MAV_LOCAL_VERIFICATION }}`, and refuses
-   to return on red. Then:
+2. **Invoke `/{{ SKILLS.DO_CODE }} <one-line task description>`.** The
+   skill reads before writing, makes the smallest diff that satisfies
+   the task, verifies per `{{ SKILLS.MAV_LOCAL_VERIFICATION }}`, and
+   refuses to return on red. When it returns, proceed to step 3 — do
+   not summarise and stop.
+3. **Close the `skill-dispatch` interval** with the outcome:
    ```bash
    uv run maverick report end skill-dispatch --issue {{ ARGUMENTS }} \
        --phase implement --skill-name {{ SKILLS.DO_CODE }} \
@@ -210,10 +214,9 @@ This phase has changed. **Push after every task, not at the end.** See
    On `failure`, halt the per-task loop and diagnose per
    `{{ SKILLS.MAV_SYSTEMATIC_DEBUGGING }}` — do not proceed to the
    commit step with a failing build or red tests.
-2. **If the change needs new or updated tests and `{{ SKILLS.DO_CODE }}`
-   did not already cover them**, wrap that work in `{{ SKILLS.DO_TEST }}`
-   as a sibling dispatch (pick `unit` or `integration` per the change's
-   boundary):
+4. **(Optional) Sibling-dispatch `/{{ SKILLS.DO_TEST }}`** if the change
+   needs new or updated tests that `{{ SKILLS.DO_CODE }}` did not
+   already cover. Same three-step shape as above:
    ```bash
    uv run maverick report begin skill-dispatch --issue {{ ARGUMENTS }} \
        --phase implement --skill-name {{ SKILLS.DO_TEST }}
@@ -222,13 +225,14 @@ This phase has changed. **Push after every task, not at the end.** See
        --phase implement --skill-name {{ SKILLS.DO_TEST }} \
        --outcome <success|failure>
    ```
-3. Create a conventional commit referencing the issue number.
-4. **Push immediately**:
+   When `/{{ SKILLS.DO_TEST }}` returns, proceed to step 5.
+5. **Create a conventional commit** referencing the issue number.
+6. **Push immediately.**
    - If this is the first push on the branch, set upstream:
      `git push -u origin <branch>`.
    - If on a stacked branch, run the retarget check per
      `{{ SKILLS.MAV_STACKED_PRS }}` **before every push**.
-5. **Log the commit** to the workflow report. SHA and subject come from
+7. **Log the commit** to the workflow report. SHA and subject come from
    git; the timestamp is wall-clock at the moment of this CLI call:
    ```bash
    SHA=$(git rev-parse HEAD)
@@ -236,9 +240,9 @@ This phase has changed. **Push after every task, not at the end.** See
    uv run maverick report commit --issue {{ ARGUMENTS }} \
        --phase implement --sha "$SHA" --subject "$SUBJECT"
    ```
-6. Update the tasks comment (or close the sub-issue).
-7. Heartbeat: `uv run maverick coord heartbeat <repo> {{ ARGUMENTS }}` if it
-   is time for a refresh.
+8. **Update the tasks comment** (or close the sub-issue).
+9. **Heartbeat:** `uv run maverick coord heartbeat <repo> {{ ARGUMENTS }}` if
+   it is time for a refresh.
 
 After the last task, run the full verification suite once more.
 
@@ -345,16 +349,25 @@ path. Any changed code AND any code that could be impacted by the
 changes (callers, importers, dependents) must be reviewed by
 `{{ SKILLS.DO_CYBERSECURITY_REVIEW }}` before the PR can be opened.
 
-1. Compute the full diff: `git diff origin/<base>...HEAD`.
-2. Open the skill-dispatch interval: `uv run maverick report begin skill-dispatch --issue {{ ARGUMENTS }} --phase security --skill-name {{ SKILLS.DO_CYBERSECURITY_REVIEW }}`.
-3. Dispatch the **{{ SKILLS.DO_CYBERSECURITY_REVIEW }}** skill with:
+Each step below is its own obligation. After `/{{ SKILLS.DO_CYBERSECURITY_REVIEW }}`
+returns in step 3, **do not stop** — continue with step 4. The inner
+skill's return is a hand-back, not a phase-complete signal (#106).
+
+1. **Compute the full diff:** `git diff origin/<base>...HEAD`.
+2. **Open the `skill-dispatch` interval** for the review:
+   `uv run maverick report begin skill-dispatch --issue {{ ARGUMENTS }} --phase security --skill-name {{ SKILLS.DO_CYBERSECURITY_REVIEW }}`.
+3. **Dispatch `/{{ SKILLS.DO_CYBERSECURITY_REVIEW }}`** with:
    - **Mode:** `update`
    - **Diff:** the output of step 1, passed via stdin or as a file path
    - **Instructions:** review the changed code AND the impact set
      (callers, importers, dependents — bounded to one or two hops).
      Return the structured outcome (verdict + findings) defined in the
      skill's Update Mode contract.
-4. Close the skill-dispatch interval: `uv run maverick report end skill-dispatch --issue {{ ARGUMENTS }} --phase security --skill-name {{ SKILLS.DO_CYBERSECURITY_REVIEW }} --outcome <success|failure|blocked>` (use `blocked` if the verdict was BLOCKING).
+
+   When the skill returns, proceed to step 4 — do not summarise and
+   stop.
+4. **Close the `skill-dispatch` interval** with the outcome:
+   `uv run maverick report end skill-dispatch --issue {{ ARGUMENTS }} --phase security --skill-name {{ SKILLS.DO_CYBERSECURITY_REVIEW }} --outcome <success|failure|blocked>` (use `blocked` if the verdict was BLOCKING).
 5. **Act on the verdict:**
    - **BLOCKING** — halt. Surface the findings to the user verbatim.
      Do not open the PR. The user resolves the BLOCKING items by

--- a/src/maverick/skills/do-test/body.md.j2
+++ b/src/maverick/skills/do-test/body.md.j2
@@ -106,3 +106,28 @@ fixture lifecycle, isolation strategy, slowness budget).
 - **Tests must be deterministic.** No reliance on system time, random
   seeds, network availability outside the boundary under test, or
   ordering between independent tests.
+
+## Return Protocol
+
+`{{ SKILLS.DO_TEST }}` is a **subroutine of the calling workflow's
+per-task loop** — not a terminal action. Returning from this skill is a
+hand-back to the caller's next numbered step, not a completion event
+(#106).
+
+When you return from this skill, **do not** post a closing summary, do
+not stop, do not treat green-tests as "task done." The calling
+workflow's loop still owns, in order:
+
+1. Closing the `skill-dispatch` interval that wrapped this invocation
+   (`uv run maverick report end skill-dispatch … --outcome success`).
+2. Conventional commit referencing the issue number, then push (with
+   stacked-PR retarget if applicable).
+3. Logging the commit row to the workflow report
+   (`uv run maverick report commit …`).
+4. Updating the tasks comment / closing the sub-issue.
+5. Heartbeat refresh.
+
+If you find yourself drafting a final summary after returning here,
+that is the signal: scroll back to the calling workflow's per-task
+loop and resume from the step immediately after the
+`/{{ SKILLS.DO_TEST }}` invocation.


### PR DESCRIPTION
## Summary

A real \`do-issue-solo\` run (post-#101) exited after \`/do-code\` returned, skipping the rest of Phase 5's per-task loop. The affected session's own diagnosis: the Skill tool injects a long block of inner-skill instructions that displaces the outer workflow context, and the orchestrator conflates \"skill returned successfully\" with \"task complete.\"

Two complementary prompt-level fixes, template-only, no CLI changes:

- **\`do-issue-solo\` Phase 5 per-task loop** is restructured so each of \`open-interval\` / \`invoke\` / \`close-interval\` / \`commit\` / \`push\` / \`log\` / \`tasks\` / \`heartbeat\` is its own top-level numbered step. The loop preamble explicitly says *\"after /do-code returns, do not stop — continue with step 3.\"* Phase 7's \`/do-cybersecurity-review\` wrap site gets the same one-action-per-step pass.
- **\`/do-code\`, \`/do-test\`, \`/do-cybersecurity-review\`** each get a \`## Return Protocol\` section appended as the body's final section. Each section names the caller's still-pending obligations explicitly and tells the model *\"if you find yourself drafting a final summary, scroll back and resume from the step after the invocation.\"*

Closes #106

## Out of scope (tracked separately)

- Moving \`begin/end\` into skill bodies (the \"self-instrumenting\" option).
- \`MAVERICK_ISSUE\` env plumbing or any new CLI subcommand.
- \`do-issue-guided\` / \`do-epic\` Phase 5 — neither wraps in \`/do-code\` today.

## Test plan

- [x] \`make build\` regenerates the four \`SKILL.md\` files cleanly.
- [x] \`make lint typecheck test\` (533 tests).
- [ ] Run \`/do-issue-solo\` on a real issue and confirm the workflow report's Phase 5 contains a closed \`skill-dispatch — do-code\` interval, plus the commit row, plus the \`task-progress\` advance. The early-exit symptom (open interval at \`report verify\` time, no commit, no checkpoint advance) should not recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)