### PR TITLE
fix: align instance-id resolution so scope guard classifies autonomous runs (#130)

### DIFF
--- a/hooks/scope_guard.py
+++ b/hooks/scope_guard.py
@@ -128,22 +128,47 @@ def _load_project_guards(cwd: Path) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def _instance_id(env: dict[str, str]) -> str | None:
-    """Mirror coordinator.instance_id()'s env-based derivation (read-only)."""
+def _instance_id_path() -> Path:
+    """Where coordinator.instance_id() persists the per-user id."""
+    return Path("~/.maverick/instance_id").expanduser()
+
+
+def _instance_id(env: dict[str, str], id_path: Path | None = None) -> str | None:
+    """Mirror coordinator.instance_id()'s derivation (read-only, never writes).
+
+    The rungs must match ``coordinator.instance_id()`` exactly, or the hook
+    and the coordinator can land on different ids and disagree about whether
+    a claim belongs to this instance. In particular the file fallback is
+    essential: hooks run in a separately-spawned subprocess that in some
+    Claude Code versions does not receive the session-id env, so without it
+    the hook would fall straight to ``None`` while the coordinator resolved a
+    real id via the session hash (or the file). Read-only: the hook must
+    never generate or persist an id — that is the coordinator's job.
+    """
     explicit = env.get("MAVERICK_INSTANCE_ID")
     if explicit:
         return explicit
     session = env.get("CLAUDE_CODE_SESSION_ID") or env.get("CLAUDE_SESSION_ID")
     if session:
         return hashlib.sha256(session.encode("utf-8")).hexdigest()[:10]
+    try:
+        cached = (id_path or _instance_id_path()).read_text().strip()
+        if cached:
+            return cached
+    except OSError:
+        pass
     return None
 
 
-def is_autonomous(env: dict[str, str], claims_path: Path | None = None) -> bool:
+def is_autonomous(
+    env: dict[str, str],
+    claims_path: Path | None = None,
+    id_path: Path | None = None,
+) -> bool:
     """Autonomous = explicit env flag, or this instance holds a local claim."""
     if env.get("MAVERICK_AUTONOMOUS") == "1":
         return True
-    instance = _instance_id(env)
+    instance = _instance_id(env, id_path)
     if not instance:
         return False
     path = claims_path or Path("~/.maverick/active-claims.json").expanduser()
@@ -381,7 +406,8 @@ def decide(payload: dict) -> Verdict:
 
 
 def resolve(verdict: Verdict, payload: dict, env: dict[str, str],
-            claims_path: Path | None = None) -> Verdict:
+            claims_path: Path | None = None,
+            id_path: Path | None = None) -> Verdict:
     """Apply the interactive-vs-autonomous policy to a rule hit."""
     if verdict.decision == ALLOW:
         return verdict
