### PR TITLE
fix: read session id from CLAUDE_CODE_SESSION_ID

### DIFF
--- a/src/maverick/coordinator.py
+++ b/src/maverick/coordinator.py
@@ -43,6 +43,24 @@ CLAIM_LABEL = "claude-in-progress"
 LEASE_TTL_MINUTES = 10
 HEARTBEAT_INTERVAL_MINUTES = 2
 
+#: Env vars carrying the current Claude Code session id, most-preferred first.
+#: Claude Code exports ``CLAUDE_CODE_SESSION_ID``; ``CLAUDE_SESSION_ID`` was an
+#: earlier name kept as a fallback for older Claude Code versions.
+_SESSION_ID_ENV_VARS = ("CLAUDE_CODE_SESSION_ID", "CLAUDE_SESSION_ID")
+
+
+def claude_session_id() -> str | None:
+    """Return the current Claude Code session id, or ``None`` outside a session.
+
+    Reads ``CLAUDE_CODE_SESSION_ID`` (the current name) and falls back to the
+    legacy ``CLAUDE_SESSION_ID`` for older Claude Code versions.
+    """
+    for name in _SESSION_ID_ENV_VARS:
+        value = os.environ.get(name)
+        if value:
+            return value
+    return None
+
 
 class ClaimLost(RuntimeError):
     """Raised when a claim is detected as lost to another instance mid-run."""
@@ -106,8 +124,9 @@ def instance_id() -> str:
 
     Resolution order:
     1. ``MAVERICK_INSTANCE_ID`` env var — explicit override, wins.
