### PR TITLE
fix: honour git_workflow.story_base in worktree create (#112)

### DIFF
--- a/src/maverick/worktree.py
+++ b/src/maverick/worktree.py
@@ -12,7 +12,7 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
-from . import config
+from . import config, git_workflow
 
 WORKTREE_ROOT = Path(".maverick/worktrees")
 
@@ -56,10 +56,13 @@ def default_branch() -> str:
 
 def create(branch: str, base: str | None = None) -> Worktree:
     """Create a worktree at `.maverick/worktrees/<branch>` on a new branch
-    off `base` (default: the repo's default branch).
+    off `base`. When `base` is omitted, the project's configured
+    ``git_workflow.story_base`` wins (so Gitflow repos branch from
+    ``develop`` rather than ``origin/HEAD``); falls back to the repo's
+    default branch only if no story_base resolves.
     """
     if base is None:
-        base = default_branch()
+        base = git_workflow.get_story_base() or default_branch()
     # Refresh base so we branch off the tip of origin/<base>
     _git("fetch", "origin", base)
     root = repo_root()

--- a/tests/unit/test_worktree_create.py
+++ b/tests/unit/test_worktree_create.py
@@ -1,0 +1,81 @@
+"""Tests for ``maverick.worktree.create`` — base-branch resolution.
+
+Covers the fix for #112: when no ``base`` is passed, ``create`` must
+honour the project's configured ``git_workflow.story_base`` rather
+than silently branching off ``origin/HEAD``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from maverick import worktree
+
+
+def _stub_git_factory(captured: list[tuple[tuple[str, ...], Path | None]]):
+    """Build a stub for ``worktree._git`` that records calls and returns
+    a HEAD-like SHA when asked, otherwise an empty string.
+    """
+
+    def _stub(*args: str, cwd: Path | None = None) -> str:
+        captured.append((args, cwd))
+        if args[:2] == ("rev-parse", "HEAD"):
+            return "deadbeef\n"
+        return ""
+
+    return _stub
+
+
+class TestCreateBaseResolution:
+    """``create()`` should prefer the configured story_base over the
+    repo's default branch when no ``base`` argument is supplied.
+    """
+
+    def test_uses_configured_story_base_when_no_base_passed(
+        self, tmp_path: Path
+    ) -> None:
+        calls: list[tuple[tuple[str, ...], Path | None]] = []
+        with patch.object(worktree, "_git", side_effect=_stub_git_factory(calls)), \
+            patch.object(worktree, "repo_root", return_value=tmp_path), \
+            patch.object(worktree, "_run_post_create_hook"), \
+            patch.object(worktree.git_workflow, "get_story_base", return_value="develop"), \
+            patch.object(worktree, "default_branch") as default_branch_mock:
+            worktree.create("feat/foo")
+
+        # The worktree must be added from origin/develop, not the repo
+        # default branch — and default_branch() must not be consulted
+        # when story_base resolves to a non-empty value.
+        add_calls = [args for args, _ in calls if args[:1] == ("worktree",)]
+        assert add_calls, "expected a `git worktree add` invocation"
+        assert add_calls[0][-1] == "origin/develop"
+        default_branch_mock.assert_not_called()
+
+    def test_falls_back_to_default_branch_when_story_base_empty(
+        self, tmp_path: Path
+    ) -> None:
+        calls: list[tuple[tuple[str, ...], Path | None]] = []
+        with patch.object(worktree, "_git", side_effect=_stub_git_factory(calls)), \
+            patch.object(worktree, "repo_root", return_value=tmp_path), \
+            patch.object(worktree, "_run_post_create_hook"), \
+            patch.object(worktree.git_workflow, "get_story_base", return_value=""), \
+            patch.object(worktree, "default_branch", return_value="master"):
+            worktree.create("feat/foo")
+
+        add_calls = [args for args, _ in calls if args[:1] == ("worktree",)]
+        assert add_calls, "expected a `git worktree add` invocation"
+        assert add_calls[0][-1] == "origin/master"
+
+    def test_explicit_base_overrides_config(self, tmp_path: Path) -> None:
+        calls: list[tuple[tuple[str, ...], Path | None]] = []
+        with patch.object(worktree, "_git", side_effect=_stub_git_factory(calls)), \
+            patch.object(worktree, "repo_root", return_value=tmp_path), \
+            patch.object(worktree, "_run_post_create_hook"), \
+            patch.object(worktree.git_workflow, "get_story_base", return_value="develop"), \
+            patch.object(worktree, "default_branch") as default_branch_mock:
+            worktree.create("feat/foo", base="feat/sibling")
+
+        add_calls = [args for args, _ in calls if args[:1] == ("worktree",)]
+        assert add_calls, "expected a `git worktree add` invocation"
+        assert add_calls[0][-1] == "origin/feat/sibling"
+        default_branch_mock.assert_not_called()


### PR DESCRIPTION
## Summary

- Fixes #112. `maverick worktree create <branch>` (no `--base`) was branching off the repo default branch (`origin/HEAD`) instead of the project's configured `git_workflow.story_base`. On Gitflow-style repos where `story_base = develop`, every `do-issue-solo` run silently started work on the wrong base.
- `worktree.create()` now prefers `git_workflow.get_story_base()` over `default_branch()`. `get_story_base()` already falls back to `"main"` when the `git_workflow` block is absent, so trunk-based repos are unaffected; `default_branch()` remains as a belt-and-braces fallback for the empty case.

## Test plan

- [x] `make lint typecheck test` — 544 unit tests pass
- [x] New `tests/unit/test_worktree_create.py` covers three branches of base resolution:
  - configured `story_base` is honoured when no `base` is passed
  - falls back to `default_branch()` only when `story_base` resolves empty
  - explicit `base` argument still overrides the config
- [ ] On a Gitflow project with `story_base = develop` and `origin/HEAD = main`, `uv run maverick worktree create fix/foo` produces a worktree whose HEAD matches `origin/develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)