### PR TITLE
fix: correct extended do-code skill path and changelog placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.3.7] - 2026-06-07
-
 - Fixed the path used by /do-code to find additional coding instructions
 
 ## [3.3.6] - 2026-06-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.7] - 2026-06-07
+
+- Fixed the path used by /do-code to find additional coding instructions
+
 ## [3.3.6] - 2026-06-05
 
 ## [3.3.5] - 2026-05-21

--- a/skills/do-code/SKILL.md
+++ b/skills/do-code/SKILL.md
@@ -25,7 +25,7 @@ to perform the edits in a subagent.
 ## Project rules (mandatory)
 
 Before doing anything else, check for repo-specific coding guidance at
-`docs/maverick/skills/do-code.md` (path relative to the repo root).
+`docs/maverick/skills/do-code/SKILL.md` (path relative to the repo root).
 
 - **If the file exists**, read it fully and treat its contents as
   binding for this task. It holds project-specific rules that all

--- a/src/maverick/skills/do-code/body.md.j2
+++ b/src/maverick/skills/do-code/body.md.j2
@@ -18,7 +18,7 @@ to perform the edits in a subagent.
 ## Project rules (mandatory)
 
 Before doing anything else, check for repo-specific coding guidance at
-`docs/maverick/skills/do-code.md` (path relative to the repo root).
+`docs/maverick/skills/do-code/SKILL.md` (path relative to the repo root).
 
 - **If the file exists**, read it fully and treat its contents as
   binding for this task. It holds project-specific rules that all


### PR DESCRIPTION
## Summary
- Fixed the path used by /do-code to find the repo-specific extended coding instructions
- Moved the changelog entry under `[Unreleased]` so the release script stamps the version heading itself (avoids a duplicate `[3.3.7]` section at release time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)