### PR TITLE
Release 4.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,12 +5,12 @@
     "name": "David Cheal",
     "email": "david.cheal@thermite.au"
   },
-  "version": "3.3.10-dev",
+  "version": "4.0.0",
   "plugins": [
     {
       "name": "maverick",
       "description": "Skills, Agents, and Hooks for autonomous AI development. Claude Code, Cursor IDE, Codex.",
-      "version": "3.3.10-dev",
+      "version": "4.0.0",
       "source": "./",
       "author": {
         "name": "David Cheal",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "maverick",
   "description": "Autonomous AI development skills, agents, and hooks for Claude Code",
-  "version": "3.3.10-dev",
+  "version": "4.0.0",
   "author": {
     "name": "David Cheal",
     "email": "david.cheal@thermite.au"

--- a/.cursor-plugin/cursor.plugin.json
+++ b/.cursor-plugin/cursor.plugin.json
@@ -2,7 +2,7 @@
   "name": "maverick",
   "displayName": "Maverick",
   "description": "Autonomous AI development skills, agents, and hooks for Claude Code",
-  "version": "3.3.10-dev",
+  "version": "4.0.0",
   "author": {
     "name": "David Cheal",
     "email": "david.cheal@thermite.au"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0] - 2026-07-03
+
 A ground-up modernization of the plugin and CLI. Safety rules are now
 mechanically enforced, workflow state lives in one durable place, the
 hot-loop orchestration is deterministic code instead of prose, and the
@@ -316,7 +318,8 @@ First major release. The workflow shape changes substantially: every Maverick ac
 - AWS infrastructure provisioning support
 - Enforcement chain: best-practice skill → project skill → local verification → CI pipeline → agent review → human review
 
-[Unreleased]: https://github.com/thermiteau/maverick/compare/v3.3.9...HEAD
+[Unreleased]: https://github.com/thermiteau/maverick/compare/v4.0.0...HEAD
+[4.0.0]: https://github.com/thermiteau/maverick/compare/v3.3.8...v4.0.0
 [3.3.9]: https://github.com/thermiteau/maverick/compare/v3.3.8...v3.3.9
 [3.3.8]: https://github.com/thermiteau/maverick/compare/v3.3.7...v3.3.8
 [3.3.7]: https://github.com/thermiteau/maverick/compare/v3.3.6...v3.3.7

--- a/agents/agent-code-reviewer.md
+++ b/agents/agent-code-reviewer.md
@@ -202,4 +202,4 @@ MAVERICK_VERDICT: FAIL
 - **If in doubt, FAIL.** A conservative eject is recoverable via human
   review; a lenient PASS merges broken code.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/agents/agent-github-issue-planner.md
+++ b/agents/agent-github-issue-planner.md
@@ -87,4 +87,4 @@ checklist | sub-issues
 - **Scope boundaries** — follow the mav-scope-boundaries skill. Flag any tasks that touch infrastructure, auth, or destructive operations.
 - **Durable output** — always post the tasks comment and update the state file before returning, so work is not lost if the caller's session crashes.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/agents/agent-issue-analyst.md
+++ b/agents/agent-issue-analyst.md
@@ -80,4 +80,4 @@ Return a structured message containing:
 - **Right-sized design** — scale design depth to the task per the mav-create-solution-design skill's sizing table.
 - **Durable output** — always post the design comment and update the state file before returning, so work is not lost if the caller's session crashes.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/agents/agent-session-reviewer.md
+++ b/agents/agent-session-reviewer.md
@@ -92,4 +92,4 @@ Return your findings as structured markdown:
 - **Consider context** — prototyping code has different standards than production code
 - **Focus on actionable findings** — each finding should suggest what to do differently
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/agents/agent-tech-docs-writer.md
+++ b/agents/agent-tech-docs-writer.md
@@ -30,4 +30,4 @@ You are a Senior Technical Documentation Writer. Your role is to produce clear, 
 - **Right-sized** — scale documentation depth to the topic's complexity
 - **Project-agnostic** — do not assume any specific technology stack; discover it from the codebase
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maverick"
-version = "3.3.10-dev"
+version = "4.0.0"
 description = "Claude Code plugin that enables autonomous AI development while maintaining best practices"
 requires-python = ">=3.10"
 dependencies = [

--- a/skills/do-adopt/SKILL.md
+++ b/skills/do-adopt/SKILL.md
@@ -131,4 +131,4 @@ Follow the mav-git-workflow skill for commit conventions. Do not push — the us
 - **One commit per topic** — separate commits make it easy to review or revert individual adoptions
 - **One recommendation format** — the `status: recommended` project skill; never a parallel recommendations document
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/do-code/SKILL.md
+++ b/skills/do-code/SKILL.md
@@ -129,4 +129,4 @@ that is the signal: scroll back to the calling workflow's per-task
 loop and resume from the step immediately after the
 `/do-code` invocation.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/do-cybersecurity-review/SKILL.md
+++ b/skills/do-cybersecurity-review/SKILL.md
@@ -273,4 +273,4 @@ that is the signal: scroll back to the calling workflow and resume
 from the step immediately after the
 `/do-cybersecurity-review` dispatch.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/do-docs/SKILL.md
+++ b/skills/do-docs/SKILL.md
@@ -182,4 +182,4 @@ Run the do-tech-docs validation checklist against every document changed or crea
 - In **update** mode, scope narrowly to the diff — do not refactor surrounding documentation
 - Verify every factual claim against the source code before writing it
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/do-epic/SKILL.md
+++ b/skills/do-epic/SKILL.md
@@ -277,4 +277,4 @@ state.
 - **Never auto-close an epic with ejected stories.** Those belong to the
   human.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/do-init/SKILL.md
+++ b/skills/do-init/SKILL.md
@@ -180,4 +180,4 @@ Print a final summary to the user:
 
 The integration checklist gives the user (and any future Maverick session) a clear view of what's been completed and what's still pending.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/do-install/SKILL.md
+++ b/skills/do-install/SKILL.md
@@ -37,4 +37,4 @@ FAILURE, what was done, and any warnings.
 
 4. **Report.** Return a structured result: install path, whether the settings file was modified or already had the permission entry, and any PATH warnings.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/do-issue-guided/SKILL.md
+++ b/skills/do-issue-guided/SKILL.md
@@ -200,4 +200,4 @@ their commits landed unreviewed.
 - **Use conventional commits** that reference the issue number (e.g., `feat: add rubric export (#42)`).
 - **Always create a PR** at the end — deliver a complete result.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/do-issue-solo/SKILL.md
+++ b/skills/do-issue-solo/SKILL.md
@@ -584,4 +584,4 @@ next step is eject-to-human, not iterate.
 - **Never remove a `blocked-by:#N` label from inside the workflow.** Only a
   human may clear a block.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/do-maverick-alignment/SKILL.md
+++ b/skills/do-maverick-alignment/SKILL.md
@@ -412,4 +412,4 @@ uv run maverick integration set alignment true
 This commits the milestone into `.maverick/config.json` — the file is in git
 so the state is durable across machines and contributors.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/do-pullrequest-review/SKILL.md
+++ b/skills/do-pullrequest-review/SKILL.md
@@ -159,4 +159,4 @@ When receiving review during a do-issue workflow:
 4. If the review came from the agent-code-reviewer agent and had spec compliance failures, request a re-review after fixing
 5. Update the plan comment on the issue if fixes changed the implementation approach
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/do-tech-docs/SKILL.md
+++ b/skills/do-tech-docs/SKILL.md
@@ -193,4 +193,4 @@ Before finalising documentation:
 - [ ] All public exports from documented modules are covered (check for multiple exports per file)
 - [ ] Numbering, terminology, and facts are consistent across all documents in the set
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/do-test/SKILL.md
+++ b/skills/do-test/SKILL.md
@@ -141,4 +141,4 @@ that is the signal: scroll back to the calling workflow's per-task
 loop and resume from the step immediately after the
 `/do-test` invocation.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/do-upskill/SKILL.md
+++ b/skills/do-upskill/SKILL.md
@@ -401,4 +401,4 @@ single source of truth shared with `topics.json`:
 - **grep**: `dotenv|process\.env|os\.environ|docker-compose|devcontainer|CONTRIBUTING`
 - **files**: `.env.example`, `.env.sample`, `.env.template`, `.devcontainer/**`, `docker-compose*.yml`, `Vagrantfile`, `flake.nix`, `shell.nix`, `CONTRIBUTING.md`
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-block-propagation/SKILL.md
+++ b/skills/mav-block-propagation/SKILL.md
@@ -76,4 +76,4 @@ the story run on the next wave.
 - **Always re-check at entry.** Another instance may have applied or
   removed a label since your run started.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-bp-accessibility/SKILL.md
+++ b/skills/mav-bp-accessibility/SKILL.md
@@ -44,4 +44,4 @@ When reviewing code for user-facing interfaces, flag these patterns:
 | Custom widget without keyboard handling | Inoperable for keyboard users | Implement full keyboard interaction pattern |
 | Error shown only by colour change | Screen readers cannot detect colour | Add text message and `aria-describedby` |
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-bp-api-design/SKILL.md
+++ b/skills/mav-bp-api-design/SKILL.md
@@ -42,4 +42,4 @@ When reviewing code, flag these patterns:
 | No idempotency on payment/financial endpoints      | Duplicate processing risk          | Require idempotency keys                               |
 | API docs maintained separately from code           | Documentation drift                | Generate docs from source (OpenAPI, introspection)     |
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-bp-application-security/SKILL.md
+++ b/skills/mav-bp-application-security/SKILL.md
@@ -51,4 +51,4 @@ Check for `docs/maverick/skills/application-security/SKILL.md`. If present, read
 | Deserialisation of untrusted data                        | Remote code execution        | Avoid deserialising untrusted input; use safe formats (JSON) |
 | Missing `HttpOnly`/`Secure` flags on session cookies     | Session hijacking            | Set `HttpOnly`, `Secure`, and `SameSite` on all auth cookies |
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-bp-cicd/SKILL.md
+++ b/skills/mav-bp-cicd/SKILL.md
@@ -71,4 +71,4 @@ configuration, change stages/jobs/gates, touch CI secrets or environment
 variables, or trigger production deployments. Always: monitor CI after
 pushing and fix failures before declaring work complete.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-bp-code-review/SKILL.md
+++ b/skills/mav-bp-code-review/SKILL.md
@@ -40,4 +40,4 @@ Split strategies: by layer (backend vs frontend), by feature slice (one endpoint
 | Self-approval on protected branch                  | Missing review gate                | Configure branch protection to disallow self-approval |
 | Skipping CI to merge faster                        | Bypassing quality gates            | CI must pass; fix failures, do not skip them         |
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-bp-database-management/SKILL.md
+++ b/skills/mav-bp-database-management/SKILL.md
@@ -42,4 +42,4 @@ When reviewing code, flag these patterns:
 | `DROP TABLE` or `DROP COLUMN` without staged rollout| Breaks running application        | Stage the change: remove code references first         |
 | No transaction wrapping for multi-step migration   | Partial application on failure     | Wrap in transaction where the database supports it     |
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-bp-dependency-management/SKILL.md
+++ b/skills/mav-bp-dependency-management/SKILL.md
@@ -40,4 +40,4 @@ Check for `docs/maverick/skills/dependency-management/SKILL.md`. If present, rea
 | Large transitive dependency addition | Unexpected supply chain expansion | Investigate and consider lighter alternatives |
 | `--force` or `--legacy-peer-deps` in install commands | Masking resolution conflicts | Fix the underlying version conflict |
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-bp-environment-management/SKILL.md
+++ b/skills/mav-bp-environment-management/SKILL.md
@@ -49,4 +49,4 @@ Check for `docs/maverick/skills/environment-management/SKILL.md`. If present, re
 
 This skill covers local/dev environments only (devcontainers, Docker Compose for local services, `.env`, version pinning, onboarding). Deployed environments — Terraform, CloudFormation, Kubernetes, cloud provisioning — belong to `mav-bp-infrastructure-as-code`. When an artifact serves both (e.g., Compose used in local dev and CI), follow both.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-bp-error-handling/SKILL.md
+++ b/skills/mav-bp-error-handling/SKILL.md
@@ -39,4 +39,4 @@ Check for `docs/maverick/skills/error-handling/SKILL.md`. If present, read it â€
 | No error boundary around UI sections                | Single component crashes page  | Wrap sections in error boundaries with fallback UI |
 | Generic error message for all failures              | Poor user experience           | Distinguish client vs server errors                |
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-bp-infrastructure-as-code/SKILL.md
+++ b/skills/mav-bp-infrastructure-as-code/SKILL.md
@@ -37,4 +37,4 @@ Check for `docs/maverick/skills/infrastructure-as-code/SKILL.md`. If present, re
 | Destructive changes auto-applied               | Accidental data loss           | Require human approval for destroy/replace actions   |
 | Mixed IaC tools for the same resource layer    | Conflicting state management   | Standardise on one tool per layer                    |
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-bp-linting/SKILL.md
+++ b/skills/mav-bp-linting/SKILL.md
@@ -37,4 +37,4 @@ Check for `docs/maverick/skills/linting/SKILL.md`. If present, read it and follo
 | No pre-commit formatting | Style inconsistency across commits | Add lint-staged or equivalent |
 | Linter running on generated/vendor code | False positives, slow runs | Update ignore patterns |
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-bp-operability/SKILL.md
+++ b/skills/mav-bp-operability/SKILL.md
@@ -83,4 +83,4 @@ gap in your summary — do not trigger skill generation mid-task.
 | No correlation ID in log entries                   | Cannot link logs to traces    | Include trace ID in structured log context   |
 | SLO defined but not measured                       | False confidence              | Instrument the SLI and track the target      |
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-bp-remote-code-review/SKILL.md
+++ b/skills/mav-bp-remote-code-review/SKILL.md
@@ -63,4 +63,4 @@ Either condition alone is not enough. The marker without a `pull_request:` trigg
 - **Workflow absent** → INFO, noting that the local agent review is the gate by default and pointing to this skill if the project wants the optional CI gate.
 - **Workflow present but malformed** (marker without `pull_request:` trigger, or vice versa) → WARN, since the team's intent is unclear.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-bp-testing/SKILL.md
+++ b/skills/mav-bp-testing/SKILL.md
@@ -71,4 +71,4 @@ your summary — do not trigger skill generation mid-task.
 | Hard-coded connection strings | Breaks across environments | Use environment variables or config |
 | Test requires manual environment setup | Not reproducible | Automate with containers or scripts |
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-claude-code-recovery/SKILL.md
+++ b/skills/mav-claude-code-recovery/SKILL.md
@@ -105,4 +105,4 @@ When a subagent fails or returns incomplete results:
 - **Reduce scope on repeated failure** — if a subagent fails twice on the same task, split the task into smaller pieces.
 - **Never silently swallow failures** — if a subagent fails and you cannot recover, report the failure clearly to the user.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-create-solution-design/SKILL.md
+++ b/skills/mav-create-solution-design/SKILL.md
@@ -118,4 +118,4 @@ Before the design is considered complete:
 - [ ] Risks are honest — if there are none, you haven't looked hard enough
 - [ ] The approach is achievable in a single session (if not, flag for further decomposition)
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-create-tasks/SKILL.md
+++ b/skills/mav-create-tasks/SKILL.md
@@ -139,4 +139,4 @@ Before the task list is considered complete:
 - [ ] Dependencies between tasks are minimal and explicitly stated
 - [ ] The sum of all tasks fully implements the solution design
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-durability-on-gh/SKILL.md
+++ b/skills/mav-durability-on-gh/SKILL.md
@@ -184,4 +184,4 @@ Keep these strictly local:
 If a piece of state is regenerable within one task, don't mirror it to GitHub.
 The markers are a narrow coordination surface, not a storage layer.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-git-workflow/SKILL.md
+++ b/skills/mav-git-workflow/SKILL.md
@@ -443,4 +443,4 @@ If there are uncommitted changes:
 - **Stash them** if they are unrelated: `git stash push -m "WIP: description"`
 - **Ask the user** if you are unsure what to do with them
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-github-issue-workflow/SKILL.md
+++ b/skills/mav-github-issue-workflow/SKILL.md
@@ -170,4 +170,4 @@ inspects CI and the review verdict, and returns `{next, instruction,
 evidence}`. Follow the instruction. If the evidence contradicts what you
 observe locally, GitHub wins — local files are a cache.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-local-verification/SKILL.md
+++ b/skills/mav-local-verification/SKILL.md
@@ -104,4 +104,4 @@ Not every change needs the full suite:
 
 For the final push before PR creation, always run the full suite regardless of change type.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-multi-instance-coordination/SKILL.md
+++ b/skills/mav-multi-instance-coordination/SKILL.md
@@ -168,4 +168,4 @@ produces false confidence.
   entire epic when you only intend to work on one wave blocks other
   instances unnecessarily.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-plan-execution/SKILL.md
+++ b/skills/mav-plan-execution/SKILL.md
@@ -113,4 +113,4 @@ After all steps are complete and the full verification suite passes:
 
 Do not proceed to code review until every acceptance criterion is met and all checks pass.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-scope-boundaries/SKILL.md
+++ b/skills/mav-scope-boundaries/SKILL.md
@@ -199,4 +199,4 @@ This task requires interaction with a production system that Claude Code cannot 
 *Posted by Claude Code*
 ```
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-stacked-prs/SKILL.md
+++ b/skills/mav-stacked-prs/SKILL.md
@@ -169,4 +169,4 @@ orphan.
 - **Cross-reference `mav-git-workflow`** for conventional commit
   format, branch naming, and conflict resolution.
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/skills/mav-systematic-debugging/SKILL.md
+++ b/skills/mav-systematic-debugging/SKILL.md
@@ -173,4 +173,4 @@ When debugging occurs during plan execution (do-issue workflows):
 3. **Log diagnostic findings** — if the bug reveals a design issue, update the solution design comment on the issue
 4. **Time-box debugging** — if Phase 1 takes more than 30 minutes without progress, escalate to the user rather than continuing to investigate alone
 
-<!-- maverick-plugin-version: 3.3.10-dev -->
+<!-- maverick-plugin-version: 4.0.0 -->

--- a/uv.lock
+++ b/uv.lock
@@ -310,7 +310,7 @@ wheels = [
 
 [[package]]
 name = "maverick"
-version = "3.3.10.dev0"
+version = "4.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Release 4.0.0


A ground-up modernization of the plugin and CLI. Safety rules are now
mechanically enforced, workflow state lives in one durable place, the
hot-loop orchestration is deterministic code instead of prose, and the
skill corpus is roughly half its former size while carrying more
project-steering content. The full pipeline is validated end-to-end
against a real repository (issue → design → tasks → implementation →
docs and security gates → PR → review → auto-merge), including crash
recovery via stale-claim takeover.

### Added

- **Mechanical scope-boundary enforcement.** A `PreToolUse` scope-guard
  hook gates destructive git operations, commits/pushes on protected
  branches, infrastructure-path edits, and production-pattern commands —
  asking in interactive sessions, denying in autonomous runs, and denying
  production patterns in every mode. `maverick init` additionally writes
  baseline permission deny rules so a second layer holds even with hooks
  disabled.
- **Verified authorization.** `maverick coord authorize` grants guarded
  scopes (e.g. `infra`) only when the GitHub issue itself carries the
  authorization label or body marker; agents cannot self-grant, and the
  guard blocks direct writes to the authorization file.
- **Pre-merge auth scan.** `maverick pr auth-scan` blocks auto-merging
  any PR touching authentication surfaces or CI workflow definitions,
  independent of the review verdict.
- **Deterministic workflow verbs.** `coord resume-point` (computes the
  resume position from GitHub state), `coord heartbeat-loop --daemonize`
  + `heartbeat-status` (pidfile-managed lease refresh), `coord
  release-all`, `tasks check` (idempotent checklist updates), `bprop run`
  (the whole block-propagation walk as one resumable command), `issue
  comment post/update` (artefact comments with ids recorded
  automatically), `docs shortlist`, `pr wait` (bounded waits with
  distinct exit codes), and `gh-state write`.
- **Automatic claim release.** A `SessionEnd` hook releases every claim
  the session still holds; lease expiry remains the designed backstop for
  machine death.
- **Automatic report bookkeeping.** Subagent lifecycle hooks record
  agent-dispatch intervals; invoking a tracked inner skill opens its
  interval; `report end --auto` closes the most recent interval with one
  short command; `report generate` flushes anything left open. The
  workflow report now assembles itself.
- **GitHub Action on-ramp.** `templates/github/claude-maverick.yml` runs
  Maverick on GitHub-hosted runners — `@claude` mentions for interactive
  help, or label an issue `claude-do` for an end-to-end autonomous run.
  A decision matrix in the docs compares it with Claude cloud routines
  and the self-hosted EC2 pipeline.
- **Build-time guarantees.** The skill/agent build now fails loudly on
  unknown template variables, validates every config against its
  directory and the name registry, YAML-serializes frontmatter, and lints
  that every non-invocable skill has at least one consumer.

### Changed

- **One state surface.** Issue-workflow state lives entirely in the
  `maverick-task-progress` marker on the GitHub issue — phase, branch,
  artefact comment ids, and authorized scopes, written only through the
  CLI with merge semantics. The local `.claude/issue-state.json` file is
  gone, and with it the schema drift between the file, the marker, and
  the skills.
- **A hardened merge gate.** `agent-code-reviewer` is read-only
  (no file-editing tools), pinned to a strong model rather than
  inheriting the caller's, and returns a machine-parsed
  `MAVERICK_VERDICT: PASS|FAIL` marker — a missing or ambiguous marker is
  treated as FAIL. Planner and session-reviewer run on a fast model
  suited to their mechanical tasks.
- **A leaner, sharper skill corpus.** Best-practice skills are rewritten
  around Maverick's actual decisions plus their code-review anti-pattern
  tables: logging, alerting, and observability merge into
  `mav-bp-operability`; unit and integration testing merge into
  `mav-bp-testing`; the four CI platform skills collapse into a
  per-platform command table inside `mav-bp-cicd`. The workflow cluster
  is deduplicated to one owner per topic with a single canonical retry
  budget. Overall instruction load drops by roughly half.
- **Self-contained flows run isolated.** `do-init`, `do-install`,
  `do-adopt`, `do-cybersecurity-review`, and `do-maverick-alignment` run
  in forked contexts, keeping the caller's window clean.
- **Guided reviews review what ships.** `do-issue-guided` now runs code
  review after the documentation and security phases, so the approved
  diff is the merged diff, and it checks for existing autonomous claims
  before starting.
- **Upskill, consolidated.** `do-upskill` supports single-topic
  generation, resolves plugin paths correctly from any project, draws
  detection hints from one generated registry, and writes thin
  `.claude/rules/` pointers so any session finds the project facts.
  `do-adopt recommend` replaces the standalone `do-recommend` skill with
  a single recommendation artifact format.
- The alignment audit verifies the testing coverage gate it previously
  only preached, and documents which practice areas are audit-backed
  versus advisory.

### Removed

- `.claude/issue-state.json` and all jq-based state plumbing.
- `agent-maverick` — forked skill contexts do its job natively.
- `do-recommend` (folded into `do-adopt`), the four platform CI/CD
  skills (absorbed into `mav-bp-cicd`), and five unreferenced
  best-practice skills, with their few load-bearing rules folded into
  the skills that are actually loaded.

### Fixed

- `{{ ARGUMENTS }}` now renders as the runtime `$ARGUMENTS` placeholder
  in built skills; argument-bearing commands work as written.
- `user-invocable`/`disable-model-invocation` frontmatter is emitted
  explicitly, so reference skills actually ship non-invocable.
- Agent frontmatter renders with a correct closing delimiter, and values
  containing YAML metacharacters round-trip safely.
- Subagent lifecycle hooks recognise namespaced plugin agent names.
- Unit tests no longer write to the developer's real claims registry.

---

**After squash-merging this PR**, the `release-finalize` workflow will automatically:
1. Tag the merge commit with `v4.0.0`
2. Create a GitHub Release
3. Open a follow-up PR that bumps `main` to the next `-dev` version