@@ -389,10 +415,14 @@ def resolve(verdict: Verdict, payload: dict, env: dict[str, str],
         return Verdict(DENY, verdict.reason, always_deny=True)
 
     cwd = Path(payload.get("cwd") or ".")
-    if is_autonomous(env, claims_path):
-        # Autonomous: infra edits are allowed only with recorded authorization.
-        if "infrastructure" in verdict.reason and "infra" in _session_auth_scopes(cwd):
-            return _ALLOW
+    # A recorded `infra` grant authorizes infrastructure edits in *any* mode.
+    # `maverick coord authorize` only writes it after verifying issue-level
+    # authorization, so an explicit grant should suppress the prompt whether
+    # the run is classified interactive or autonomous — a misclassification
+    # must not defeat an authorization the user has already recorded.
+    if "infrastructure" in verdict.reason and "infra" in _session_auth_scopes(cwd):
+        return _ALLOW
+    if is_autonomous(env, claims_path, id_path):
         return Verdict(
             DENY,
             verdict.reason

--- a/src/maverick/coordinator.py
+++ b/src/maverick/coordinator.py
@@ -112,6 +112,29 @@ def _instance_id_path() -> Path:
     return Path("~/.maverick/instance_id").expanduser()
 
 
+def _mirror_instance_id(value: str) -> None:
+    """Best-effort: persist *value* to the instance-id file.
+
+    Keeps the file cache in sync with the live session-derived id so an
+    env-less sibling process (the scope-guard hook) resolves the same id via
+    its file fallback. Writes only when the file is missing or differs, to
+    avoid needless churn, and self-heals a file that holds a stale id from an
+    earlier env-less ``coord`` run. Failures are swallowed — the file cache
+    is an optimisation, never a correctness requirement here.
+    """
+    path = _instance_id_path()
+    try:
+        if path.read_text().strip() == value:
+            return
+    except OSError:
+        pass
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(value)
+    except OSError:
+        pass
+
+
 def _claims_registry_path() -> Path:
     """Local registry of claims held by instances on this machine.
 
@@ -199,6 +222,13 @@ def instance_id() -> str:
     if session:
         value = hashlib.sha256(session.encode("utf-8")).hexdigest()[:10]
         os.environ["MAVERICK_INSTANCE_ID"] = value
+        # Mirror the session-derived id to the file cache so a separately
+        # spawned process that lacks the session env — notably the
+        # scope-guard PreToolUse hook — resolves the *same* id via its
+        # read-only file fallback instead of landing on a stale random id.
+        # Without this the two derivation ladders can fork and the hook
+        # misclassifies an autonomous run as interactive (issue #130).
+        _mirror_instance_id(value)
         return value
     path = _instance_id_path()
     try:

--- a/src/maverick/hooks/scope_guard.py
+++ b/src/maverick/hooks/scope_guard.py
@@ -128,22 +128,47 @@ def _load_project_guards(cwd: Path) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def _instance_id(env: dict[str, str]) -> str | None:
-    """Mirror coordinator.instance_id()'s env-based derivation (read-only)."""
+def _instance_id_path() -> Path:
+    """Where coordinator.instance_id() persists the per-user id."""
+    return Path("~/.maverick/instance_id").expanduser()
+
+
+def _instance_id(env: dict[str, str], id_path: Path | None = None) -> str | None:
+    """Mirror coordinator.instance_id()'s derivation (read-only, never writes).
+
+    The rungs must match ``coordinator.instance_id()`` exactly, or the hook
+    and the coordinator can land on different ids and disagree about whether
+    a claim belongs to this instance. In particular the file fallback is
+    essential: hooks run in a separately-spawned subprocess that in some
+    Claude Code versions does not receive the session-id env, so without it
+    the hook would fall straight to ``None`` while the coordinator resolved a
+    real id via the session hash (or the file). Read-only: the hook must
+    never generate or persist an id — that is the coordinator's job.
+    """
     explicit = env.get("MAVERICK_INSTANCE_ID")
     if explicit:
         return explicit
     session = env.get("CLAUDE_CODE_SESSION_ID") or env.get("CLAUDE_SESSION_ID")
     if session:
         return hashlib.sha256(session.encode("utf-8")).hexdigest()[:10]
+    try:
+        cached = (id_path or _instance_id_path()).read_text().strip()
+        if cached:
+            return cached
+    except OSError:
+        pass
     return None
 
 
-def is_autonomous(env: dict[str, str], claims_path: Path | None = None) -> bool:
+def is_autonomous(
+    env: dict[str, str],
+    claims_path: Path | None = None,
+    id_path: Path | None = None,
+) -> bool:
     """Autonomous = explicit env flag, or this instance holds a local claim."""
     if env.get("MAVERICK_AUTONOMOUS") == "1":
         return True
-    instance = _instance_id(env)
+    instance = _instance_id(env, id_path)
     if not instance:
         return False
     path = claims_path or Path("~/.maverick/active-claims.json").expanduser()
@@ -381,7 +406,8 @@ def decide(payload: dict) -> Verdict:
 
 
 def resolve(verdict: Verdict, payload: dict, env: dict[str, str],
-            claims_path: Path | None = None) -> Verdict:
+            claims_path: Path | None = None,
+            id_path: Path | None = None) -> Verdict:
     """Apply the interactive-vs-autonomous policy to a rule hit."""
     if verdict.decision == ALLOW:
         return verdict
@@ -389,10 +415,14 @@ def resolve(verdict: Verdict, payload: dict, env: dict[str, str],
         return Verdict(DENY, verdict.reason, always_deny=True)
 
     cwd = Path(payload.get("cwd") or ".")
-    if is_autonomous(env, claims_path):
-        # Autonomous: infra edits are allowed only with recorded authorization.
-        if "infrastructure" in verdict.reason and "infra" in _session_auth_scopes(cwd):
-            return _ALLOW
+    # A recorded `infra` grant authorizes infrastructure edits in *any* mode.
+    # `maverick coord authorize` only writes it after verifying issue-level
+    # authorization, so an explicit grant should suppress the prompt whether
+    # the run is classified interactive or autonomous — a misclassification
+    # must not defeat an authorization the user has already recorded.
+    if "infrastructure" in verdict.reason and "infra" in _session_auth_scopes(cwd):
+        return _ALLOW
+    if is_autonomous(env, claims_path, id_path):
         return Verdict(
             DENY,
             verdict.reason

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -108,7 +108,11 @@ class TestInstanceId:
 
         assert first == second
         assert len(first) == 10
-        assert not path.exists()
+        # The id is now *mirrored* to the file so the env-less scope-guard
+        # hook resolves the same value (#130). Derivation still never *reads*
+        # the file, so the #40 first-call race is not reintroduced — the
+        # mirror is deterministic, so a concurrent writer writes the same id.
+        assert path.read_text().strip() == first
 
     def test_derives_from_legacy_session_id(self, monkeypatch, tmp_path):
         """Falls back to the legacy CLAUDE_SESSION_ID name when the current
@@ -125,7 +129,7 @@ class TestInstanceId:
 
         assert first == second
         assert len(first) == 10
-        assert not path.exists()
+        assert path.read_text().strip() == first  # mirrored for the hook (#130)
 
     def test_current_session_id_wins_over_legacy(self, monkeypatch, tmp_path):
         """When both names are present the current CLAUDE_CODE_SESSION_ID is
@@ -171,6 +175,36 @@ class TestInstanceId:
         monkeypatch.setenv("MAVERICK_INSTANCE_ID", "explicit")
         monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "ignored")
         assert coordinator.instance_id() == "explicit"
+
+    def test_session_id_self_heals_stale_file(self, monkeypatch, tmp_path):
+        """#130: a stale random id in the file (written by an earlier env-less
+        `coord` run) is overwritten with the live session-derived id, so the
+        env-less scope-guard hook stops disagreeing with the coordinator."""
+        path = tmp_path / "instance_id"
+        path.write_text("847a039d01")  # stale random id from a prior run
+        monkeypatch.setattr(coordinator, "_instance_id_path", lambda: path)
+        monkeypatch.delenv("MAVERICK_INSTANCE_ID", raising=False)
+        monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "session-xyz")
+
+        derived = coordinator.instance_id()
+
+        assert derived != "847a039d01"
+        assert path.read_text().strip() == derived
+
+    def test_mirror_failure_does_not_break_derivation(self, monkeypatch, tmp_path):
+        """A read-only file cache must not stop the session id from resolving —
+        the mirror is best-effort."""
+        unwritable = tmp_path / "no-such-dir" / "instance_id"
+        # Force the parent to be a file so mkdir(parents=True) fails.
+        (tmp_path / "no-such-dir").write_text("blocking file")
+        monkeypatch.setattr(coordinator, "_instance_id_path", lambda: unwritable)
+        monkeypatch.delenv("MAVERICK_INSTANCE_ID", raising=False)
+        monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "session-xyz")
+
+        assert len(coordinator.instance_id()) == 10
+        assert not unwritable.exists()
 
 
 class TestBlockLabel:

