### PR TITLE
docs: sync documentation with the codebase

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,64 @@
+---
+title: Documentation Index
+scope: Landing page and navigation map for the Maverick documentation set
+last-verified: 2026-07-02
+---
+
+# Maverick Documentation
+
+This directory holds the conceptual documentation for Maverick — the philosophy,
+architecture, workflows, and standards behind the plugin. The machine-readable
+skills and agents that *enforce* these ideas live under `src/maverick/` (source)
+and are built to the root-level `skills/` and `agents/` directories.
+
+New here? Start with [Overview](overview.md), then read the
+[Issue-driven Autonomous Workflow](do-issue-workflow.md).
+
+## Start here
+
+| Doc | What it covers |
+| --- | --- |
+| [Overview](overview.md) | Architecture and philosophy — the problem Maverick solves and how the pieces fit together. |
+| [Vibe Coding](vibe-coders.md) | Why a defined way of working matters when building with LLMs. |
+| [Architecture](architecture.md) | The skill/agent catalogue and the upskill system. |
+
+## Workflow & build
+
+| Doc | What it covers |
+| --- | --- |
+| [Issue-driven Autonomous Workflow](do-issue-workflow.md) | End-to-end flow from GitHub issue through implementation, review, and merge — single story and epic. |
+| [Error Handling and Recovery](claude-code-error-handling-and-recovery.md) | Workflow resilience, state persistence, and crash recovery for LLM sessions. |
+| [Maverick Build](maverick-build.md) | The build process and the release workflow. |
+| [GitHub Labels and Marker Comments](conventions/github-markers.md) | Canonical reference for the labels and machine-readable comments that coordinate multi-instance workflows. |
+
+## Standards & practices
+
+| Doc | What it covers |
+| --- | --- |
+| [Logging Standards](standards-and-practices/logging-standards.md) | Structured, consistent logging for LLM-generated code. |
+| [Alerting Standards](standards-and-practices/alerting-standards.md) | Operational alerting and how Maverick enforces it. |
+| [Comprehensive Testing](standards-and-practices/comprehensive-testing.md) | Testing as the primary quality gate. |
+| [CI/CD Integration](standards-and-practices/cicd.md) | Pipeline standards, quality gates, and local verification. |
+| [Git Workflow](standards-and-practices/git-workflow.md) | Branch strategy, commit conventions, and PR discipline. |
+| [Code Review](standards-and-practices/code-review.md) | Maverick's two-stage autonomous review process. |
+| [Security Review](standards-and-practices/security-review.md) | Identifying and mitigating vulnerabilities in LLM-generated code. |
+
+## Containment & boundaries
+
+| Doc | What it covers |
+| --- | --- |
+| [Scope Boundaries](scope-boundaries.md) | The operating envelope — four hard limits an agent must not cross without explicit instruction. |
+| [LLM Containment](llm-containment.md) | Defence-in-depth strategies for constraining autonomous agents. |
+
+## Infrastructure
+
+| Doc | What it covers |
+| --- | --- |
+| [Claude Code Workers](claude-code-workers.md) | Remote compute instances running Claude Code on AWS. |
+
+## Reference
+
+| Doc | What it covers |
+| --- | --- |
+| [Skills catalogue](skills/maverick-skills.md) | Every skill shipped with the plugin (generated from source configs). |
+| [References](references.md) | External documentation links for platforms, tools, and specifications. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 title: Maverick Architecture
 scope: Best practice workflows
 relates-to:
-last-verified: 2026-04-02
+last-verified: 2026-07-02
 ---
 
 # Architecture
@@ -14,12 +14,12 @@ Skills are markdown files with YAML frontmatter that load into the LLM's context
 | Category            | Skills                                                                                                                                                                                                          | Purpose                                                        |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
 | **Best Practices**  | logging, alerting, observability, linting, unit-testing, integration-testing, error-handling, application-security, code-review, api-design, accessibility, database-management, dependency-management, documentation, environment-management, infrastructure-as-code, solutions-design, source-control, task-tracking, versioning | Define standards for each practice area                        |
-| **Workflow**        | do-issue-solo, do-issue-guided, do-epic, create-solution-design, create-tasks                                                                                                                                  | Orchestrate multi-step development workflows                   |
+| **Workflow**        | do-issue-solo, do-issue-guided, do-epic, mav-create-solution-design, mav-create-tasks                                                                                                                          | Orchestrate multi-step development workflows                   |
 | **Execution**       | mav-plan-execution, mav-local-verification                                                                                                                                                                     | Control how tasks are executed and verified                    |
 | **Git & GitHub**    | mav-git-workflow, mav-github-issue-workflow                                                                                                                                                                    | Define branching, commit, and issue interaction patterns       |
 | **CI/CD Platforms** | mav-bp-cicd, mav-bp-cicd-github, mav-bp-cicd-gitlab, mav-bp-cicd-azure, mav-bp-cicd-bitbucket                                                                                                                | Platform-agnostic standards and platform-specific monitoring   |
 | **Governance**      | mav-scope-boundaries, mav-claude-code-recovery, mav-systematic-debugging                                                                                                                                      | Define hard limits and resilience patterns                     |
-| **Project Setup**   | upskill, maverick-alignment, tech-docs, pullrequest-review                                                                                                                                                     | Generate project skills, audit codebases, manage documentation |
+| **Project Setup**   | do-upskill, do-maverick-alignment, do-tech-docs, do-pullrequest-review                                                                                                                                         | Generate project skills, audit codebases, manage documentation |
 
 ### The Upskill System
 
@@ -27,7 +27,7 @@ Best-practice skills define universal standards. But every project is different 
 
 ```mermaid
 flowchart TD
-    UP["/upskill invoked"] --> SCAN["Scan codebase for each topic"]
+    UP["/do-upskill invoked"] --> SCAN["Scan codebase for each topic"]
     SCAN --> FOUND{"Implementation found?"}
     FOUND -->|"yes"| FULL["Write project skill from detected patterns"]
     FOUND -->|"no"| BP{"Best-practice skill exists?"}
@@ -38,7 +38,7 @@ flowchart TD
     STUB --> OUT
 ```
 
-- Scans the codebase for each topic defined in `skills/upskill/topics.json`
+- Scans the codebase for each topic defined in `skills/do-upskill/topics.json`
 - If an implementation exists (e.g., Pino logger configured), documents exactly what's there
 - If no implementation exists but a best-practice skill is available, generates a **recommended** implementation tailored to the project's stack
 - Project skills are version-controlled and editable - the team can review and adjust recommendations
@@ -103,4 +103,4 @@ flowchart TD
 | **do-issue-guided** | Checkpoints at design, plan, review, and completion   | Supervised development - human validates approach at key decision points      |
 | **do-epic**         | None per story; user reviews ejected PRs only         | Multi-story epic with DAG-scheduled parallel execution                        |
 
-All three workflows share the per-story phases: solution design → create tasks → execution → verification → PR creation. `do-epic` adds a wave-scheduling layer on top, dispatching `do-issue-solo` per story under each wave's worktrees. The `create-tasks` skill decomposes a solution design into discrete tasks — posted as a checklist comment for fewer than 5 tasks, or as GitHub sub-issues with dependency ordering for 5 or more.
+All three workflows share the per-story phases: solution design → create tasks → execution → verification → PR creation. `do-epic` adds a wave-scheduling layer on top, dispatching `do-issue-solo` per story under each wave's worktrees. The `mav-create-tasks` skill decomposes a solution design into discrete tasks — posted as a checklist comment for fewer than 5 tasks, or as GitHub sub-issues with dependency ordering for 5 or more.

--- a/docs/claude-code-error-handling-and-recovery.md
+++ b/docs/claude-code-error-handling-and-recovery.md
@@ -4,7 +4,7 @@ scope: Workflow resilience, state persistence, and crash recovery for LLM sessio
 relates-to:
   - scope-boundaries.md
   - cicd.md
-last-verified: 2026-03-02
+last-verified: 2026-07-02
 ---
 
 # Claude Code Error Handling and Recovery
@@ -51,35 +51,38 @@ All Maverick workflows use the same state file pattern:
 
 ### Issue workflow state contents
 
-| Field             | Purpose                                                      |
-| ----------------- | ------------------------------------------------------------ |
-| `phase`           | Current workflow phase (design, plan, implement, verify, PR) |
-| `branch`          | Branch name created for this work                            |
-| `issueNumber`     | The GitHub issue driving this work                           |
-| `designCommentId` | GitHub comment ID where the solution design was posted       |
-| `planCommentId`   | GitHub comment ID where the implementation plan was posted   |
-| `completedSteps`  | List of implementation steps already completed               |
-| `lastAction`      | Description of the last action taken before session ended    |
+The canonical schema is defined by the `mav-github-issue-workflow` skill:
 
