### PR TITLE
fix: make workflow report LLM column reflect reality, not assertions (#108)

### DIFF
--- a/agents/agent-github-issue-planner.md
+++ b/agents/agent-github-issue-planner.md
@@ -1,6 +1,7 @@
 ---
 name: agent-github-issue-planner
 description: Takes a solution design and produces an ordered task list. Dispatched by do-issue-solo and do-issue-guided as a subagent so that planning does not consume the caller's context window.
+model: sonnet
 color: green
 skills:
   - mav-github-issue-workflow

--- a/agents/agent-maverick.md
+++ b/agents/agent-maverick.md
@@ -1,6 +1,7 @@
 ---
 name: agent-maverick
 description: Handles Maverick plugin and CLI management — installation, project initialisation, and configuration. Dispatched so that CLI internals don't consume the caller's context.
+model: sonnet
 color: magenta
 skills:
   - do-init

--- a/src/maverick/agents/agent-github-issue-planner/config.py
+++ b/src/maverick/agents/agent-github-issue-planner/config.py
@@ -12,6 +12,7 @@ CONFIG = AgentConfig(
         """Takes a solution design and produces an ordered task list. Dispatched by do-issue-solo and do-issue-guided as a subagent so that planning does not consume the caller's context window."""
     ),
     color="green",
+    model="sonnet",
     skills=[
         MAV_GITHUB_ISSUE_WORKFLOW,
         MAV_CREATE_TASKS,

--- a/src/maverick/agents/agent-maverick/config.py
+++ b/src/maverick/agents/agent-maverick/config.py
@@ -9,6 +9,7 @@ CONFIG = AgentConfig(
         " consume the caller's context."
     ),
     color="magenta",
+    model="sonnet",
     skills=[
         DO_INIT,
         DO_INSTALL,

--- a/src/maverick/config.py
+++ b/src/maverick/config.py
@@ -315,27 +315,23 @@ CONFIG_DEFAULTS: MaverickConfig = {
     "llm": {
         # Default model for any row not matched by a more specific
         # rule. Opus is the safe default — reasoning-heavy work expects
-        # it. Repos that want to economise can drop this to Sonnet.
+        # it. Set per-user in ~/.maverick/config.json's `llm.default`,
+        # or per-repo in .maverick/config.json (repo overrides user).
         "default": "claude-opus-4-7",
-        # Per-agent overrides. Reasoning-heavy agents (issue-analyst,
-        # code-reviewer) fall through to `default` (Opus). Agents that
-        # mostly follow patterns are pinned to Sonnet so they're cheap
-        # by default; override per-repo in .maverick/config.json's
-        # `llm.agents` block.
-        "agents": {
-            "agent-github-issue-planner": "claude-sonnet-4-6",
-            "agent-tech-docs-writer": "claude-sonnet-4-6",
-            "agent-maverick": "claude-sonnet-4-6",
-            "agent-session-reviewer": "claude-sonnet-4-6",
-        },
-        # Per-skill overrides. Reasoning-heavy skills (do-code,
-        # do-cybersecurity-review) fall through to `default` (Opus).
-        # Pattern-following skills are pinned to Sonnet.
-        "skills": {
-            "do-test": "claude-sonnet-4-6",
-            "do-docs": "claude-sonnet-4-6",
-            "do-tech-docs": "claude-sonnet-4-6",
-        },
+        # Per-agent overrides are intentionally empty: the source of
+        # truth for an agent's model is its AgentConfig.model field
+        # (rendered into the agent's frontmatter), NOT a presumption
+        # table on the consumer side (#108). The CLI reads each agent's
+        # pinned model from the registry; this map only matters when a
+        # user/repo explicitly forces an override.
+        "agents": {},
+        # Per-skill overrides are intentionally empty: skills are
+        # instruction blocks loaded into the orchestrator's session,
+        # not separate dispatch units. They cannot run on a different
+        # model from the orchestrator (#108). The CLI ignores this map
+        # at resolution time; it remains here for backward compatibility
+        # with existing config files that wrote into it.
+        "skills": {},
     },
 }
 
@@ -662,37 +658,47 @@ def _default_llm() -> LlmConfig:
     }
 
 
+def _merge_llm_block(result: LlmConfig, block: dict[str, Any]) -> None:
+    """Deep-merge a single ``llm`` block over ``result`` in place."""
+    if isinstance(block.get("default"), str) and block["default"]:
+        result["default"] = block["default"]
+    for sub in ("agents", "skills"):
+        user_map = block.get(sub)
+        if isinstance(user_map, dict):
+            for k, v in user_map.items():
+                if isinstance(k, str) and isinstance(v, str):
+                    result[sub][k] = v  # type: ignore[literal-required]
+
+
 def read_llm_config(path: Path | None = None) -> LlmConfig:
-    """Read the llm block from the project config, deep-merged over defaults.
+    """Read the llm block, deep-merged in order: defaults → user → repo.
 
-    Returns Maverick's baked-in defaults if the file does not exist or has
-    no ``llm`` block. Per-repo overrides:
+    Merge order (later wins):
 
-    - ``default``: if set, replaces the Maverick default.
-    - ``agents``: deep-merged — repo entries override Maverick entries by
-      key, but Maverick entries the repo doesn't mention stay in effect.
-    - ``skills``: same deep-merge semantics.
+    1. Maverick's baked-in defaults (``CONFIG_DEFAULTS["llm"]``).
+    2. User-level config at ``~/.maverick/config.json`` (``llm`` block).
+    3. Repo-level config at ``.maverick/config.json`` (``llm`` block).
 
-    To **fully replace** the agents or skills map (e.g. "this repo uses
-    only Opus, no per-agent overrides"), the repo writes an empty dict:
-    ``"agents": {}`` ― deep-merge over an empty user dict still applies
-    Maverick defaults, so use ``{"agent-foo": ""}`` to suppress a single
-    Maverick default, or write ``llm.default`` only and accept that the
-    Maverick per-agent map continues to apply.
+    Each layer is deep-merged: ``default`` is replaced if present;
+    ``agents`` / ``skills`` entries override by key, leaving keys not
+    mentioned at the earlier layer intact.
+
+    For agents, the **source of truth** for which model an agent runs on
+    is the agent's own ``AgentConfig.model`` field (rendered into its
+    frontmatter), not this map. The map exists only so that a
+    user/repo can force a different model identifier for the report
+    (#108).
     """
     target = path or project_config_path()
-    raw = _load_json(target)
-    block = raw.get("llm") if isinstance(raw, dict) else None
+    repo_raw = _load_json(target)
+    user_raw = _load_json(SYSTEM_CONFIG_FILE) if SYSTEM_CONFIG_FILE.exists() else {}
     result = _default_llm()
-    if isinstance(block, dict):
-        if isinstance(block.get("default"), str) and block["default"]:
-            result["default"] = block["default"]
-        for sub in ("agents", "skills"):
-            user_map = block.get(sub)
-            if isinstance(user_map, dict):
-                for k, v in user_map.items():
-                    if isinstance(k, str) and isinstance(v, str):
-                        result[sub][k] = v  # type: ignore[literal-required]
+    user_block = user_raw.get("llm") if isinstance(user_raw, dict) else None
+    if isinstance(user_block, dict):
+        _merge_llm_block(result, user_block)
+    repo_block = repo_raw.get("llm") if isinstance(repo_raw, dict) else None
+    if isinstance(repo_block, dict):
+        _merge_llm_block(result, repo_block)
     return result
 
 

--- a/src/maverick/report_cli.py
+++ b/src/maverick/report_cli.py
@@ -463,6 +463,39 @@ def _current_skill(issue: int, repo_root: Path | None = None) -> str | None:
     return None
 
 
+_AGENT_MODEL_CACHE: dict[str, str | None] | None = None
+
+
+def _agent_pinned_model(agent: str) -> str | None:
+    """Look up an agent's pinned ``model`` from its AgentConfig.
+
+    Returns the generation label (``"claude-sonnet"``/``"claude-opus"``/
+    ``"claude-haiku"``) for agents whose config.py sets a ``model`` pin,
+    or ``None`` if the agent inherits its model from the orchestrator.
+
+    The registry's discovery scan is cached on first call; subsequent
+    lookups are dict reads. Plugin agents are static at runtime, so a
+    cache miss only happens on the very first event written per process.
+
+    A best-effort fallback: any exception during discovery (missing
+    template dir on an unusual install, broken config.py during a
+    bisect, etc.) returns ``None`` so the caller falls through to the
+    orchestrator's model rather than crashing the write.
+    """
+    global _AGENT_MODEL_CACHE
+    if _AGENT_MODEL_CACHE is None:
+        try:
+            from maverick.registry import discover_agents
+
+            _AGENT_MODEL_CACHE = {
+                cfg.name: (f"claude-{cfg.model}" if cfg.model else None)
+                for cfg in discover_agents()
+            }
+        except Exception:  # noqa: BLE001 — best-effort
+            _AGENT_MODEL_CACHE = {}
+    return _AGENT_MODEL_CACHE.get(agent)
+
+
 def _current_llm(
     explicit: str | None = None,
     issue: int | None = None,
@@ -473,19 +506,27 @@ def _current_llm(
     """Resolve the LLM identifier for a row being written.
 
     Resolution chain, in priority order:
+
     1. Explicit ``--llm`` on the CLI call.
     2. ``MAVERICK_LLM`` env var (workflow-wide override).
-    3. Per-agent entry in the project ``llm.agents`` config block.
-    4. Per-skill entry in the project ``llm.skills`` config block.
-    5. Project ``llm.default``.
-    6. Latest ``run-start`` row's ``llm`` for this issue (inherits across
-       CLI invocations even if the orchestrator never opened the project
-       config — useful for one-off runs).
+    3. **Agent rows only:** explicit per-agent override in the merged
+       ``llm.agents`` config block (user or repo), if present.
+    4. **Agent rows only:** the agent's own pinned model from its
+       ``AgentConfig.model`` field. This is the source of truth — the
+       same value that gets rendered into the agent's frontmatter and
+       therefore the same generation Claude Code actually dispatches.
+    5. ``llm.default`` from the merged config (defaults → user → repo).
+    6. Latest ``run-start`` row's ``llm`` for this issue (inherits
+       across CLI invocations even if the orchestrator never opened
+       the project config — useful for one-off runs).
     7. The ``FALLBACK_LLM`` literal.
 
-    The project config (3-5) is deep-merged over Maverick's built-in
-    defaults at load time, so reasonable values are always present even
-    without an ``llm`` block in ``.maverick/config.json``.
+    ``skill_name`` is accepted for API compatibility but no longer
+    drives resolution: skills are instruction blocks loaded into the
+    orchestrator's session and cannot run on a different model from it
+    (#108). Skill-dispatch rows therefore land in step 5 (orchestrator
+    default) unless an explicit per-skill override is set in the
+    config's ``llm.skills`` block.
     """
     import os as _os
 
@@ -501,13 +542,18 @@ def _current_llm(
     except Exception:  # noqa: BLE001 — best-effort; fall through on any error
         llm_cfg = None
 
-    if llm_cfg is not None:
-        if agent and agent in llm_cfg["agents"]:
+    if agent:
+        if llm_cfg is not None and agent in llm_cfg["agents"]:
             return llm_cfg["agents"][agent]
-        if skill_name and skill_name in llm_cfg["skills"]:
-            return llm_cfg["skills"][skill_name]
-        if llm_cfg["default"]:
-            return llm_cfg["default"]
+        pinned = _agent_pinned_model(agent)
+        if pinned:
+            return pinned
+
+    if skill_name and llm_cfg is not None and skill_name in llm_cfg["skills"]:
+        return llm_cfg["skills"][skill_name]
+
+    if llm_cfg is not None and llm_cfg["default"]:
+        return llm_cfg["default"]
 
     if issue is not None:
         try:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -374,6 +374,81 @@ class TestGitWorkflowConfig:
         assert all("git_workflow" not in e for e in errors)
 
 
+class TestReadLlmConfig:
+    """#108: llm config merges defaults → user → repo (later wins).
+
+    User-level config (`~/.maverick/config.json` `llm`) was previously
+    ignored; repo could override defaults but the user-level layer
+    didn't exist. The merge also drops the hardcoded per-agent /
+    per-skill presumption tables — those defaults are now empty dicts.
+    """
+
+    def _stage(self, tmp_path: Path, monkeypatch, user: dict | None, repo: dict | None):
+        project_dir = tmp_path / ".maverick"
+        if repo is not None:
+            project_dir.mkdir(parents=True, exist_ok=True)
+            (project_dir / "config.json").write_text(json.dumps({"llm": repo}))
+        monkeypatch.setattr(config, "PROJECT_CONFIG_DIR", project_dir)
+        system_cfg = tmp_path / "system_config.json"
+        if user is not None:
+            system_cfg.write_text(json.dumps({"llm": user}))
+        monkeypatch.setattr(config, "SYSTEM_CONFIG_FILE", system_cfg)
+
+    def test_defaults_when_neither_user_nor_repo_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        self._stage(tmp_path, monkeypatch, user=None, repo=None)
+        cfg = config.read_llm_config()
+        assert cfg["default"] == "claude-opus-4-7"
+        # Per-agent / per-skill presumption tables are intentionally empty.
+        assert cfg["agents"] == {}
+        assert cfg["skills"] == {}
+
+    def test_user_overrides_default_when_no_repo(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        self._stage(
+            tmp_path, monkeypatch,
+            user={"default": "claude-sonnet-4-7"},
+            repo=None,
+        )
+        assert config.read_llm_config()["default"] == "claude-sonnet-4-7"
+
+    def test_repo_overrides_user(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        self._stage(
+            tmp_path, monkeypatch,
+            user={"default": "claude-sonnet-4-7"},
+            repo={"default": "claude-haiku-4-5"},
+        )
+        assert config.read_llm_config()["default"] == "claude-haiku-4-5"
+
+    def test_user_agents_kept_when_repo_overrides_default_only(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """User sets an agent override; repo only touches `default`.
+        The user's agent entry survives the merge."""
+        self._stage(
+            tmp_path, monkeypatch,
+            user={"agents": {"agent-foo": "claude-sonnet-4-6"}},
+            repo={"default": "claude-haiku-4-5"},
+        )
+        cfg = config.read_llm_config()
+        assert cfg["default"] == "claude-haiku-4-5"
+        assert cfg["agents"] == {"agent-foo": "claude-sonnet-4-6"}
+
+    def test_repo_agent_overrides_user_agent_by_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        self._stage(
+            tmp_path, monkeypatch,
+            user={"agents": {"agent-foo": "claude-sonnet-4-6"}},
+            repo={"agents": {"agent-foo": "claude-opus-4-7"}},
+        )
+        assert config.read_llm_config()["agents"]["agent-foo"] == "claude-opus-4-7"
+
+
 class TestSaveConfig:
     def test_creates_dir_and_writes(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         cfg_dir = tmp_path / "new_dir"

--- a/tests/unit/test_report_cli.py
+++ b/tests/unit/test_report_cli.py
@@ -322,6 +322,10 @@ class TestLLMResolution:
         monkeypatch.setattr(report_cli, "_main_repo_root", lambda cwd=None: tmp_path)
         monkeypatch.setenv("MAVERICK_INSTANCE_ID", "test1234ab")
         monkeypatch.delenv("MAVERICK_LLM", raising=False)
+        # Isolate the agent-model cache so registry discovery never leaks
+        # between tests. Tests that need a populated cache monkeypatch
+        # this themselves.
+        monkeypatch.setattr(report_cli, "_AGENT_MODEL_CACHE", {})
 
     def _patch_config(self, monkeypatch, **overrides):
         """Replace `read_llm_config` with a fixture that returns the given values."""
@@ -431,6 +435,61 @@ class TestLLMResolution:
             repo_root=tmp_path,
         )
         assert report_cli._current_llm(issue=321, repo_root=tmp_path) == "claude-opus-4-7"
+
+    def test_agent_frontmatter_pin_is_used_when_no_config_override(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """#108: source of truth for an agent's model is its AgentConfig.model
+        pin (rendered into frontmatter), not a presumption table. When config
+        has no explicit override for this agent, the registry's pin wins over
+        the orchestrator default."""
+        self._setup(tmp_path, monkeypatch)
+        self._patch_config(monkeypatch, default="claude-opus-4-7", agents={})
+        # Force the cache so the test doesn't depend on real discovery.
+        monkeypatch.setattr(
+            report_cli, "_AGENT_MODEL_CACHE",
+            {"agent-tech-docs-writer": "claude-sonnet", "agent-issue-analyst": None},
+        )
+        # Agent with a pin in its frontmatter → its generation label.
+        assert (
+            report_cli._current_llm(agent="agent-tech-docs-writer")
+            == "claude-sonnet"
+        )
+        # Agent without a pin → falls through to orchestrator's default.
+        assert (
+            report_cli._current_llm(agent="agent-issue-analyst") == "claude-opus-4-7"
+        )
+
+    def test_config_per_agent_override_beats_frontmatter_pin(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """User/repo can still force a specific model for an agent — that
+        beats the frontmatter pin (which is only the generation label)."""
+        self._setup(tmp_path, monkeypatch)
+        self._patch_config(
+            monkeypatch,
+            default="claude-opus-4-7",
+            agents={"agent-tech-docs-writer": "claude-sonnet-4-7"},
+        )
+        monkeypatch.setattr(
+            report_cli, "_AGENT_MODEL_CACHE",
+            {"agent-tech-docs-writer": "claude-sonnet"},
+        )
+        assert (
+            report_cli._current_llm(agent="agent-tech-docs-writer")
+            == "claude-sonnet-4-7"
+        )
+
+    def test_skill_name_alone_does_not_drive_resolution(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """#108: skills are instruction blocks in the orchestrator's session.
+        Without an explicit `llm.skills` override, a skill_name argument has
+        no effect — the row records the orchestrator's default."""
+        self._setup(tmp_path, monkeypatch)
+        self._patch_config(monkeypatch, default="claude-opus-4-7", skills={})
+        assert report_cli._current_llm(skill_name="do-code") == "claude-opus-4-7"
+        assert report_cli._current_llm(skill_name="do-test") == "claude-opus-4-7"
 
     def test_writer_auto_populates_llm_on_every_row(
         self, tmp_path: Path, monkeypatch


### PR DESCRIPTION
## Summary

The LLM column in the workflow report was a config lookup, not telemetry. A real run on Maverick 3.3.3 surfaced \`claude-sonnet-4-6\` for \`agent-github-issue-planner\`, but the agent had no \`model:\` pin and actually inherited Opus 4.7 from the orchestrator. \`CONFIG_DEFAULTS\` and reality disagreed; the report believed the table.

Three coupled changes — addresses both halves of the user's request:

### 1. Source of truth = agent frontmatter (deterministic, no presumption)
\`_current_llm\` now reads each agent's pinned \`AgentConfig.model\` from \`registry.discover_agents()\` (cached). When the agent has a pin, the report records the generation label (\`claude-sonnet\` etc.); when the agent inherits, the report falls through to the orchestrator's default. The hardcoded \`CONFIG_DEFAULTS[\"llm\"][\"agents\"]\` presumption table is emptied — explicit user/repo overrides still win when set, but baseline presumptions no longer fabricate data.

### 2. Skills drop out of the resolution chain
Skills are instruction blocks loaded into the orchestrator's session. They cannot run on a different model from the orchestrator's, so the previous per-skill presumptions were guaranteed to disagree with reality. Skill-dispatch rows now record the orchestrator's default unless a user/repo explicitly forces a per-skill override (kept for back-compat; the default \`llm.skills\` table is empty).

### 3. \`read_llm_config\` merges defaults → user → repo
The user-level config layer (\`~/.maverick/config.json\` \`llm\` block) was previously ignored — only the repo layer was consulted. Repo still wins, but user-level overrides now work as the user requested.

### Plus: pin two agents that the baseline table presumed Sonnet
\`agent-github-issue-planner\` and \`agent-maverick\` get \`model=\"sonnet\"\` in their \`AgentConfig\`. The baseline's presumption was they ran on Sonnet for cost; making the pin physical aligns the agents with the report (and with the existing \`agent-tech-docs-writer\` / \`agent-session-reviewer\` pattern).

Closes #108

## Test plan

- [x] 8 new unit tests cover the new resolution paths (\`TestReadLlmConfig\` + new \`TestLLMResolution\` cases). 541 total pass.
- [x] \`make build\` regenerates \`agents/agent-github-issue-planner.md\` and \`agents/agent-maverick.md\` with \`model: sonnet\` in their frontmatter.
- [x] \`make lint typecheck test\` green.
- [ ] Run \`/do-issue-solo\` on a real issue; verify the Phase 3 row records \`claude-sonnet\` and Phase 5 \`skill-dispatch\` rows record the orchestrator's model (not a presumed value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)