--- a/tests/unit/test_scope_guard_hook.py
+++ b/tests/unit/test_scope_guard_hook.py
@@ -277,6 +277,35 @@ class TestResolve:
         assert guard.is_autonomous(env, claims_path=claims)
         assert not guard.is_autonomous({"MAVERICK_INSTANCE_ID": "other"}, claims_path=claims)
 
+    def test_autonomous_via_instance_id_file_without_session_env(self, guard, tmp_path):
+        """Issue #130 Test C: a claim recorded under the file id must classify
+        as autonomous even when the hook subprocess receives no session env."""
+        id_file = tmp_path / "instance_id"
+        id_file.write_text("847a039d01\n")
+        claims = tmp_path / "active-claims.json"
+        claims.write_text(
+            json.dumps(
+                {"claims": [{"repo": "o/r", "issue": 1, "instance_id": "847a039d01"}]}
+            )
+        )
+        # No MAVERICK_INSTANCE_ID / session env at all — only the file bridges.
+        assert guard.is_autonomous({}, claims_path=claims, id_path=id_file)
+
+    def test_instance_id_file_fallback_read_only(self, guard, tmp_path):
+        id_file = tmp_path / "instance_id"
+        id_file.write_text("f90bfff5dc")
+        assert guard._instance_id({}, id_path=id_file) == "f90bfff5dc"
+        # Session env still wins over the file.
+        assert (
+            guard._instance_id(
+                {"CLAUDE_CODE_SESSION_ID": "sess"}, id_path=id_file
+            )
+            != "f90bfff5dc"
+        )
+
+    def test_instance_id_missing_file_is_none(self, guard, tmp_path):
+        assert guard._instance_id({}, id_path=tmp_path / "nonexistent") is None
+
     def test_autonomous_infra_allowed_with_session_auth(self, guard, tmp_path):
         (tmp_path / ".maverick").mkdir()
         (tmp_path / ".maverick" / "session-auth.json").write_text(
@@ -289,6 +318,20 @@ class TestResolve:
             _edit(".github/workflows/ci.yml", cwd=str(tmp_path)),
             env={"MAVERICK_AUTONOMOUS": "1"},
         )