-### Task workflow state contents
+```json
+{
+  "issue": 42,
+  "repo": "owner/repo",
+  "branch": "feat/42-short-description",
+  "phase": "understand|design|plan|branch|implement|complete",
+  "comments": {
+    "design": null,
+    "plan": null,
+    "completion": null
+  }
+}
+```
 
-| Field       | Purpose                                                      |
-| ----------- | ------------------------------------------------------------ |
-| `task_id`   | Task identifier (e.g., `TASK-001`)                           |
-| `branch`    | Branch name created for this work                            |
-| `phase`     | Current workflow phase (understand, design, plan, branch, implement, review, complete) |
-| `created`   | Timestamp of task creation                                   |
-
-For the task workflow, artefacts (design, plan, progress) are stored as committed files alongside the state file rather than as GitHub comments. This means `task.md`, `design.md`, `plan.md`, and `completion.md` survive branch operations and are recoverable from git history.
+| Field                 | Purpose                                                      |
+| --------------------- | ------------------------------------------------------------ |
+| `issue`               | The GitHub issue number driving this work                    |
+| `repo`                | `owner/repo` the work targets                                |
+| `branch`              | Branch name created for this work                            |
+| `phase`               | Current workflow phase (`understand`, `design`, `plan`, `branch`, `implement`, `complete`) |
+| `comments.design`     | GitHub comment ID where the solution design was posted       |
+| `comments.plan`       | GitHub comment ID where the implementation plan was posted   |
+| `comments.completion` | GitHub comment ID where the completion summary was posted    |
 
 ### Why each field matters
 
 - **phase** - tells the new session where to resume, preventing duplicate work
-- **branch** - prevents creating a second branch for the same issue or task
-- **comment IDs** (issue workflows) - allows the new session to read back its own artefacts from GitHub
-- **task_id** (task workflows) - identifies the task directory containing all artefacts
-- **completedSteps** - prevents re-implementing work that is already on the branch
-- **lastAction** - provides context about what was happening when the session ended
+- **branch** - prevents creating a second branch for the same issue
+- **comments.*** - GitHub comment IDs let the new session read back its own artefacts (design, plan, completion summary) from the issue
+- **issue / repo** - identify the GitHub issue and repository the resumed session must operate on
 
 ## Crash Recovery Flow
 
@@ -110,13 +113,14 @@ flowchart TD
 
 ### Recovery phases
 
-| Phase          | On resume                                  | Verification                                       |
-| -------------- | ------------------------------------------ | -------------------------------------------------- |
-| Design         | Read design from GitHub comment            | Comment exists and contains design content         |
-| Plan           | Read plan from GitHub comment              | Comment exists and contains plan steps             |
-| Implementation | Check completed steps against branch state | Each completed step has corresponding code changes |
-| Verification   | Re-run all checks                          | Lint, typecheck, and tests all pass                |
-| PR             | Check if PR exists                         | PR is open and linked to the issue                 |
+| Phase       | On resume                                       | Verification                                       |
+| ----------- | ----------------------------------------------- | -------------------------------------------------- |
+| `understand` | Re-read the issue                              | Issue exists and is readable                       |
+| `design`    | Read design from the GitHub comment             | `comments.design` set; comment contains design     |
+| `plan`      | Read plan from the GitHub comment               | `comments.plan` set; comment contains plan steps   |
+| `branch`    | Check out the recorded branch                   | Branch exists and matches `branch`                 |
+| `implement` | Compare branch state against the plan           | Completed steps have corresponding code changes    |
+| `complete`  | Check the completion summary and PR             | `comments.completion` set; PR open and linked      |
 
 ## Artefact Durability
 
@@ -260,7 +264,7 @@ stateDiagram-v2
 
 - Always check for existing state before starting work
 - Always verify state matches reality before resuming
-- Always persist artefacts immediately upon creation (GitHub comments for issue workflows, committed files for task workflows)
+- Always persist artefacts immediately upon creation (posted as GitHub comments and recorded by ID in the state file)
 - Never retry commands blindly - diagnose first
 - Never retry more than twice without human escalation
 - Never manually fix subagent failures - dispatch a new subagent

--- a/docs/claude-code-workers.md
+++ b/docs/claude-code-workers.md
@@ -4,7 +4,7 @@ scope: Remote compute instances running Claude Code
 relates-to:
   - cicd.md
   - maverick-build.md
-last-verified: 2026-03-20
+last-verified: 2026-07-02
 ---
 
 ## Remote Compute
@@ -82,7 +82,7 @@ Bake a Linux AMI pre-configured with Claude Code using cloud-init. This step is 
 maverick build-ami
 ```
 
-The `build-ami` command requires `maverick infra deploy` to have been run first — it reads the security group, IAM profile, subnet, and secret ARN from the VPC stack outputs. The only config value needed is the EC2 key pair name.
+The `build-ami` command requires `maverick infra deploy` to have been run first — it reads the security group, IAM profile, and subnet from the VPC stack outputs. The only config value needed is the EC2 key pair name.
 
 The script will:
 
@@ -124,3 +124,5 @@ In your GitHub repo: Settings → Webhooks → Add webhook:
 - **Content type:** `application/json`
 - **Secret:** The value of `GITHUB_WEBHOOK_SECRET` in your Secrets Manager secret
 - **Events:** Select "Issues"
+
+Only the `labeled` action with the configured trigger label creates a work item — the handler ignores every other issue event. The trigger label defaults to `claude-do` (the `WebhookLabel` CloudFormation parameter / `WEBHOOK_LABEL` env var). So after the webhook is wired up, a worker is dispatched only when an issue is labelled `claude-do`; opening or editing an issue does nothing on its own.

--- a/docs/conventions/github-markers.md
+++ b/docs/conventions/github-markers.md
@@ -22,6 +22,7 @@ Maverick coordinates multi-instance workflows through labels and machine-readabl
 | `claude-in-progress` | issue      | A Claude Code instance has claimed this issue | Claude Code instance (on claim)              |
 | `needs-human`        | issue + PR | Code reviewer ejected this for human handling | Claude Code instance (on eject)              |
 | `blocked-by:#N`      | issue      | Depends transitively on ejected issue `#N`    | Claude Code instance (via block propagation) |
+| `merged-to-<branch>` | issue      | The issue's PR was merged to `<branch>`       | Claude Code instance (on merge)              |
 
 Labels must be created once per repo. Maverick's `do-init` can create them automatically when present.
 
@@ -31,6 +32,7 @@ Labels must be created once per repo. Maverick's `do-init` can create them autom
 claim    → claude-in-progress added
 release  → claude-in-progress removed
 eject    → needs-human added (stays until human closes the issue)
+merge    → merged-to-<branch> added (on auto-merge, before the issue is closed)
 block    → blocked-by:#N added
 unblock  → blocked-by:#N removed (human only — Maverick never removes)
 ```

--- a/docs/do-issue-workflow.md
+++ b/docs/do-issue-workflow.md
@@ -8,7 +8,7 @@ relates-to:
   - code-review.md
   - cicd.md
   - claude-code-error-handling-and-recovery.md
-last-verified: 2026-04-27
+last-verified: 2026-07-02
 ---
 
 # Issue-driven Autonomous Workflow
@@ -69,7 +69,7 @@ flowchart TD
         ANALYSE --> DECOMPOSE --> SHAPE
     end
 
-    SHAPE -- Single story --> SOLO_WT[Create one worktree off develop]
+    SHAPE -- Single story --> SOLO_WT[Create one worktree off the base branch story_base]
     SHAPE -- Epic --> DAG
 
     %% ─────────────── Epic planning ───────────────
@@ -107,7 +107,7 @@ flowchart TD
         direction TB
         REVERIFY{Claim still held<br/>and not blocked?}
         STACKED{Sibling PR<br/>open and unmerged?}
-        BR_DEV[Branch from develop]
+        BR_DEV[Branch from story_base]
         BR_SIBLING[Branch from sibling PR<br/>stacked PR]
         TASK[Implement next task]
         VERIFY[Local verify<br/>lint, typecheck, tests]
@@ -121,7 +121,7 @@ flowchart TD
         SEC_VERDICT{Security verdict?}
         BLOCKING_HALT[Halt, surface findings, route<br/>back to implementation]
         RETARGET{Stacked branch:<br/>sibling base merged?}
-        RT[Retarget PR base to develop]
+        RT[Retarget PR base to story_base]
         CI_PUSH[Pre-push verification, push final state]
         CI_WAIT[Monitor CI per mav-bp-cicd]
         CI_OK{CI passes?}
@@ -158,7 +158,7 @@ flowchart TD
 
     %% ─── Approve path ───
     VERDICT -- PASS --> APPROVE[Maverick GitHub App posts gh pr review --approve<br/>auditable agent-reviewed trail]
-    APPROVE --> AUTOMERGE[Auto-merge PR<br/>squash to develop]
+    APPROVE --> AUTOMERGE[Auto-merge PR<br/>squash to story_base]
     AUTOMERGE --> RELEASE[Release claim on this story]
     RELEASE --> EPIC_OK{Story belongs<br/>to an epic?}
 
@@ -170,7 +170,7 @@ flowchart TD
     NEXT_WAVE -- No --> END
 
     %% ─── Eject path ───
-    VERDICT -- FAIL --> EJECT[Apply maverick-needs-human label<br/>request human review on PR<br/>release claim]
+    VERDICT -- FAIL --> EJECT[Apply needs-human label<br/>request human review on PR<br/>release claim]
     EJECT --> EPIC_FAIL{Story belongs<br/>to an epic?}
     EPIC_FAIL -- No --> END
     EPIC_FAIL -- Yes --> PROPAGATE[Propagate block to all transitive descendants<br/>walk the DAG, label each blocked-by]
@@ -188,7 +188,7 @@ The very first step of every action skill is `uv run maverick preflight <skill-n
 
 Before any work begins, the workflow hydrates its view of the world from GitHub — the DAG comment on the parent epic (if any), the rolling state snapshot, every claim and lease comment, every `blocked-by` label. Local files are treated as a stale cache.
 