-    2. ``CLAUDE_SESSION_ID`` env var — derive a deterministic 10-char id
-       from a hash of the session id. Two different CC sessions get
+    2. ``CLAUDE_CODE_SESSION_ID`` env var (legacy ``CLAUDE_SESSION_ID``) —
+       derive a deterministic 10-char id from a hash of the session id.
+       Two different CC sessions get
        distinct ids; every subagent and subprocess inside one CC session
        converges on the same id without needing a file write, which
        sidesteps the first-call race in the file-cache path (#40).
@@ -117,7 +136,7 @@ def instance_id() -> str:
     cached = os.environ.get("MAVERICK_INSTANCE_ID")
     if cached:
         return cached
-    session = os.environ.get("CLAUDE_SESSION_ID")
+    session = claude_session_id()
     if session:
         value = hashlib.sha256(session.encode("utf-8")).hexdigest()[:10]
         os.environ["MAVERICK_INSTANCE_ID"] = value

--- a/src/maverick/report_cli.py
+++ b/src/maverick/report_cli.py
@@ -66,7 +66,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -75,7 +74,7 @@ from pathlib import Path
 from typing import Any, TypedDict
 
 from maverick.cli import _get_version
-from maverick.coordinator import instance_id
+from maverick.coordinator import claude_session_id, instance_id
 from maverick.gh_state import TASK_PROGRESS_PHASES
 from maverick.session_review.parser import (
     UsageRecord,
@@ -1070,7 +1069,7 @@ def _report_run_start(args: argparse.Namespace) -> int:
     event = _build_base(args, "run-start")
     event["maverick_skill"] = args.skill  # explicit even though base set it
     event["phase"] = args.phase or "claimed"
-    sid = os.environ.get("CLAUDE_SESSION_ID")
+    sid = claude_session_id()
     if sid:
         event["claude_session_id"] = sid
     append_event(event)
@@ -1155,7 +1154,7 @@ def _report_note(args: argparse.Namespace) -> int:
 def _report_resume(args: argparse.Namespace) -> int:
     event = _build_base(args, "resume")
     event["phase"] = args.phase
-    sid = os.environ.get("CLAUDE_SESSION_ID")
+    sid = claude_session_id()
     if sid:
         event["claude_session_id"] = sid
     append_event(event)
@@ -1357,7 +1356,7 @@ def build_subparsers(subparsers: argparse._SubParsersAction) -> None:
         "--no-tokens",
         action="store_true",
         help=(
-            "Skip the Token usage section even when CLAUDE_SESSION_ID was "
+            "Skip the Token usage section even when CLAUDE_CODE_SESSION_ID was "
             "captured. Useful for offline rendering or when ~/.claude/projects "
             "is not available."
         ),

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -17,6 +17,7 @@ from maverick import coordinator, gh_state
 class TestInstanceId:
     def test_stable_within_session(self, monkeypatch, tmp_path):
         monkeypatch.delenv("MAVERICK_INSTANCE_ID", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
         monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
         monkeypatch.setattr(
             coordinator, "_instance_id_path", lambda: tmp_path / "instance_id"
@@ -43,12 +44,14 @@ class TestInstanceId:
 
         # First "process": no env var, no file — generate and persist.
         monkeypatch.delenv("MAVERICK_INSTANCE_ID", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
         monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
         first = coordinator.instance_id()
         assert path.read_text() == first
 
         # Second "process": env var cleared, file present — read from file.
         monkeypatch.delenv("MAVERICK_INSTANCE_ID", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
         monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
         second = coordinator.instance_id()
         assert second == first
@@ -76,6 +79,7 @@ class TestInstanceId:
         (tmp_path / "no-such-dir").write_text("blocking file")
         monkeypatch.setattr(coordinator, "_instance_id_path", lambda: unwritable)
         monkeypatch.delenv("MAVERICK_INSTANCE_ID", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
         monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
         a = coordinator.instance_id()
         b = coordinator.instance_id()
@@ -84,15 +88,16 @@ class TestInstanceId:
         assert not unwritable.exists()
 
     def test_derives_from_claude_session_id(self, monkeypatch, tmp_path):
-        """#40: when CLAUDE_SESSION_ID is set, every subagent and subprocess
-        within that session derives the same instance id deterministically,
-        with no file write required — sidesteps the first-call file-cache
-        race that produced multiple ids per session.
+        """#40: when CLAUDE_CODE_SESSION_ID is set, every subagent and
+        subprocess within that session derives the same instance id
+        deterministically, with no file write required — sidesteps the
+        first-call file-cache race that produced multiple ids per session.
         """
         path = tmp_path / "instance_id"
         monkeypatch.setattr(coordinator, "_instance_id_path", lambda: path)
         monkeypatch.delenv("MAVERICK_INSTANCE_ID", raising=False)
-        monkeypatch.setenv("CLAUDE_SESSION_ID", "session-abc-123")
+        monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "session-abc-123")
 
         first = coordinator.instance_id()
 
@@ -105,6 +110,40 @@ class TestInstanceId:
         assert len(first) == 10
         assert not path.exists()
 
+    def test_derives_from_legacy_session_id(self, monkeypatch, tmp_path):
+        """Falls back to the legacy CLAUDE_SESSION_ID name when the current
+        CLAUDE_CODE_SESSION_ID is absent (older Claude Code versions)."""
+        path = tmp_path / "instance_id"
+        monkeypatch.setattr(coordinator, "_instance_id_path", lambda: path)
+        monkeypatch.delenv("MAVERICK_INSTANCE_ID", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+        monkeypatch.setenv("CLAUDE_SESSION_ID", "legacy-session")
+
+        first = coordinator.instance_id()
+        monkeypatch.delenv("MAVERICK_INSTANCE_ID", raising=False)
+        second = coordinator.instance_id()
+
+        assert first == second
+        assert len(first) == 10
+        assert not path.exists()
+
+    def test_current_session_id_wins_over_legacy(self, monkeypatch, tmp_path):
+        """When both names are present the current CLAUDE_CODE_SESSION_ID is
+        preferred, so behaviour is stable across the rename."""
+        monkeypatch.setattr(
+            coordinator, "_instance_id_path", lambda: tmp_path / "instance_id"
+        )
+        monkeypatch.delenv("MAVERICK_INSTANCE_ID", raising=False)
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "current")
+        monkeypatch.setenv("CLAUDE_SESSION_ID", "legacy")
+        both = coordinator.instance_id()
+
+        monkeypatch.delenv("MAVERICK_INSTANCE_ID", raising=False)
+        monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+        current_only = coordinator.instance_id()
+
+        assert both == current_only
+
     def test_distinct_sessions_derive_distinct_ids(self, monkeypatch, tmp_path):
         """Two concurrent Claude Code sessions on the same machine must
         present as distinct instances to the coordinator."""
@@ -112,24 +151,25 @@ class TestInstanceId:
             coordinator, "_instance_id_path", lambda: tmp_path / "instance_id"
         )
         monkeypatch.delenv("MAVERICK_INSTANCE_ID", raising=False)
+        monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
 
-        monkeypatch.setenv("CLAUDE_SESSION_ID", "session-A")
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "session-A")
         a = coordinator.instance_id()
 
         monkeypatch.delenv("MAVERICK_INSTANCE_ID", raising=False)
-        monkeypatch.setenv("CLAUDE_SESSION_ID", "session-B")
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "session-B")
         b = coordinator.instance_id()
 
         assert a != b
 
     def test_explicit_env_overrides_session_id(self, monkeypatch, tmp_path):
-        """MAVERICK_INSTANCE_ID still wins over CLAUDE_SESSION_ID, so users
-        can pin a specific id for recovery scenarios."""
+        """MAVERICK_INSTANCE_ID still wins over CLAUDE_CODE_SESSION_ID, so
+        users can pin a specific id for recovery scenarios."""
         monkeypatch.setattr(
             coordinator, "_instance_id_path", lambda: tmp_path / "instance_id"
         )
         monkeypatch.setenv("MAVERICK_INSTANCE_ID", "explicit")
-        monkeypatch.setenv("CLAUDE_SESSION_ID", "ignored")
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "ignored")
         assert coordinator.instance_id() == "explicit"
 
 

--- a/tests/unit/test_report_cli.py
+++ b/tests/unit/test_report_cli.py
@@ -1163,7 +1163,7 @@ class TestRunStartCapturesSessionId:
         self, tmp_path: Path, monkeypatch
     ):
         monkeypatch.setattr(report_cli, "_main_repo_root", lambda cwd=None: tmp_path)
-        monkeypatch.setenv("CLAUDE_SESSION_ID", "sess-from-env")
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "sess-from-env")
         monkeypatch.setattr(report_cli, "instance_id", lambda: "inst000000")
         args = argparse.Namespace(
             issue=321, phase=None, skill="do-issue-solo",
@@ -1176,10 +1176,29 @@ class TestRunStartCapturesSessionId:
         )
         assert events[-1]["claude_session_id"] == "sess-from-env"
 
+    def test_run_start_captures_legacy_session_id_from_env(
+        self, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(report_cli, "_main_repo_root", lambda cwd=None: tmp_path)
+        monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+        monkeypatch.setenv("CLAUDE_SESSION_ID", "legacy-sess")
+        monkeypatch.setattr(report_cli, "instance_id", lambda: "inst000000")
+        args = argparse.Namespace(
+            issue=321, phase=None, skill="do-issue-solo",
+            agent=None, llm=None, skill_name=None,
+        )
+        rc = report_cli._report_run_start(args)
+        assert rc == 0
+        events = report_cli.load_timeline(
+            report_cli.timeline_path(321, repo_root=tmp_path)
+        )
+        assert events[-1]["claude_session_id"] == "legacy-sess"
+
     def test_run_start_omits_session_id_when_env_unset(
         self, tmp_path: Path, monkeypatch
     ):
         monkeypatch.setattr(report_cli, "_main_repo_root", lambda cwd=None: tmp_path)
+        monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
         monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
         monkeypatch.setattr(report_cli, "instance_id", lambda: "inst000000")
         args = argparse.Namespace(


### PR DESCRIPTION
## Summary

Claude Code exports the current session id as `CLAUDE_CODE_SESSION_ID`, but the codebase read the non-existent `CLAUDE_SESSION_ID`. Two consequences:

1. `coordinator.instance_id()` never took the session-derived path (the #40 fix) — it silently fell through to the file cache, reintroducing the first-call race and weakening distinctness of concurrent sessions.
2. `report_cli` never recorded `claude_session_id` on `run-start`/`resume` timeline events, so token usage couldn't be linked to a session.

## Changes

- Add a shared `coordinator.claude_session_id()` helper that prefers `CLAUDE_CODE_SESSION_ID` and falls back to the legacy `CLAUDE_SESSION_ID` (older Claude Code versions).
- Route all three call sites through it; update the docstring and `--no-tokens` help text.
- Remove the now-unused `import os` in `report_cli.py`.
- Tests: clear/set both env var names where the file-cache path is forced, and add coverage for the legacy fallback and current-wins-over-legacy precedence.

## Verification

- `ruff` clean, `pyright` 0 errors
- 117 unit tests pass (`test_coordinator.py`, `test_report_cli.py`)
- `make build` shows no build-output drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)