+        assert resolved.decision == guard.ALLOW
+
+    def test_interactive_infra_allowed_with_session_auth(self, guard, tmp_path):
+        """A recorded `infra` grant suppresses the prompt regardless of how the
+        run is classified — an interactive (mis)classification must not defeat
+        an authorization the user already recorded (issue #130 secondary)."""
+        (tmp_path / ".maverick").mkdir()
+        (tmp_path / ".maverick" / "session-auth.json").write_text(
+            json.dumps({"repo": "o/r", "issue": 1, "scopes": ["infra"]})
+        )
+        payload = _edit(".github/workflows/ci.yml", cwd=str(tmp_path))
+        hit = guard.decide(payload)
+        # env has no autonomous signal → classified interactive.
+        resolved = guard.resolve(hit, payload, env={})
         assert resolved.decision == guard.ALLOW
 
     def test_autonomous_infra_denied_without_session_auth(self, guard, tmp_path):


### PR DESCRIPTION
Fixes #130.

## Root cause

The scope-guard `PreToolUse` hook and `coordinator.instance_id()` derived the Maverick instance id via **two non-identical resolution ladders**. When the hook subprocess lacked the session-id env (a reduced hook env in some Claude Code versions), the coordinator resolved a real id (session hash / file cache) while the hook fell straight to `None`. `is_autonomous()` then returned `False`, so a genuinely-autonomous infra-path edit surfaced an interactive `ask` prompt instead of the intended autonomous `deny` — spurious permission prompts during `do-issue-solo`, and a silent safety downgrade (lost deny) in headless/CI runs.

## Fix

- **Hook** (`scope_guard._instance_id()`) — same read-only `~/.maverick/instance_id` file fallback as the coordinator (never generates or writes).
- **Coordinator** (`instance_id()`) — mirrors the session-derived id to the file cache so an env-less sibling process resolves the same value, and self-heals a stale random id left by an earlier env-less `coord` run. Derivation still never *reads* the file, so the #40 first-call race is not reintroduced (the mirror is deterministic).
- **`resolve()`** — honours a recorded `infra` scope in **both** the interactive and autonomous branches (secondary finding), so a misclassification can't defeat an authorization the user already recorded with `maverick coord authorize`.

## Tests

Regression coverage added:
- `is_autonomous()` returns `True` for a claim recorded under the file id when the session env is absent (issue Test C).
- Coordinator mirrors the session-hash id to the file and self-heals a stale one.
- `resolve()` allows an infra edit when `session-auth.json` grants `infra`, regardless of interactive/autonomous classification.

`make lint typecheck test` → **727 passed**, clean lint/typecheck. Build output regenerated via `make build`.

Reproduced the issue's Test C against the wired hook end-to-end: the env-less claim now correctly **denies (exit 2)** instead of the buggy `ask`. Scenarios A/B/D from the issue verified unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)