-The issue is then claimed atomically: a `claude-in-progress` label, an assignee, and a lease comment with an instance id and expiry timestamp. The lease is refreshed by a heartbeat at a short interval (1–2 min) with a short TTL (5–10 min) so machine death is detected quickly. If another instance already holds a valid lease, the workflow aborts cleanly without modifying the issue. If the lease is stale, the new instance posts a takeover comment and proceeds.
+The issue is then claimed atomically: a `claude-in-progress` label, a `maverick-claim` marker comment, and a lease comment with an instance id and expiry timestamp. The lease is refreshed by a heartbeat at a short interval (1–2 min) with a short TTL (5–10 min) so machine death is detected quickly. If another instance already holds a valid lease, the workflow aborts cleanly without modifying the issue. If the lease is stale, the new instance posts a takeover comment and proceeds.
 
 ### Pre-development
 
@@ -200,7 +200,7 @@ For epics only: cross-story dependencies and shared-file collisions are analysed
 
 ### Wave dispatch
 
-For each wave: stories carrying `blocked-by` labels are filtered out, a worktree is created per surviving story off `develop`, and execution dispatches either in parallel (one subagent per worktree) or serially. The same per-story flow runs in each worktree.
+For each wave: stories carrying `blocked-by` labels are filtered out, a worktree is created per surviving story off the base branch (`story_base`, defaulting to the repo's default branch), and execution dispatches either in parallel (one subagent per worktree) or serially. The same per-story flow runs in each worktree.
 
 For a standalone story (non-epic) the flow is the same minus the wave layer — a single worktree, a single per-story flow, no wave coordination.
 
@@ -209,7 +209,7 @@ For a standalone story (non-epic) the flow is the same minus the wave layer — 
 This is the core loop and is identical for epic-driven and standalone work:
 
 1. **Re-verify the claim.** A late `blocked-by` propagation from a sibling ejection or an expired lease aborts the story before any push.
-2. **Branch.** From `develop` for an independent story; from a sibling branch when the story depends on a sibling whose PR is open but not yet merged (stacked PR pattern).
+2. **Branch.** From `story_base` (the repo's default branch unless overridden) for an independent story; from a sibling branch when the story depends on a sibling whose PR is open but not yet merged (stacked PR pattern).
 3. **Implement task by task.** Each task: implement → local verification (lint, typecheck, tests) → conventional commit referencing the issue → **push immediately**. Pushing per task is a durability checkpoint — if the machine dies between tasks, the work survives.
 4. **Wrap up.** After the last task: full verification, then two mandatory pre-push reviews (always run, no skip path):
    - **Documentation review** dispatches `agent-tech-docs-writer` in `update` mode against the diff — updates stale docs and creates new ones for new components. "No changes required" is a valid outcome but is recorded explicitly.
@@ -221,11 +221,11 @@ This is the core loop and is identical for epic-driven and standalone work:
 `agent-code-reviewer` runs in two stages against the open PR: **spec compliance** (does this implement what the issue actually asked for?) then **code quality** (correctness, test coverage of changed behaviour, scope discipline, maintainability). Security is explicitly *not* part of this gate — it is handled by the pre-push `do-cybersecurity-review` (Phase 7) and findings are already in the PR body by the time the agent reviews. The verdict is **PASS** or **FAIL** — there is no "approve with suggestions" middle ground.
 
 - **PASS** → the Maverick GitHub App posts `gh pr review --approve` with the verdict (via `maverick gh-app gh -- pr review`), and the PR auto-merges (`gh pr merge --auto --squash`). The claim is released.
-- **FAIL** → the PR is ejected: a `maverick-needs-human` label is applied to the issue and PR, the review is posted as a comment, and the claim is released. The agent does **not** attempt to fix and retry.
+- **FAIL** → the PR is ejected: a `needs-human` label is applied to the issue and PR, the review is posted as a comment, and the claim is released. The agent does **not** attempt to fix and retry.
 
 ### Block propagation (epic path only)
 
-When a story in an epic is ejected, every transitive descendant in the DAG is labelled `blocked-by:#<ejected-story>`. Any in-flight subagent working on a now-blocked story has its claim released and its work discarded — that work would have been built on a foundation that's not landing. A propagation marker (`maverick-bprop:#N`) is written before the walk and cleared after, so a crash mid-walk is resumable without leaving partial blocks.
+When a story in an epic is ejected, every transitive descendant in the DAG is labelled `blocked-by:#<ejected-story>`. Any in-flight subagent working on a now-blocked story has its claim released and its work discarded — that work would have been built on a foundation that's not landing. A propagation marker (`maverick-bprop`) is written before the walk and cleared after, so a crash mid-walk is resumable without leaving partial blocks.
 
 ### Termination
 

--- a/docs/llm-containment.md
+++ b/docs/llm-containment.md
@@ -5,7 +5,7 @@ relates-to:
   - scope-boundaries.md
   - security-review.md
   - cicd.md
-last-verified: 2026-03-02
+last-verified: 2026-07-02
 ---
 
 # LLM Containment
@@ -219,7 +219,7 @@ The ideal LLM working environment is ephemeral -- created for a task and destroy
 - **Clean dependency installation** -- each environment installs dependencies fresh, preventing version drift
 - **Time-bounded** -- environments are automatically destroyed after a timeout, preventing orphaned resources
 
-Maverick's worker pipeline uses this pattern: each GitHub issue gets a fresh clone in a temporary directory that is cleaned up after the task completes, regardless of success or failure.
+Maverick's worker pipeline uses this pattern: each GitHub issue gets a fresh clone in a deterministic per-issue subdirectory of a persistent work directory (e.g. `/home/claude/work/{owner-repo}-{issue}`), cleaned up in a `finally` block after the task completes, regardless of success or failure.
 
 ## Destructive Operation Restrictions
 

--- a/docs/maverick-build.md
+++ b/docs/maverick-build.md
@@ -2,8 +2,8 @@
 title: Maverick Build
 scope: Understanding the maverick build process, release workflow, and the rationale behind them
 relates-to:
-  - maverick-install.md
-last-verified: 2026-03-20
+  - overview.md
+last-verified: 2026-07-02
 ---
 
 # Maverick Build
@@ -66,7 +66,7 @@ make generate
 
 ## Releasing
 
-Releases are created using `scripts/release.sh`. The script bumps the version across all manifest files, updates the changelog, commits, and tags — keeping the process repeatable and consistent.
+Releases are created using `scripts/release.sh`. The script bumps the version across all manifest files, updates the changelog, and commits on a release branch — keeping the process repeatable and consistent. Tagging happens in CI (`release-finalize.yml`) after the release PR is merged, not in the script.
 
 ### Version locations
 
@@ -83,15 +83,19 @@ The version string appears in four files that must stay in sync:
 
 ### Usage
 
+The script takes a **bump type** — `major`, `minor`, or `patch` (default `patch`). It computes the next version from the current `-dev` version; it does **not** accept an explicit version number.
+
 ```bash
-# Preview what the release will do (no files modified)
-./scripts/release.sh --dry-run 0.2.0
+# Create a patch release (default)
+./scripts/release.sh patch
 
-# Create a release
-./scripts/release.sh 0.2.0
+# Or a minor / major release
+./scripts/release.sh minor
+./scripts/release.sh major
 
-# Or via Make
-make release VERSION=0.2.0
+# Equivalent Make targets
+make release          # patch
+make release-minor    # minor
 ```
 
 ### What the script does

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -13,7 +13,7 @@ relates-to:
   - scope-boundaries.md
   - llm-containment.md
   - claude-code-error-handling-and-recovery.md
-last-verified: 2026-04-02
+last-verified: 2026-07-02
 ---
 
 ## Overview
@@ -24,15 +24,15 @@ It provides skills, agents, and hooks that constrain and guide LLM behaviour - m
 
 ## The Problem Maverick Solves
 
-LLMs generate code fast but dont come with any concept of quality, best practice or constraint. Claude Code will happily agree to build the worlds worst idea, with a smile, because without guardrails:
+LLMs generate code fast but don't come with any concept of quality, best practice or constraint. Claude Code will happily agree to build the world's worst idea, with a smile, because without guardrails:
 
 - **No operational awareness** - LLMs don't add structured logging, alerting, or monitoring unless explicitly told to. Production code becomes undiagnosable.
-- **No security reasoning** - LLMs reproduce vulnerable patterns from training data. SQL injection, XSS, and secrets exposure go unnoticed. It wont make any effort to ensure cybersecurity is maintined.
-- **No testing discipline** - LLMs write working code and you can think youve got a product. Until it runs anywhere except on your machine because its filled with bugs you cant see. Without tests, those bugs ship.
-- **No workflow discipline** - LLMs commit to main, skip CI, ignore conventions, and produce untraceable changes. If you ask an LLM to create a large ammount of changes ina single attempt it will try and you'll regret it. Large tasks need structured decomposition into manageable sub-tasks with clear dependency ordering.
+- **No security reasoning** - LLMs reproduce vulnerable patterns from training data. SQL injection, XSS, and secrets exposure go unnoticed. It wont make any effort to ensure cybersecurity is maintained.
+- **No testing discipline** - LLMs write working code and you can think you've got a product. Until it runs anywhere except on your machine because its filled with bugs you cant see. Without tests, those bugs ship.
+- **No workflow discipline** - LLMs commit to main, skip CI, ignore conventions, and produce untraceable changes. If you ask an LLM to create a large amount of changes in a single attempt it will try and you'll regret it. Large tasks need structured decomposition into manageable sub-tasks with clear dependency ordering.
 - **No self-review** - LLMs don't question their own output. Code that looks correct may miss requirements or violate project conventions.
 
-These risks multiply enourmously in unattended development when no human is watching the LLM work. There is no developer catching issues in real-time, no reviewer glancing at the diff, no operator noticing silent failures. Every quality gap becomes a production risk.
+These risks multiply enormously in unattended development when no human is watching the LLM work. There is no developer catching issues in real-time, no reviewer glancing at the diff, no operator noticing silent failures. Every quality gap becomes a production risk.
 
 ## How Maverick Solves It
 
@@ -72,7 +72,7 @@ See [claude-code-workers.md](claude-code-workers.md) for full details.
 
 ## Why Each Practice Area Is Central
 
-Every practice area in maverick exists because it addresses a specific failure mode of LLM-generated code. These failures are things the tech industry has learned through decades of watching humans crate the same mistake, that now get automated by unconstrained LLM's.
+Every practice area in maverick exists because it addresses a specific failure mode of LLM-generated code. These failures are things the tech industry has learned through decades of watching humans create the same mistake, that now get automated by unconstrained LLM's.
 
 None are optional - they form an interlocking system where each practice reinforces the others.
 
@@ -85,7 +85,7 @@ None are optional - they form an interlocking system where each practice reinfor
 | Linting                                                      | Style drift, inconsistency, detectable bugs         | Automated consistency enforcement without human style policing               |
 | Error Handling                                               | Swallowed errors, missing retries, cascade failures | LLMs skip error paths - enforced patterns prevent silent data loss           |
 | [CI/CD](standards-and-practices/cicd.md)                     | Broken builds, untested code reaching main          | Last line of defence - catches what local verification misses                |
-| [Git Workflow](git-workflow.md)                              | Untraceable changes, broken main branch             | Audit trail and reversibility - every change linked to an issue via PR       |
+| [Git Workflow](standards-and-practices/git-workflow.md)      | Untraceable changes, broken main branch             | Audit trail and reversibility - every change linked to an issue via PR       |
 | Source Control                                               | Missing repos, leaked secrets, poor hygiene         | Foundational requirement - no repo means no traceability                     |
 | [Code Review](standards-and-practices/code-review.md)        | Requirement mismatches, convention violations       | Autonomous reviewer catches what the generating LLM missed                   |
 | [Security](standards-and-practices/security-review.md)       | OWASP vulnerabilities, exposed secrets              | LLMs reproduce vulnerable patterns - review catches them before merge        |
@@ -108,7 +108,7 @@ Maverick encodes best practices as machine-readable artefacts that the LLM must 
 | Mechanism  | Role                                                            | Example                                                                                                                            |
 | ---------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | **Skills** | Define what good looks like - standards, conventions, workflows | `mav-bp-logging` defines log levels and structured format                                                                          |
-| **Agents** | Verify compliance autonomously - review, test, document         | `code-reviewer` catches spec gaps, missing tests, and quality issues; `do-cybersecurity-review` catches security issues separately |
+| **Agents** | Verify compliance autonomously - review, test, document         | `agent-code-reviewer` catches spec gaps, missing tests, and quality issues (security is handled separately by the `do-cybersecurity-review` skill) |
 | **Hooks**  | Enforce rules automatically at tool-call boundaries             | Block commits to protected branches, prevent secret exposure                                                                       |
 
 ### The Enforcement Chain
@@ -131,25 +131,24 @@ Each link in this chain catches different classes of issues:
 
 ```
 maverick/
-├── skills/                     # Machine-readable guidance (44 skills)
-│   ├── mav-bp-*/               # Universal best-practice standards (20 skills)
+├── skills/                     # Machine-readable guidance (54 skills, build output)
+│   ├── mav-bp-*/               # Universal best-practice standards (21 skills)
 │   ├── mav-bp-cicd-*/          # Platform-specific CI/CD skills
 │   ├── do-issue-*/             # GitHub issue workflow entry points
-│   ├── do-task-*/              # Local task workflow entry points
+│   ├── do-epic/                # Epic-driven parallel workflow
 │   ├── do-upskill/             # Project skill generation
 │   └── ...                     # Execution, governance, debugging
-├── agents/                     # Autonomous workers (7 agents)
+├── agents/                     # Autonomous workers (6 agents, build output)
 │   ├── agent-code-reviewer.md
 │   ├── agent-issue-analyst.md
 │   ├── agent-github-issue-planner.md
-│   ├── agent-task-planner.md
 │   ├── agent-session-reviewer.md
 │   ├── agent-maverick.md
 │   └── agent-tech-docs-writer.md
-├── hooks/                      # Tool-call enforcement rules
+├── hooks/                      # Tool-call enforcement rules (build output)
 ├── docs/                       # Philosophy and rationale (this directory)
 ├── scripts/                    # Developer tooling (release, validation)
-├── cli/                        # Maverick CLI (init, cloud, worker)
+├── src/maverick/               # Maverick CLI + skill/agent sources (init, cloud, worker)
 └── .claude-plugin/             # Plugin manifest
 ```
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -3,7 +3,7 @@ title: References
 scope: External documentation links for platforms, tools, and specifications used by Maverick
 relates-to:
   - overview.md
-last-verified: 2026-03-02
+last-verified: 2026-07-02
 ---
 
 # References

--- a/docs/scope-boundaries.md
+++ b/docs/scope-boundaries.md
@@ -4,7 +4,7 @@ scope: Defining and enforcing the operating envelope for LLM agents
 relates-to:
   - llm-containment.md
   - security-review.md
-last-verified: 2026-03-02
+last-verified: 2026-07-02
 ---
 
 # Scope Boundaries
@@ -133,7 +133,7 @@ flowchart LR
     subgraph Explicit["Explicit instruction (permitted)"]
         E1["Issue: 'Update the Dockerfile<br/>to use Node 20'"]
         E2["User message: 'Modify the<br/>CI workflow to add linting'"]
-        E3["Issue comment: 'Delete the<br/>stale feature/old-api branch'"]
+        E3["Issue comment: 'Add rate-limit<br/>config to the api module'"]
     end
 
     subgraph Inferred["Inferred need (refused)"]

--- a/docs/skills/maverick-skills.md
+++ b/docs/skills/maverick-skills.md
@@ -15,7 +15,7 @@ Implement a focused code change. Use this skill as the wrapper for any implement
 
 ## do-cybersecurity-review
 
-Run a security audit of the project's existing codebase and write a findings report to docs/security-audit.md. Covers secrets exposure, dependency vulnerabilities, authentication and authorisation patterns, input validation, transport security, and common OWASP risks. Run as part of do-init or on demand.
+Audit a codebase for security risks in one of two modes. In full-audit mode it scans the entire codebase and writes a findings report to docs/security-audit.md (run as part of do-init or on demand). In update mode it reviews only a diff plus the code it could impact, returning a structured findings list as a pre-push gate for do-issue-solo and do-issue-guided. Covers secrets exposure, dependency vulnerabilities, authentication and authorisation patterns, input validation, transport security, and common OWASP risks.
 
 
 ## do-docs
@@ -55,7 +55,7 @@ Analyze a project's codebase against Maverick standard practices and write a fin
 
 ## do-pullrequest-review
 
-How to process code review feedback — verify before implementing, push back when wrong, clarify before acting on partial understanding. Applied when receiving review from the code-reviewer agent or human reviewers.
+How to process code review feedback — verify before implementing, push back when wrong, clarify before acting on partial understanding. Applied when receiving review from the agent-code-reviewer or human reviewers.
 
 
 ## do-recommend

--- a/docs/standards-and-practices/alerting-standards.md
+++ b/docs/standards-and-practices/alerting-standards.md
@@ -4,7 +4,7 @@ scope: Why operational alerting is essential for LLM-generated code and how Mave
 relates-to:
   - logging-standards.md
   - scope-boundaries.md
-last-verified: 2026-03-02
+last-verified: 2026-07-02
 ---
 
 # Alerting Standards
@@ -47,7 +47,7 @@ flowchart TD
     A[mav-bp-alerting skill] -->|defines standards| B[upskill system]
     B -->|generates project-specific guidance| C[project alerting skill]
     C -->|constrains LLM during coding| D[code generation]
-    D -->|produces code with alerting| E[code-reviewer agent]
+    D -->|produces code with alerting| E[agent-code-reviewer]
     E -->|checks alerting compliance| F{compliant?}
     F -->|yes| G[local verification]
     F -->|no| H[reject with feedback]
@@ -64,9 +64,9 @@ The mav-bp-alerting skill defines universal alerting standards: severity levels,
 
 The upskill system analyses a project's existing alerting infrastructure and generates a project-specific alerting guide. This tells the LLM which alerting service the project uses (SNS, PagerDuty, Opsgenie, custom), what severity thresholds apply, and how alerts should be routed. Without this layer, the LLM applies generic alerting patterns that may not integrate with the project's operational setup.
 
-### Layer 3: code-reviewer agent
+### Layer 3: agent-code-reviewer
 
-The code-reviewer agent inspects error-handling code for alerting compliance. It checks that unrecoverable errors trigger alerts, that alert severity is appropriate, that alert context includes required fields, and that recoverable errors are not over-alerted. Violations are flagged with specific guidance.
+The `agent-code-reviewer` inspects error-handling code for alerting compliance. It checks that unrecoverable errors trigger alerts, that alert severity is appropriate, that alert context includes required fields, and that recoverable errors are not over-alerted. Violations are flagged with specific guidance.
 
 ## Severity Levels
 
@@ -96,7 +96,7 @@ Every alert must include sufficient context for an on-call responder to begin in
 | error_message     | Yes                | Human-readable description of what failed          |
 | timestamp         | Yes                | ISO 8601 timestamp of when the failure occurred    |
 | affected_resource | Yes                | The entity, endpoint, or operation that failed     |
-| correlation_id    | If available       | Request or trace ID for log correlation            |
+| correlationId     | If available       | Request or trace ID for log correlation            |
 | error_count       | If threshold-based | Number of occurrences that triggered the threshold |
 | log_pointer       | If available       | Direct link or query to related log entries        |
 | runbook_url       | If available       | Link to the relevant runbook for this failure type |
@@ -170,7 +170,7 @@ Alerts must be routed through a centralised alerting platform, not sent ad-hoc v
 
 ## Common Alerting Anti-Patterns in LLM-Generated Code
 
-The following anti-patterns appear frequently in LLM-generated code and are flagged by the code-reviewer agent.
+The following anti-patterns appear frequently in LLM-generated code and are flagged by the `agent-code-reviewer`.
 
 | Anti-pattern                | Description                                                                                          | Correct approach                                                                           |
 | --------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
@@ -202,4 +202,4 @@ The mav-scope-boundaries skill interacts with alerting in an important way: when
 - [Alarm fatigue](https://en.wikipedia.org/wiki/Alarm_fatigue)
 - [Incident management](https://en.wikipedia.org/wiki/Incident_management)
 - [Site reliability engineering](https://en.wikipedia.org/wiki/Site_reliability_engineering)
-- [Monitoring (computing)](https://en.wikipedia.org/wiki/Website_monitoring)
+- [Website monitoring](https://en.wikipedia.org/wiki/Website_monitoring)

--- a/docs/standards-and-practices/cicd.md
+++ b/docs/standards-and-practices/cicd.md
@@ -5,7 +5,7 @@ relates-to:
   - comprehensive-testing.md
   - git-workflow.md
   - scope-boundaries.md
-last-verified: 2026-04-02
+last-verified: 2026-07-02
 ---
 
 # CI/CD Integration
@@ -35,13 +35,13 @@ Without CI, step 3 is absent and the only barrier is the LLM's own judgement abo
 | `mav-bp-cicd-azure`      | Azure DevOps-specific pipeline monitoring and build awareness             |
 | `mav-bp-cicd-bitbucket`  | Bitbucket Pipelines-specific monitoring and build awareness               |
 | `mav-local-verification` | Runs lint, typecheck, and tests before push (shift-left verification)     |
-| `upskill`                | Detects the project's CI platform and generates project-specific guidance |
+| `do-upskill`                | Detects the project's CI platform and generates project-specific guidance |
 
-The `upskill` skill is important here: it examines the repository for CI configuration files and generates a project-level skill that tells the LLM how this specific project's pipeline works. This means the LLM knows not just generic CI practices but the actual pipeline stages, required checks, and deployment targets for the project it is working on.
+The `do-upskill` skill is important here: it examines the repository for CI configuration files and generates a project-level skill that tells the LLM how this specific project's pipeline works. This means the LLM knows not just generic CI practices but the actual pipeline stages, required checks, and deployment targets for the project it is working on.
 
 ## Platform Support
 
-Maverick supports three CI platforms with dedicated skills and detects several more for project-level guidance.
+Maverick supports four CI platforms with dedicated skills and detects several more for project-level guidance.
 
 ### Dedicated platform skills
 
@@ -56,17 +56,17 @@ Maverick supports three CI platforms with dedicated skills and detects several m
 
 | Platform  | Config detection          | Guidance                    |
 | --------- | ------------------------- | --------------------------- |
-| Jenkins   | `Jenkinsfile`             | Project skill via `upskill` |
-| CircleCI  | `.circleci/config.yml`    | Project skill via `upskill` |
-| Buildkite | `.buildkite/pipeline.yml` | Project skill via `upskill` |
-| Travis CI | `.travis.yml`             | Project skill via `upskill` |
-| TeamCity  | `.teamcity/`              | Project skill via `upskill` |
+| Jenkins   | `Jenkinsfile`             | Project skill via `do-upskill` |
+| CircleCI  | `.circleci/config.yml`    | Project skill via `do-upskill` |
+| Buildkite | `.buildkite/pipeline.yml` | Project skill via `do-upskill` |
+| Travis CI | `.travis.yml`             | Project skill via `do-upskill` |
+| TeamCity  | `.teamcity/`              | Project skill via `do-upskill` |
 
-When `upskill` detects a CI platform, it generates a project-level skill describing the pipeline configuration, stages, and any platform-specific requirements the LLM must respect.
+When `do-upskill` detects a CI platform, it generates a project-level skill describing the pipeline configuration, stages, and any platform-specific requirements the LLM must respect.
 
 ### Maverick's own CI
 
-Maverick itself uses GitHub Actions for CI (`.github/workflows/unit-tests.yml`), running its unit test suite on pushes and PRs to `main`.
+Maverick itself uses GitHub Actions for CI (`.github/workflows/ci.yml`), running its unit test suite on pushes and PRs to `main`.
 
 ## Pipeline Stages
 
@@ -162,7 +162,7 @@ Code moves through environments in a fixed sequence. The same artefact is promot
 
 | Environment | Deployment trigger                      | Rollback            | Who approves       |
 | ----------- | --------------------------------------- | ------------------- | ------------------ |
-| Development | Automatic on merge to `develop`         | Automatic           | No approval needed |
+| Development | Automatic on merge to the trunk branch  | Automatic           | No approval needed |
 | Staging     | Automatic on release candidate tag      | Automatic           | No approval needed |
 | Production  | Manual trigger after staging validation | Manual or automatic | Human required     |
 

--- a/docs/standards-and-practices/code-review.md
+++ b/docs/standards-and-practices/code-review.md
@@ -5,12 +5,12 @@ relates-to:
   - comprehensive-testing.md
   - security-review.md
   - cicd.md
-last-verified: 2026-04-02
+last-verified: 2026-07-02
 ---
 
 # Code Review
 
-Code review is the practice of examining source code before it is merged to catch defects, enforce standards, and verify intent. In LLM-driven development, code review takes on a fundamentally different role: the code-reviewer agent provides autonomous review for every change, ensuring that even unattended LLM sessions produce code that meets project standards before it reaches a human reviewer.
+Code review is the practice of examining source code before it is merged to catch defects, enforce standards, and verify intent. In LLM-driven development, code review takes on a fundamentally different role: the `agent-code-reviewer` provides autonomous review for every change, ensuring that even unattended LLM sessions produce code that meets project standards before it reaches a human reviewer.
 
 ## Why Code Review Matters for LLM-Generated Code
 
@@ -34,7 +34,7 @@ In attended development, a human reviews code before creating a PR. In unattende
 - The LLM generates code, tests it, and creates a PR without human involvement
 - If there is no review step between code generation and PR creation, the PR contains unreviewed code
 - Human reviewers then face a large diff of LLM-generated code with no pre-screening
-- The code-reviewer agent fills this gap by reviewing every change before it becomes a PR
+- The `agent-code-reviewer` fills this gap by reviewing every change before it becomes a PR
 
 ## How Maverick Enforces Code Review
 
@@ -43,17 +43,17 @@ Maverick implements a multi-stage review process that combines autonomous agent 
 ```mermaid
 flowchart TD
     A[LLM generates code] --> B[mav-local-verification skill]
-    B -->|tests pass| C[code-reviewer agent: Stage 1]
+    B -->|tests pass| C[agent-code-reviewer: Stage 1]
     C -->|spec compliance check| D{matches requirements?}
     D -->|no| E[reject with specific feedback]
     E -->|LLM revises| A
-    D -->|yes| F[code-reviewer agent: Stage 2]
+    D -->|yes| F[agent-code-reviewer: Stage 2]
     F -->|code quality check| G{meets quality standards?}
     G -->|no| H[reject with specific feedback]
     H -->|LLM revises| A
     G -->|yes| I[PR created]
     I --> J[human review]
-    J -->|feedback via pullrequest-review skill| K{approved?}
+    J -->|feedback via do-pullrequest-review skill| K{approved?}
     K -->|no| L[LLM addresses feedback]
     L --> A
     K -->|yes| M[merged]
@@ -126,7 +126,7 @@ LLMs can misinterpret requirements while producing clean, well-tested code that 
 
 ### Why review happens before the PR
 
-Maverick's code-reviewer agent runs before a PR is created, not after. This ordering is important:
+Maverick's `agent-code-reviewer` runs before a PR is created, not after. This ordering is important:
 
 - If review happens after PR creation, the LLM has already published unreviewed code to the team
 - Issues found post-PR require rework that creates noise in the PR history (force pushes, fixup commits)
@@ -135,7 +135,7 @@ Maverick's code-reviewer agent runs before a PR is created, not after. This orde
 
 ### Human review as the final gate
 
-Autonomous review does not replace human review. It augments it. The code-reviewer agent catches mechanical issues (missing tests, convention violations, error handling gaps) so that human reviewers can focus on higher-order concerns:
+Autonomous review does not replace human review. It augments it. The `agent-code-reviewer` catches mechanical issues (missing tests, convention violations, error handling gaps) so that human reviewers can focus on higher-order concerns:
 
 - Does the design approach make sense for this project?
 - Are there architectural implications the agent could not evaluate?
@@ -144,17 +144,17 @@ Autonomous review does not replace human review. It augments it. The code-review
 
 ## Processing Review Feedback
 
-The pullrequest-review skill handles the feedback loop when human reviewers request changes on a PR.
+The `do-pullrequest-review` skill handles the feedback loop when human reviewers request changes on a PR.
 
 ### Feedback processing workflow
 
 1. Human reviewer leaves comments on the PR with requested changes
-2. The pullrequest-review skill parses the review comments
+2. The `do-pullrequest-review` skill parses the review comments
 3. Each comment is categorised: required change, suggestion, question, or nitpick
 4. Required changes are addressed by the LLM with corresponding code modifications
 5. Suggestions are evaluated and either adopted or responded to with rationale
 6. Questions are answered with references to the relevant code or requirements
-7. Modified code goes through the code-reviewer agent again before pushing
+7. Modified code goes through the `agent-code-reviewer` again before pushing
 
 ### Feedback principles
 
@@ -181,7 +181,7 @@ The pullrequest-review skill handles the feedback loop when human reviewers requ
 
 ### Scope discipline in review
 
-The code-reviewer agent also checks that the LLM's changes are appropriately scoped. LLMs sometimes make drive-by improvements to code near their changes, refactor unrelated functions, or "fix" pre-existing issues outside the task scope. While individually beneficial, these unscoped changes:
+The `agent-code-reviewer` also checks that the LLM's changes are appropriately scoped. LLMs sometimes make drive-by improvements to code near their changes, refactor unrelated functions, or "fix" pre-existing issues outside the task scope. While individually beneficial, these unscoped changes:
 
 - Make PRs harder to review by mixing intentional changes with incidental ones
 - Increase the risk of unintended side effects
@@ -193,15 +193,15 @@ The reviewer flags unscoped changes and asks the LLM to remove them or split the
 
 ### Code review and testing
 
-The code-reviewer agent checks test adequacy as part of Stage 2. It verifies that new code has tests, that tests are meaningful (not superficial), and that coverage targets are met. See comprehensive-testing.md for test quality criteria.
+The `agent-code-reviewer` checks test adequacy as part of Stage 2. It verifies that new code has tests, that tests are meaningful (not superficial), and that coverage targets are met. See comprehensive-testing.md for test quality criteria.
 
 ### Code review and security
 
-Security is **not** part of the code review process. The code-reviewer agent's scope is limited to whether the code is well-written, tested, and meets the GitHub issue requirements. Security findings are surfaced separately by `do-cybersecurity-review` (in update mode) as a mandatory pre-push gate that runs before the PR is opened — by the time a reviewer sees the PR, security findings have already been folded into the PR body. See security-review.md for the broader security pipeline.
+Security is **not** part of the code review process. The `agent-code-reviewer`'s scope is limited to whether the code is well-written, tested, and meets the GitHub issue requirements. Security findings are surfaced separately by `do-cybersecurity-review` (in update mode) as a mandatory pre-push gate that runs before the PR is opened — by the time a reviewer sees the PR, security findings have already been folded into the PR body. See security-review.md for the broader security pipeline.
 
 ### Code review and CI/CD
 
-The code-reviewer agent runs before CI. If code passes review but fails CI, the failure is typically an environment-specific issue rather than a code quality issue. The CI pipeline provides a final verification layer after human review and before merge. See cicd.md for pipeline details.
+The `agent-code-reviewer` runs before CI. If code passes review but fails CI, the failure is typically an environment-specific issue rather than a code quality issue. The CI pipeline provides a final verification layer after human review and before merge. See cicd.md for pipeline details.
 
 ## Further Reading
 

--- a/docs/standards-and-practices/comprehensive-testing.md
+++ b/docs/standards-and-practices/comprehensive-testing.md
@@ -4,7 +4,7 @@ scope: Why rigorous testing is the primary quality gate for LLM-generated code a
 relates-to:
   - code-review.md
   - cicd.md
-last-verified: 2026-04-02
+last-verified: 2026-07-02
 ---
 
 # Comprehensive Testing
@@ -54,17 +54,15 @@ Maverick enforces testing through multiple reinforcing mechanisms across the dev
 
 ```mermaid
 flowchart TD
-    A[mav-bp-unit-testing skill] -->|defines standards| B[upskill system]
+    A[mav-bp-unit-testing skill] -->|defines standards| B[do-upskill system]
     B -->|generates project-specific test guidance| C[project test skill]
     C -->|constrains LLM during coding| D[code generation with tests]
-
-    E[TDD skill] -->|test-first workflow| D
 
     D --> F[mav-local-verification skill]
     F -->|runs tests pre-commit| G{tests pass?}
     G -->|no| H[LLM fixes code or tests]
     H --> D
-    G -->|yes| I[code-reviewer agent]
+    G -->|yes| I[agent-code-reviewer]
     I -->|checks test quality| J{adequate coverage?}
     J -->|no| K[reject with feedback]
     K --> D
@@ -82,13 +80,13 @@ flowchart TD
 | mav-bp-unit-testing                       | Defines universal unit test standards: strategy, coverage targets, quality criteria      |
 | mav-bp-integration-testing                | Defines integration test standards: scope, external dependencies, data isolation         |
 | mav-local-verification                    | Requires all tests to pass locally before code is committed                              |
-| Project-specific test skill (via upskill) | Specifies the project's test framework, conventions, and additional requirements         |
+| Project-specific test skill (via do-upskill) | Specifies the project's test framework, conventions, and additional requirements       |
 
 ### Agents that enforce testing
 
-| Agent           | Role                                                                |
-| --------------- | ------------------------------------------------------------------- |
-| code-reviewer   | Checks that tests exist, are meaningful, and cover the changed code |
+| Agent                 | Role                                                                |
+| --------------------- | ------------------------------------------------------------------- |
+| `agent-code-reviewer` | Checks that tests exist, are meaningful, and cover the changed code |
 
 ### The mav-local-verification gate
 
@@ -130,13 +128,13 @@ Maverick defines a three-tier test strategy that balances thoroughness with main
 - **What to test**: The most important user workflows that, if broken, would have immediate business impact
 - **What NOT to test**: Every possible user interaction - E2E tests are expensive to write and maintain
 
-```mermaid
-pyramid
-    title Test Strategy Pyramid
-    "E2E Tests" : 10
-    "Integration Tests" : 30
-    "Unit Tests" : 60
-```
+The test strategy follows the classic pyramid — a broad base of fast unit tests, fewer integration tests, and a small number of E2E tests:
+
+| Layer             | Approximate share | Character                          |
+| ----------------- | ----------------- | ---------------------------------- |
+| Unit tests        | ~60%              | Fast, isolated — the broad base    |
+| Integration tests | ~30%              | Cross-module interaction           |
+| E2E tests         | ~10%              | Slow, full-environment — the apex  |
 
 ## Coverage Targets
 
@@ -151,7 +149,7 @@ pyramid
 
 ### Coverage as a floor, not a ceiling
 
-Coverage targets are minimum thresholds, not goals to optimise for. A codebase with 60% coverage and meaningful tests is better than one with 95% coverage full of tautological assertions. The code-reviewer agent evaluates test quality, not just coverage numbers.
+Coverage targets are minimum thresholds, not goals to optimise for. A codebase with 60% coverage and meaningful tests is better than one with 95% coverage full of tautological assertions. The `agent-code-reviewer` evaluates test quality, not just coverage numbers.
 
 ## Test Quality Criteria
 
@@ -174,7 +172,7 @@ Tests should be named to describe the behaviour being verified, not the method b
 
 ### Testing and code review
 
-The code-reviewer agent checks test adequacy as part of its code quality review. It verifies that:
+The `agent-code-reviewer` checks test adequacy as part of its code quality review. It verifies that:
 
 - New code has corresponding tests
 - Tests cover both success and error paths
@@ -200,7 +198,7 @@ This cycle is how an LLM iterates toward correctness. Without tests, the LLM has
 
 ## Maverick's Own Tests
 
-Maverick follows its own testing standards with a pytest unit test suite covering the Python codebase under `src/maverick/`. The suite includes tests for models, names, config, registry, CLI, lambda handler, and session review modules (parser, analyzers, reporter, skills). Tests run automatically on pushes and PRs to `main` via GitHub Actions (`.github/workflows/unit-tests.yml`).
+Maverick follows its own testing standards with a pytest unit test suite covering the Python codebase under `src/maverick/`. The suite includes tests for models, names, config, registry, CLI, lambda handler, and session review modules (parser, analyzers, reporter, skills). Tests run automatically on pushes and PRs to `main` via GitHub Actions (`.github/workflows/ci.yml`).
 
 ## Further Reading
 

--- a/docs/standards-and-practices/git-workflow.md
+++ b/docs/standards-and-practices/git-workflow.md
@@ -5,7 +5,7 @@ relates-to:
   - cicd.md
   - code-review.md
   - scope-boundaries.md
-last-verified: 2026-03-02
+last-verified: 2026-07-02
 ---
 
 # Git Workflow
@@ -37,7 +37,7 @@ These skills work together to constrain the LLM into a disciplined workflow that
 
 ## Branching Strategy
 
-Maverick uses a trunk-based model: `main` is the only long-lived branch. All work happens on short-lived branches that PR back to `main`.
+Maverick uses a trunk-based model: `main` is the trunk where development happens, and `stable` is a CI-managed long-lived branch that end users install from. All work happens on short-lived branches that PR back to `main`.
 
 ```mermaid
 gitGraph

--- a/docs/standards-and-practices/logging-standards.md
+++ b/docs/standards-and-practices/logging-standards.md
@@ -5,7 +5,7 @@ relates-to:
   - alerting-standards.md
   - comprehensive-testing.md
   - code-review.md
-last-verified: 2026-03-02
+last-verified: 2026-07-02
 ---
 
 # Logging Standards
@@ -55,7 +55,7 @@ flowchart TD
     A[mav-bp-logging skill] -->|defines standards| B[upskill system]
     B -->|generates project-specific guidance| C[project logging skill]
     C -->|constrains LLM during coding| D[code generation]
-    D -->|produces code with logging| E[code-reviewer agent]
+    D -->|produces code with logging| E[agent-code-reviewer]
     E -->|checks logging compliance| F{compliant?}
     F -->|yes| G[local verification]
     F -->|no| H[reject with feedback]
@@ -72,9 +72,9 @@ The mav-bp-logging skill defines universal logging standards that apply to all p
 
 The upskill system analyses a project's existing codebase and generates a project-specific logging implementation guide. This guide tells the LLM exactly which logging library to use, what format to follow, where logs are aggregated, and what project-specific fields are required. Without this layer, the LLM knows the principles but not the project's implementation.
 
-### Layer 3: code-reviewer agent
+### Layer 3: agent-code-reviewer
 
-The code-reviewer agent inspects every change for logging compliance. It checks that error paths include structured logging, that log levels are appropriate, that no sensitive data is logged, and that the project's logging library is used consistently. Violations are flagged with specific remediation guidance.
+The `agent-code-reviewer` inspects every change for logging compliance. It checks that error paths include structured logging, that log levels are appropriate, that no sensitive data is logged, and that the project's logging library is used consistently. Violations are flagged with specific remediation guidance.
 
 ## Log Levels
 
@@ -102,13 +102,14 @@ All log output must be structured as JSON with consistent fields.
 | level         | One of error, warn, debug                                 |
 | message       | Human-readable description of the event                   |
 | service       | Name of the service or application                        |
-| correlationId | Request or trace identifier for cross-service correlation |
+| context       | Object holding per-entry contextual fields (see below)    |
 
 ### Contextual fields for errors
 
-| Field         | Description                                   |
-| ------------- | --------------------------------------------- |
-| error.name    | Error class or type name                      |
+| Field          | Description                                                |
+| -------------- | ---------------------------------------------------------- |
+| correlationId  | Request or trace identifier for cross-service correlation  |
+| error.name     | Error class or type name                                   |
 | error.message | Error message text                            |
 | error.stack   | Stack trace (backend only, never frontend)    |
 | error.code    | Application-specific error code if applicable |
@@ -171,7 +172,7 @@ Logs must be routed to a centralised aggregation service rather than stored loca
 
 ## Common Logging Anti-Patterns in LLM-Generated Code
 
-The following anti-patterns appear frequently in LLM-generated code and are specifically flagged by the code-reviewer agent.
+The following anti-patterns appear frequently in LLM-generated code and are specifically flagged by the `agent-code-reviewer`.
 
 | Anti-pattern                        | Description                                                                                      | Correct approach                                                                  |
 | ----------------------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
@@ -203,11 +204,11 @@ Logging and alerting are complementary but distinct. Logging records what happen
 
 ### Logging and testing
 
-Tests should verify that error paths produce appropriate log output. The code-reviewer agent checks that error-handling code includes logging, and tests should confirm that the logged output contains the expected structured fields. See comprehensive-testing.md for test strategy details.
+Tests should verify that error paths produce appropriate log output. The `agent-code-reviewer` checks that error-handling code includes logging, and tests should confirm that the logged output contains the expected structured fields. See comprehensive-testing.md for test strategy details.
 
 ### Logging and code review
 
-The code-reviewer agent specifically checks logging compliance as part of its code quality review stage. It verifies correct log levels, structured format, no sensitive data, and consistent library usage. See code-review.md for the full review process.
+The `agent-code-reviewer` specifically checks logging compliance as part of its code quality review stage. It verifies correct log levels, structured format, no sensitive data, and consistent library usage. See code-review.md for the full review process.
 
 ## Further Reading
 

--- a/docs/standards-and-practices/security-review.md
+++ b/docs/standards-and-practices/security-review.md
@@ -5,7 +5,7 @@ relates-to:
   - scope-boundaries.md
   - llm-containment.md
   - code-review.md
-last-verified: 2026-03-02
+last-verified: 2026-07-02
 ---
 
 # Security Review

--- a/docs/vibe-coders.md
+++ b/docs/vibe-coders.md
@@ -3,24 +3,24 @@ title: Vibe Coding
 scope: A note on vibe coding
 relates-to:
   - overview.md
-last-verified: 2026-03-02
+last-verified: 2026-07-02
 ---
 
-# Vide Coding
+# Vibe Coding
 
-AI (LLM's) can be an incredible resource for software development. They can compelte in minutes what humans would take hours or days to complete.
+AI (LLM's) can be an incredible resource for software development. They can complete in minutes what humans would take hours or days to complete.
 
-The problem, is that without a clearly defined "Way of working", they can produce compelte dogshit code that might work for a while, but will ultimately fall apart. It's not that the AI cant complete the task correctly, its that innexperienced product owners or software developers dont know what to ask for. Unfortunately, the AI wont tell you that your idea is bat shit crazy or that you havent implemetned any security or scalability. It will just do exactly as you ask.
+The problem, is that without a clearly defined "Way of working", they can produce complete dogshit code that might work for a while, but will ultimately fall apart. It's not that the AI cant complete the task correctly, its that inexperienced product owners or software developers don't know what to ask for. Unfortunately, the AI wont tell you that your idea is bat shit crazy or that you havent implemented any security or scalability. It will just do exactly as you ask.
 
 Maverick aims to meet the needs of people who are working in more established software development workflows, but it can absolutely make a vibe coders life better. There is no downside to following sensible best practices and getting your AI to create reliable, maintanable and secure solutions.
 
 ## But wont this use more tokens?
 
-Yes, Maverick will eat some tokens. It needs to load additional context and it needs to be a lot more 'chatty' in the way it interacts with other servcies.
+Yes, Maverick will eat some tokens. It needs to load additional context and it needs to be a lot more 'chatty' in the way it interacts with other services.
 
 THIS IS A GOOD THING.
 
-By getting it right the first time, Maverick will save you an enourmous amount of rework later.
+By getting it right the first time, Maverick will save you an enormous amount of rework later.
 
 ## But wont it be slower?
 
@@ -28,13 +28,13 @@ Yes, Maverick takes more time to complete tasks. It thinks more, plans more and 
 
 THIS IS A GOOD THING
 
-Again, get it right the first time and you'll save an enourmous ammount of time later. You also need to keep in mind "extra time" is relative. We are not talking hours and days here. Its a few extra minutes at most.
+Again, get it right the first time and you'll save an enormous amount of time later. You also need to keep in mind "extra time" is relative. We are not talking hours and days here. Its a few extra minutes at most.
 
 ## I dont understand half of what this thing is doing
 
 Yep, thats an issue. Welcome to building software properly instead of half assing it and inflicting the results on your customers. Software development is insanely difficult. Then you need to host/distribute it, secure it, maintain it and support your users. You are going to hit a very steep learning curve and its going to hurt.
 
-Maverick tries to take away a lot of this pain. It will try to automatically improve your codebase and just start following best practices where it can. There are limits of course and at some point you should get involved in exactly what practices you want to prioratise and follow. That can come later though.
+Maverick tries to take away a lot of this pain. It will try to automatically improve your codebase and just start following best practices where it can. There are limits of course and at some point you should get involved in exactly what practices you want to prioritise and follow. That can come later though.
 
 Investing in your understanding of what it takes to create professional software will:
 

--- a/skills/do-cybersecurity-review/SKILL.md
+++ b/skills/do-cybersecurity-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: do-cybersecurity-review
-description: Run a security audit of the project's existing codebase and write a findings report to docs/security-audit.md. Covers secrets exposure, dependency vulnerabilities, authentication and authorisation patterns, input validation, transport security, and common OWASP risks. Run as part of do-init or on demand.
+description: Audit a codebase for security risks in one of two modes. In full-audit mode it scans the entire codebase and writes a findings report to docs/security-audit.md (run as part of do-init or on demand). In update mode it reviews only a diff plus the code it could impact, returning a structured findings list as a pre-push gate for do-issue-solo and do-issue-guided. Covers secrets exposure, dependency vulnerabilities, authentication and authorisation patterns, input validation, transport security, and common OWASP risks.
 user-invocable: true
 disable-model-invocation: false
 ---

--- a/skills/do-pullrequest-review/SKILL.md
+++ b/skills/do-pullrequest-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: do-pullrequest-review
-description: How to process code review feedback — verify before implementing, push back when wrong, clarify before acting on partial understanding. Applied when receiving review from the code-reviewer agent or human reviewers.
+description: How to process code review feedback — verify before implementing, push back when wrong, clarify before acting on partial understanding. Applied when receiving review from the agent-code-reviewer or human reviewers.
 disable-model-invocation: false
 ---
 

--- a/src/maverick/skills/do-cybersecurity-review/config.py
+++ b/src/maverick/skills/do-cybersecurity-review/config.py
@@ -8,11 +8,14 @@ from maverick.names import (
 CONFIG = SkillConfig(
     name=DO_CYBERSECURITY_REVIEW,
     description=(
-        "Run a security audit of the project's existing codebase and write a "
-        "findings report to docs/security-audit.md. Covers secrets exposure, "
-        "dependency vulnerabilities, authentication and authorisation patterns, "
-        "input validation, transport security, and common OWASP risks. Run as "
-        "part of do-init or on demand."
+        "Audit a codebase for security risks in one of two modes. In full-audit "
+        "mode it scans the entire codebase and writes a findings report to "
+        "docs/security-audit.md (run as part of do-init or on demand). In update "
+        "mode it reviews only a diff plus the code it could impact, returning a "
+        "structured findings list as a pre-push gate for do-issue-solo and "
+        "do-issue-guided. Covers secrets exposure, dependency vulnerabilities, "
+        "authentication and authorisation patterns, input validation, transport "
+        "security, and common OWASP risks."
     ),
     user_invocable=True,
     disable_model_invocation=False,

--- a/src/maverick/skills/do-pullrequest-review/config.py
+++ b/src/maverick/skills/do-pullrequest-review/config.py
@@ -4,7 +4,7 @@ from maverick.names import DO_PULLREQUEST_REVIEW
 CONFIG = SkillConfig(
     name=DO_PULLREQUEST_REVIEW,
     description=(
-        "How to process code review feedback — verify before implementing, push back when wrong, clarify before acting on partial understanding. Applied when receiving review from the code-reviewer agent or human reviewers."
+        "How to process code review feedback — verify before implementing, push back when wrong, clarify before acting on partial understanding. Applied when receiving review from the agent-code-reviewer or human reviewers."
     ),
     user_invocable=False,
     disable_model_invocation=False,


### PR DESCRIPTION
## Summary

Re-verifies every doc under `docs/` against the actual source and fixes accumulated drift found in a full documentation review.

### High severity
- **maverick-build.md**: real `release.sh` bump-type API (`patch|minor|major`), tagging clarified as CI-side, fixed dangling `relates-to`.
- **claude-code-error-handling-and-recovery.md**: removed the fictional "task workflow", corrected the issue-state schema and phase enum, realigned the recovery-phases table.
- **git-workflow.md**: corrected the `main`/`stable` long-lived-branch description.
- **cicd.md / comprehensive-testing.md**: `unit-tests.yml` → `ci.yml`.

### Medium
Skill/agent counts (44→54, 7→6), removed nonexistent `do-task-*` / `agent-task-planner`, `cli/`→`src/maverick/`, fixed the one broken link, skill-name prefixes, `develop`→`story_base`, `maverick-needs-human`→`needs-human`, `maverick-bprop` marker, three→four CI platforms, `upskill`→`do-upskill`, removed the nonexistent "TDD skill", replaced the invalid `pyramid` Mermaid, `code-reviewer agent`→`agent-code-reviewer`, `pullrequest-review`→`do-pullrequest-review`, webhook trigger-label note, scope-boundaries destructive-git example, `merged-to-<branch>` label.

### Low / cosmetic
Added `docs/README.md` index, refreshed all `last-verified` dates, standardized `correlationId`, fixed the alerting link and typos.

Also regenerates two skills whose source `config.py` descriptions were corrected (do-cybersecurity-review modes, do-pullrequest-review agent name) — those live in the follow-on commit under `src/` + `skills/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)